### PR TITLE
Add enforcer plugin to break the build earlier if wrong java version …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -549,6 +549,13 @@
                     <artifactId>s3-upload-maven-plugin</artifactId>
                     <version>${s3-upload-maven-plugin.version}</version>
                 </plugin>
+                
+                <!-- ENFORCER PLUGIN -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.0.0-M2</version>
+                </plugin>
 
             </plugins>
         </pluginManagement>
@@ -665,6 +672,25 @@
 				</executions>
 				<inherited>false</inherited>
 			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-java</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>${java.version}</version>
+                                </requireJavaVersion>
+                            </rules>    
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
…is used.

```
[INFO] ------------------------< com.pi4j:pi4j-parent >------------------------
[INFO] Building Pi4J :: Parent POM 2.0-SNAPSHOT                          [1/10]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO]
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ pi4j-parent ---
[INFO]
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce-java) @ pi4j-parent ---
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireJavaVersion failed with message:
Detected JDK Version: 9.0.4 is not in the allowed range 11.
```