### PR TITLE
Use current Thread's context ClassLoader when creating provider proxy…

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/provider/impl/DefaultRuntimeProviders.java
+++ b/pi4j-core/src/main/java/com/pi4j/provider/impl/DefaultRuntimeProviders.java
@@ -265,7 +265,7 @@ public class DefaultRuntimeProviders implements RuntimeProviders {
 
                 ProviderProxyHandler handler = new ProviderProxyHandler(runtime, providerInstance);
                 var providerProxy = Proxy.newProxyInstance(
-                        Provider.class.getClassLoader(),
+                        Thread.currentThread().getContextClassLoader(),
                         ReflectionUtil.getAllInterfaces(providerInstance).toArray(new Class[]{}),
                         handler);
 


### PR DESCRIPTION
… instance

Fixes #100 