### PR TITLE
LinuxFile reused scratch buffers ensuring size was usable.  But the …

### DIFF
--- a/libraries/pi4j-library-linuxfs/src/main/java/com/pi4j/library/linuxfs/LinuxFile.java
+++ b/libraries/pi4j-library-linuxfs/src/main/java/com/pi4j/library/linuxfs/LinuxFile.java
@@ -214,7 +214,7 @@ public class LinuxFile extends RandomAccessFile {
 
         if (byteSize > localBufferSize)
             throw new ScratchBufferOverrun();
-        // if no buffer exists, one always created.
+        // if no buffer currently exists, new one always created.
         // if buffer exists and limit is not equal to this getOffsetsBuffer, allocate new
         if (buf == null) {
             ByteBuffer bb = ByteBuffer.allocateDirect(localBufferSize);

--- a/libraries/pi4j-library-linuxfs/src/main/java/com/pi4j/library/linuxfs/LinuxFile.java
+++ b/libraries/pi4j-library-linuxfs/src/main/java/com/pi4j/library/linuxfs/LinuxFile.java
@@ -214,7 +214,8 @@ public class LinuxFile extends RandomAccessFile {
 
         if (byteSize > localBufferSize)
             throw new ScratchBufferOverrun();
-
+        // if no buffer exists, one always created.
+        // if buffer exists and limit is not equal to this getOffsetsBuffer, allocate new
         if (buf == null) {
             ByteBuffer bb = ByteBuffer.allocateDirect(localBufferSize);
 
@@ -223,9 +224,18 @@ public class LinuxFile extends RandomAccessFile {
 
             buf = bb.asIntBuffer();
             localOffsetsBuffer.set(buf);
-        }
+        } else if(buf.limit() != size) {
+            localOffsetsBuffer.remove();
+            ByteBuffer bb = ByteBuffer.allocateDirect(localBufferSize);
 
+            //keep native order, set before cast to IntBuffer
+            bb.order(ByteOrder.nativeOrder());
+
+            buf = bb.asIntBuffer();
+            localOffsetsBuffer.set(buf);
+        }
         return buf;
+
     }
 
 
@@ -236,7 +246,7 @@ public class LinuxFile extends RandomAccessFile {
             throw new ScratchBufferOverrun();
 
         // if no buffer exists, one always created.
-        // if buffer exists and limit is not equal to this requirement, allocate new
+        // if buffer exists and limit is not equal to this getDataBuffer, allocate new
         if (buf == null) {
             buf = ByteBuffer.allocateDirect(size);
             localDataBuffer.set(buf);

--- a/libraries/pi4j-library-linuxfs/src/main/java/com/pi4j/library/linuxfs/LinuxFile.java
+++ b/libraries/pi4j-library-linuxfs/src/main/java/com/pi4j/library/linuxfs/LinuxFile.java
@@ -211,19 +211,21 @@ public class LinuxFile extends RandomAccessFile {
     protected synchronized IntBuffer getOffsetsBuffer(int size) {
         final int byteSize = size * 4;
         IntBuffer buf = localOffsetsBuffer.get();
-
+        if (buf != null) {
+            // always reallocate buffer to ensure correct limits
+            localOffsetsBuffer.remove();
+            buf = localOffsetsBuffer.get();
+        }
         if (byteSize > localBufferSize)
             throw new ScratchBufferOverrun();
 
-        if (buf == null) {
-            ByteBuffer bb = ByteBuffer.allocateDirect(localBufferSize);
+        ByteBuffer bb = ByteBuffer.allocateDirect(localBufferSize);
 
-            //keep native order, set before cast to IntBuffer
-            bb.order(ByteOrder.nativeOrder());
+        //keep native order, set before cast to IntBuffer
+        bb.order(ByteOrder.nativeOrder());
 
-            buf = bb.asIntBuffer();
-            localOffsetsBuffer.set(buf);
-        }
+        buf = bb.asIntBuffer();
+        localOffsetsBuffer.set(buf);
 
         return buf;
     }
@@ -231,14 +233,16 @@ public class LinuxFile extends RandomAccessFile {
 
     protected  synchronized ByteBuffer getDataBuffer(int size) {
         ByteBuffer buf = localDataBuffer.get();
-
+        if (buf != null) {
+            // always reallocate buffer to ensure correct limits
+            localDataBuffer.remove();
+            buf = localDataBuffer.get();
+        }
         if (size > localBufferSize)
             throw new ScratchBufferOverrun();
 
-        if (buf == null) {
-            buf = ByteBuffer.allocateDirect(size);
-            localDataBuffer.set(buf);
-        }
+        buf = ByteBuffer.allocateDirect(size);
+        localDataBuffer.set(buf);
 
         return buf;
     }

--- a/libraries/pi4j-library-linuxfs/src/main/java/com/pi4j/library/linuxfs/LinuxFile.java
+++ b/libraries/pi4j-library-linuxfs/src/main/java/com/pi4j/library/linuxfs/LinuxFile.java
@@ -235,13 +235,20 @@ public class LinuxFile extends RandomAccessFile {
         if (size > localBufferSize)
             throw new ScratchBufferOverrun();
 
+        // if no buffer exists, one always created.
+        // if buffer exists and limit is not equal to this requirement, allocate new
         if (buf == null) {
+            buf = ByteBuffer.allocateDirect(size);
+            localDataBuffer.set(buf);
+        } else if(buf.limit() != size){
+            localDataBuffer.remove();
             buf = ByteBuffer.allocateDirect(size);
             localDataBuffer.set(buf);
         }
 
         return buf;
     }
+
 
     public static class ScratchBufferOverrun extends IllegalArgumentException {
         private static final long serialVersionUID = -418203522640826177L;

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/i2c/LinuxFsI2C.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/i2c/LinuxFsI2C.java
@@ -243,7 +243,7 @@ public class LinuxFsI2C extends I2CBase implements I2C {
         short writeLength = (short) register.length;
         // two pointers will be used so 2 pairs of offset entries
         IntBuffer offsets = IntBuffer.allocate(4);
-         // create ByteBuffer, load with write details
+         // create ByteBuffer, load with the write details
         ByteBuffer ioctlData = ByteBuffer.allocate(2048);
         // Ensures Pi BCM little_endian
         ioctlData.order(ByteOrder.nativeOrder());

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/i2c/LinuxFsI2C.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/i2c/LinuxFsI2C.java
@@ -243,7 +243,7 @@ public class LinuxFsI2C extends I2CBase implements I2C {
         short writeLength = (short) register.length;
         // two pointers will be used so 2 pairs of offset entries
         IntBuffer offsets = IntBuffer.allocate(4);
-         // create ByteBuffer, load with the write details
+         // create ByteBuffer, load with the write details Matches i2c provider 
         ByteBuffer ioctlData = ByteBuffer.allocate(2048);
         // Ensures Pi BCM little_endian
         ioctlData.order(ByteOrder.nativeOrder());

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/i2c/LinuxFsI2C.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/i2c/LinuxFsI2C.java
@@ -244,7 +244,7 @@ public class LinuxFsI2C extends I2CBase implements I2C {
         // two pointers will be used so 2 pairs of offset entries
         IntBuffer offsets = IntBuffer.allocate(4);
          // create ByteBuffer, load with write details
-        ByteBuffer ioctlData = ByteBuffer.allocate(500);
+        ByteBuffer ioctlData = ByteBuffer.allocate(2048);
         // Ensures Pi BCM little_endian
         ioctlData.order(ByteOrder.nativeOrder());
         ioctlData.putShort(deviceAddr);


### PR DESCRIPTION
…limit value cannot be modified so later usage failed as an intended overwrite

Modified both methods that return a buffer.   The methods ensured the an existing buffer was large enough for the new request and returned it. But its new usage may containa greater limit value.   I could not alter the limit value of an existing buffer, instead if an old buffer exists I remove it an allocate a new buffer.

This is an answer to a  post.  If you agree with this, can you spin a 2.5.1 snap shot so this user can progress.
I did not research how many attributes we needed to compare if we wanted to reuse an existing buffer 
@eitch @FDelporte 