### PR TITLE
linuxfs-pwm provider fixes for Pi5 operation. Default now pwmchip2, w…

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmBase.java
@@ -135,7 +135,9 @@ public abstract class PwmBase extends IOBase<Pwm, PwmConfig, PwmProvider> implem
         if(this.config.initialValue() != null){
             try {
                 if(this.config.initialValue() <= 0){
-                    this.off();
+                    if(this.isOn()) {
+                        this.off();
+                    }
                 } else {
                     this.on(this.config.initialValue());
                 }

--- a/pi4j-core/src/main/java/com/pi4j/util/Frequency.java
+++ b/pi4j-core/src/main/java/com/pi4j/util/Frequency.java
@@ -97,6 +97,9 @@ public class Frequency {
      */
     public static int getFrequencyFromNanos(Number nanoseconds){
         int frequency;
+        if(nanoseconds.longValue() <= 0){
+            return(0);
+        }
         long period = 1000000000; // NANOSECONDS PER SECOND;
         frequency = Math.round(1000000000/nanoseconds.longValue());
         return frequency;

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/internal/LinuxPwm.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/internal/LinuxPwm.java
@@ -44,7 +44,8 @@ public class LinuxPwm {
     public static String DEFAULT_SYSTEM_PATH = "/sys/class/pwm";
 
     /** Constant <code>DEFAULT_PWM_CHIP=0</code> */
-    public static int DEFAULT_PWM_CHIP = 0;
+    /** In Pi5 the chip is number 2 */
+    public static int DEFAULT_PWM_CHIP = 2;
 
     protected final String systemPath;
     protected final int chip;

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwm.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwm.java
@@ -86,7 +86,7 @@ public class LinuxFsPwm extends PwmBase implements Pwm {
                 logger.trace("exporting PWM [" + this.config.address() + "]; " + pwm.getPwmPath());
                 pwm.export();
                 // Delay to allow the SSD to persist the new directory and device partitions
-                Thread.sleep(250);
+                Thread.sleep(70);
             } else{
                 logger.trace("PWM [" + this.config.address() + "] is already exported; " + pwm.getPwmPath());
             }
@@ -224,7 +224,9 @@ public class LinuxFsPwm extends PwmBase implements Pwm {
         // otherwise ... un-export the GPIO pin from the Linux file system impl
         try {
             logger.trace("un-exporting PWM [" + this.config.address() + "]; " + pwm.getPwmPath());
-            pwm.unexport();
+            if(pwm.isExported()) {
+                pwm.unexport();
+            }
         } catch (java.io.IOException e) {
             logger.error(e.getMessage(), e);
             throw new ShutdownException("Failed to UN-EXPORT PWM [" + config().address() + "] @ <" + pwm.systemPath() + ">; " + e.getMessage(), e);

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwm.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwm.java
@@ -85,13 +85,18 @@ public class LinuxFsPwm extends PwmBase implements Pwm {
             if(!pwm.isExported()) {
                 logger.trace("exporting PWM [" + this.config.address() + "]; " + pwm.getPwmPath());
                 pwm.export();
+                // Delay to allow the SSD to persist the new directory and device partitions
+                Thread.sleep(250);
             } else{
                 logger.trace("PWM [" + this.config.address() + "] is already exported; " + pwm.getPwmPath());
             }
         } catch (java.io.IOException e) {
             logger.error(e.getMessage(), e);
             throw new InitializeException("Unable to export PWM [" + config.address() + "] @ <" + pwm.systemPath() + ">; " + e.getMessage(), e);
-        }
+        } catch (InterruptedException e) {
+            logger.error(e.getMessage(), e);
+            throw new InitializeException("Programmed delay failure, unable to export PWM [" + config.address() + "] @ <" + pwm.systemPath() + ">; " + e.getMessage(), e);
+         }
 
         // [INITIALIZE STATE] initialize PWM pin state (via superclass impl)
         super.initialize(context);


### PR DESCRIPTION
…as chip 0. After initial export of a channel, sleep quarter second so SSD card compllets directory and individual device file creation. Bug fix when user calls getActualFreq prior to setting PWM channel ON.