### PR TITLE
based on machine (pi5)  set pwmchip to 2, Also set provider priority …

### DIFF
--- a/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalInputProviderImpl.java
+++ b/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalInputProviderImpl.java
@@ -1,8 +1,7 @@
 package com.pi4j.plugin.gpiod.provider.gpio.digital;
 
-import com.pi4j.boardinfo.definition.BoardModel;
-import com.pi4j.boardinfo.definition.Soc;
-import com.pi4j.boardinfo.util.BoardModelDetection;
+
+import com.pi4j.boardinfo.util.BoardInfoHelper;
 import com.pi4j.context.Context;
 import com.pi4j.exception.InitializeException;
 import com.pi4j.exception.ShutdownException;
@@ -37,13 +36,12 @@ public class GpioDDigitalInputProviderImpl extends DigitalInputProviderBase impl
 
     @Override
     public int getPriority() {
-        // the gpioD driver should be higher priority when on Pi5.
+        // the gpioD driver should be higher priority when on Rp1 chip
         int rval = 0;
-        BoardModel model = BoardModelDetection.current().getBoardModel();
-        if(model.getSoc() == Soc.BCM2712) {
-            rval = 120;
+         if(BoardInfoHelper.usesRP1()) {
+            rval = 150;
         }else{
-            rval = 50;
+            rval = 150;
         }
         return(rval);
     }

--- a/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalInputProviderImpl.java
+++ b/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalInputProviderImpl.java
@@ -1,5 +1,8 @@
 package com.pi4j.plugin.gpiod.provider.gpio.digital;
 
+import com.pi4j.boardinfo.definition.BoardModel;
+import com.pi4j.boardinfo.definition.Soc;
+import com.pi4j.boardinfo.util.BoardModelDetection;
 import com.pi4j.context.Context;
 import com.pi4j.exception.InitializeException;
 import com.pi4j.exception.ShutdownException;
@@ -34,8 +37,15 @@ public class GpioDDigitalInputProviderImpl extends DigitalInputProviderBase impl
 
     @Override
     public int getPriority() {
-        // GpioD should be used if available
-        return 150;
+        // the gpioD driver should be higher priority when on Pi5.
+        int rval = 0;
+        BoardModel model = BoardModelDetection.current().getBoardModel();
+        if(model.getSoc() == Soc.BCM2712) {
+            rval = 120;
+        }else{
+            rval = 50;
+        }
+        return(rval);
     }
 
     /**

--- a/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalOutputProviderImpl.java
+++ b/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalOutputProviderImpl.java
@@ -27,6 +27,9 @@ package com.pi4j.plugin.gpiod.provider.gpio.digital;
  * #L%
  */
 
+import com.pi4j.boardinfo.definition.BoardModel;
+import com.pi4j.boardinfo.definition.Soc;
+import com.pi4j.boardinfo.util.BoardModelDetection;
 import com.pi4j.context.Context;
 import com.pi4j.exception.InitializeException;
 import com.pi4j.exception.ShutdownException;
@@ -67,8 +70,15 @@ public class GpioDDigitalOutputProviderImpl extends DigitalOutputProviderBase im
 
     @Override
     public int getPriority() {
-        // GpioD should be used if available
-        return 150;
+        // the gpioD driver should be higher priority when on Pi5.
+        int rval = 0;
+        BoardModel model = BoardModelDetection.current().getBoardModel();
+        if(model.getSoc() == Soc.BCM2712) {
+            rval = 120;
+        }else{
+            rval = 50;
+        }
+        return(rval);
     }
 
     @Override

--- a/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalOutputProviderImpl.java
+++ b/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalOutputProviderImpl.java
@@ -27,9 +27,7 @@ package com.pi4j.plugin.gpiod.provider.gpio.digital;
  * #L%
  */
 
-import com.pi4j.boardinfo.definition.BoardModel;
-import com.pi4j.boardinfo.definition.Soc;
-import com.pi4j.boardinfo.util.BoardModelDetection;
+import com.pi4j.boardinfo.util.BoardInfoHelper;
 import com.pi4j.context.Context;
 import com.pi4j.exception.InitializeException;
 import com.pi4j.exception.ShutdownException;
@@ -70,13 +68,12 @@ public class GpioDDigitalOutputProviderImpl extends DigitalOutputProviderBase im
 
     @Override
     public int getPriority() {
-        // the gpioD driver should be higher priority when on Pi5.
+        // the gpioD driver should be higher priority when on RP1 chip
         int rval = 0;
-        BoardModel model = BoardModelDetection.current().getBoardModel();
-        if(model.getSoc() == Soc.BCM2712) {
-            rval = 120;
+       if(BoardInfoHelper.usesRP1()) {
+            rval = 150;
         }else{
-            rval = 50;
+            rval = 150;
         }
         return(rval);
     }

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/LinuxFsPlugin.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/LinuxFsPlugin.java
@@ -27,6 +27,9 @@ package com.pi4j.plugin.linuxfs;
  * #L%
  */
 
+import com.pi4j.boardinfo.definition.BoardModel;
+import com.pi4j.boardinfo.definition.Soc;
+import com.pi4j.boardinfo.util.BoardModelDetection;
 import com.pi4j.extension.Plugin;
 import com.pi4j.extension.PluginService;
 import com.pi4j.plugin.linuxfs.internal.LinuxGpio;
@@ -108,7 +111,6 @@ public class LinuxFsPlugin implements Plugin {
 
     public static String DEFAULT_GPIO_FILESYSTEM_PATH = LinuxGpio.DEFAULT_SYSTEM_PATH;
     public static String DEFAULT_PWM_FILESYSTEM_PATH = LinuxPwm.DEFAULT_SYSTEM_PATH;
-    public static int DEFAULT_PWM_CHIP = LinuxPwm.DEFAULT_PWM_CHIP;
 
     private Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -121,7 +123,14 @@ public class LinuxFsPlugin implements Plugin {
         // get Linux file system path for GPIO & PWM
         String gpioFileSystemPath = DEFAULT_GPIO_FILESYSTEM_PATH;
         String pwmFileSystemPath = DEFAULT_PWM_FILESYSTEM_PATH;
-        int pwmChip = DEFAULT_PWM_CHIP;
+
+        int pwmChip;
+        BoardModel model = BoardModelDetection.current().getBoardModel();
+        if(model.getSoc() == Soc.BCM2712) {
+            pwmChip = LinuxPwm.DEFAULT_PI5_PWM_CHIP;
+        }else{
+            pwmChip = LinuxPwm.DEFAULT_LEGACY_PWM_CHIP;
+        }
 
         // [GPIO] get overriding custom 'linux.gpio.system.path' setting from Pi4J context
         if(service.context().properties().has("linux.gpio.system.path")){

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/LinuxFsPlugin.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/LinuxFsPlugin.java
@@ -27,9 +27,8 @@ package com.pi4j.plugin.linuxfs;
  * #L%
  */
 
-import com.pi4j.boardinfo.definition.BoardModel;
-import com.pi4j.boardinfo.definition.Soc;
-import com.pi4j.boardinfo.util.BoardModelDetection;
+
+import com.pi4j.boardinfo.util.BoardInfoHelper;
 import com.pi4j.extension.Plugin;
 import com.pi4j.extension.PluginService;
 import com.pi4j.plugin.linuxfs.internal.LinuxGpio;
@@ -125,9 +124,8 @@ public class LinuxFsPlugin implements Plugin {
         String pwmFileSystemPath = DEFAULT_PWM_FILESYSTEM_PATH;
 
         int pwmChip;
-        BoardModel model = BoardModelDetection.current().getBoardModel();
-        if(model.getSoc() == Soc.BCM2712) {
-            pwmChip = LinuxPwm.DEFAULT_PI5_PWM_CHIP;
+        if(BoardInfoHelper.usesRP1()) {
+            pwmChip = LinuxPwm.DEFAULT_RP1_PWM_CHIP;
         }else{
             pwmChip = LinuxPwm.DEFAULT_LEGACY_PWM_CHIP;
         }

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/internal/LinuxPwm.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/internal/LinuxPwm.java
@@ -27,6 +27,9 @@ package com.pi4j.plugin.linuxfs.internal;
  * #L%
  */
 
+import com.pi4j.boardinfo.definition.BoardModel;
+import com.pi4j.boardinfo.definition.Soc;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -43,9 +46,18 @@ public class LinuxPwm {
     /** Constant <code>DEFAULT_SYSTEM_PATH="/sys/class/pwm"</code> */
     public static String DEFAULT_SYSTEM_PATH = "/sys/class/pwm";
 
-    /** Constant <code>DEFAULT_PWM_CHIP=0</code> */
+    /** Constant <code>DEFAULT_LEGACY_PWM_CHIP=0</code> */
+    /** In Pi Models Previous to Pi5 the chip is number 0 */
+    public static int DEFAULT_LEGACY_PWM_CHIP = 0;
+
+    /** Constant <code>DEFAULT_PI5_PWM_CHIP=2</code> */
     /** In Pi5 the chip is number 2 */
-    public static int DEFAULT_PWM_CHIP = 2;
+    public static int DEFAULT_PI5_PWM_CHIP = 2;
+
+    /** Constant <code>DEFAULT_PWM_CHIP=2</code> */
+    /** In Pi5 the chip is number 2 */
+    public static int DEFAULT_PWM_CHIP = DEFAULT_PI5_PWM_CHIP;
+
 
     protected final String systemPath;
     protected final int chip;
@@ -77,7 +89,8 @@ public class LinuxPwm {
      * @param systemPath a {@link String} object.
      * @param address a int.
      */
-    public LinuxPwm(String systemPath, int address){
+
+    public LinuxPwm(String systemPath, int address) {
         this(DEFAULT_SYSTEM_PATH, DEFAULT_PWM_CHIP, address);
     }
 
@@ -89,6 +102,8 @@ public class LinuxPwm {
     public LinuxPwm(int address){
         this(DEFAULT_SYSTEM_PATH, address);
     }
+
+
 
     /**
      * <p>channels.</p>

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/internal/LinuxPwm.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/internal/LinuxPwm.java
@@ -27,9 +27,6 @@ package com.pi4j.plugin.linuxfs.internal;
  * #L%
  */
 
-import com.pi4j.boardinfo.definition.BoardModel;
-import com.pi4j.boardinfo.definition.Soc;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -47,16 +44,16 @@ public class LinuxPwm {
     public static String DEFAULT_SYSTEM_PATH = "/sys/class/pwm";
 
     /** Constant <code>DEFAULT_LEGACY_PWM_CHIP=0</code> */
-    /** In Pi Models Previous to Pi5 the chip is number 0 */
+    /** In Pi Models Previous to RP1 the chip is number 0 */
     public static int DEFAULT_LEGACY_PWM_CHIP = 0;
 
-    /** Constant <code>DEFAULT_PI5_PWM_CHIP=2</code> */
-    /** In Pi5 the chip is number 2 */
-    public static int DEFAULT_PI5_PWM_CHIP = 2;
+    /** Constant <code>DEFAULT_RP1_PWM_CHIP=2</code> */
+    /** In RP1 the chip is number 2 */
+    public static int DEFAULT_RP1_PWM_CHIP = 2;
 
     /** Constant <code>DEFAULT_PWM_CHIP=2</code> */
-    /** In Pi5 the chip is number 2 */
-    public static int DEFAULT_PWM_CHIP = DEFAULT_PI5_PWM_CHIP;
+    /** In RP1 the chip is number 2 */
+    public static int DEFAULT_PWM_CHIP = DEFAULT_RP1_PWM_CHIP;
 
 
     protected final String systemPath;

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalInputProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalInputProviderImpl.java
@@ -27,10 +27,8 @@ package com.pi4j.plugin.linuxfs.provider.gpio.digital;
  * #L%
  */
 
-import com.pi4j.boardinfo.definition.BoardModel;
-import com.pi4j.boardinfo.definition.Soc;
-import com.pi4j.boardinfo.util.BoardModelDetection;
-import com.pi4j.io.exception.IOAlreadyExistsException;
+
+import com.pi4j.boardinfo.util.BoardInfoHelper;
 import com.pi4j.io.gpio.digital.DigitalInput;
 import com.pi4j.io.gpio.digital.DigitalInputConfig;
 import com.pi4j.io.gpio.digital.DigitalInputProviderBase;
@@ -57,10 +55,9 @@ public class LinuxFsDigitalInputProviderImpl extends DigitalInputProviderBase im
 
     @Override
     public int getPriority() {
-        // the linux FS Digital driver should be higher priority than Pigpio on Pi5.
+        // the linux FS Digital driver should be higher priority than Pigpio on RP1 chip
         int rval = 0;
-        BoardModel model = BoardModelDetection.current().getBoardModel();
-        if(model.getSoc() == Soc.BCM2712) {
+        if(BoardInfoHelper.usesRP1()) {
             rval = 100;
         }else{
             rval = 50;

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalInputProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalInputProviderImpl.java
@@ -27,6 +27,9 @@ package com.pi4j.plugin.linuxfs.provider.gpio.digital;
  * #L%
  */
 
+import com.pi4j.boardinfo.definition.BoardModel;
+import com.pi4j.boardinfo.definition.Soc;
+import com.pi4j.boardinfo.util.BoardModelDetection;
 import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.gpio.digital.DigitalInput;
 import com.pi4j.io.gpio.digital.DigitalInputConfig;
@@ -54,8 +57,15 @@ public class LinuxFsDigitalInputProviderImpl extends DigitalInputProviderBase im
 
     @Override
     public int getPriority() {
-        // the linux FS DI driver should not be used over the pigpio
-        return 50;
+        // the linux FS Digital driver should be higher priority than Pigpio on Pi5.
+        int rval = 0;
+        BoardModel model = BoardModelDetection.current().getBoardModel();
+        if(model.getSoc() == Soc.BCM2712) {
+            rval = 100;
+        }else{
+            rval = 50;
+        }
+        return(rval);
     }
 
     /**

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalOutputProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalOutputProviderImpl.java
@@ -27,10 +27,8 @@ package com.pi4j.plugin.linuxfs.provider.gpio.digital;
  * #L%
  */
 
-import com.pi4j.boardinfo.definition.BoardModel;
-import com.pi4j.boardinfo.definition.Soc;
-import com.pi4j.boardinfo.util.BoardModelDetection;
-import com.pi4j.io.exception.IOAlreadyExistsException;
+
+import com.pi4j.boardinfo.util.BoardInfoHelper;
 import com.pi4j.io.gpio.digital.DigitalOutput;
 import com.pi4j.io.gpio.digital.DigitalOutputConfig;
 import com.pi4j.io.gpio.digital.DigitalOutputProviderBase;
@@ -58,10 +56,9 @@ public class LinuxFsDigitalOutputProviderImpl extends DigitalOutputProviderBase
 
     @Override
     public int getPriority() {
-        // the linux FS Digital driver should be higher priority than Pigpio on Pi5.
+        // the linux FS Digital driver should be higher priority than Pigpio on RP1 chip.
         int rval = 0;
-        BoardModel model = BoardModelDetection.current().getBoardModel();
-        if(model.getSoc() == Soc.BCM2712) {
+        if(BoardInfoHelper.usesRP1()) {
             rval = 100;
         }else{
             rval = 50;

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalOutputProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalOutputProviderImpl.java
@@ -27,6 +27,9 @@ package com.pi4j.plugin.linuxfs.provider.gpio.digital;
  * #L%
  */
 
+import com.pi4j.boardinfo.definition.BoardModel;
+import com.pi4j.boardinfo.definition.Soc;
+import com.pi4j.boardinfo.util.BoardModelDetection;
 import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.gpio.digital.DigitalOutput;
 import com.pi4j.io.gpio.digital.DigitalOutputConfig;
@@ -55,8 +58,15 @@ public class LinuxFsDigitalOutputProviderImpl extends DigitalOutputProviderBase
 
     @Override
     public int getPriority() {
-        // the linux FS DO driver should not be used over the pigpio
-        return 50;
+        // the linux FS Digital driver should be higher priority than Pigpio on Pi5.
+        int rval = 0;
+        BoardModel model = BoardModelDetection.current().getBoardModel();
+        if(model.getSoc() == Soc.BCM2712) {
+            rval = 100;
+        }else{
+            rval = 50;
+        }
+        return(rval);
     }
 
     /**

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/i2c/LinuxFsI2CProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/i2c/LinuxFsI2CProviderImpl.java
@@ -27,6 +27,9 @@ package com.pi4j.plugin.linuxfs.provider.i2c;
  * #L%
  */
 
+import com.pi4j.boardinfo.definition.BoardModel;
+import com.pi4j.boardinfo.definition.Soc;
+import com.pi4j.boardinfo.util.BoardModelDetection;
 import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.i2c.I2C;
 import com.pi4j.io.i2c.I2CConfig;
@@ -47,8 +50,15 @@ public class LinuxFsI2CProviderImpl extends I2CProviderBase implements LinuxFsI2
 
     @Override
     public int getPriority() {
-        // the linux FS I2C driver should be used over the pigpio
-        return 150;
+        // the linux FS driver should be higher priority when on Pi5.
+        int rval = 0;
+        BoardModel model = BoardModelDetection.current().getBoardModel();
+        if(model.getSoc() == Soc.BCM2712) {
+            rval = 100;
+        }else{
+            rval = 50;
+        }
+        return(rval);
     }
 
     @Override

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/i2c/LinuxFsI2CProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/i2c/LinuxFsI2CProviderImpl.java
@@ -27,10 +27,8 @@ package com.pi4j.plugin.linuxfs.provider.i2c;
  * #L%
  */
 
-import com.pi4j.boardinfo.definition.BoardModel;
-import com.pi4j.boardinfo.definition.Soc;
-import com.pi4j.boardinfo.util.BoardModelDetection;
-import com.pi4j.io.exception.IOAlreadyExistsException;
+
+import com.pi4j.boardinfo.util.BoardInfoHelper;
 import com.pi4j.io.i2c.I2C;
 import com.pi4j.io.i2c.I2CConfig;
 import com.pi4j.io.i2c.I2CProviderBase;
@@ -50,13 +48,12 @@ public class LinuxFsI2CProviderImpl extends I2CProviderBase implements LinuxFsI2
 
     @Override
     public int getPriority() {
-        // the linux FS driver should be higher priority when on Pi5.
-        int rval = 0;
-        BoardModel model = BoardModelDetection.current().getBoardModel();
-        if(model.getSoc() == Soc.BCM2712) {
-            rval = 100;
+       // the linux FS driver should be higher priority when on RP1 chip
+       int rval = 0;
+       if(BoardInfoHelper.usesRP1()) {
+            rval = 150;
         }else{
-            rval = 50;
+            rval = 150;
         }
         return(rval);
     }

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmProviderImpl.java
@@ -27,17 +27,14 @@ package com.pi4j.plugin.linuxfs.provider.pwm;
  * #L%
  */
 
-import com.pi4j.boardinfo.definition.BoardModel;
-import com.pi4j.boardinfo.definition.Soc;
-import com.pi4j.boardinfo.util.BoardModelDetection;
-import com.pi4j.io.exception.IOAlreadyExistsException;
+
+import com.pi4j.boardinfo.util.BoardInfoHelper;
 import com.pi4j.io.exception.IOException;
 import com.pi4j.io.pwm.Pwm;
 import com.pi4j.io.pwm.PwmConfig;
 import com.pi4j.io.pwm.PwmProviderBase;
 import com.pi4j.io.pwm.PwmType;
 import com.pi4j.plugin.linuxfs.internal.LinuxPwm;
-
 import static java.text.MessageFormat.format;
 
 /**
@@ -63,10 +60,9 @@ public class LinuxFsPwmProviderImpl extends PwmProviderBase implements LinuxFsPw
 
     @Override
     public int getPriority() {
-        // the linux FS PWM driver should be higher priority than Pigpio on Pi5.
+        // the linux FS PWM driver should be higher priority than Pigpio on RP1 chip
         int rval = 0;
-        BoardModel model = BoardModelDetection.current().getBoardModel();
-        if(model.getSoc() == Soc.BCM2712) {
+        if(BoardInfoHelper.usesRP1()) {
             rval = 100;
         }else{
             rval = 50;
@@ -81,9 +77,8 @@ public class LinuxFsPwmProviderImpl extends PwmProviderBase implements LinuxFsPw
         this.id = ID;
         this.name = NAME;
         this.pwmFileSystemPath = pwmFileSystemPath;
-        BoardModel model = BoardModelDetection.current().getBoardModel();
-        if(model.getSoc() == Soc.BCM2712) {
-            this.pwmChip = LinuxPwm.DEFAULT_PI5_PWM_CHIP;
+        if(BoardInfoHelper.usesRP1()) {
+            this.pwmChip = LinuxPwm.DEFAULT_RP1_PWM_CHIP;
         }else{
             this.pwmChip = LinuxPwm.DEFAULT_LEGACY_PWM_CHIP;
         }

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmProviderImpl.java
@@ -27,6 +27,9 @@ package com.pi4j.plugin.linuxfs.provider.pwm;
  * #L%
  */
 
+import com.pi4j.boardinfo.definition.BoardModel;
+import com.pi4j.boardinfo.definition.Soc;
+import com.pi4j.boardinfo.util.BoardModelDetection;
 import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.exception.IOException;
 import com.pi4j.io.pwm.Pwm;
@@ -60,8 +63,15 @@ public class LinuxFsPwmProviderImpl extends PwmProviderBase implements LinuxFsPw
 
     @Override
     public int getPriority() {
-        // the linux FS PWM driver should not be used over the pigpio
-        return 50;
+        // the linux FS PWM driver should be higher priority than Pigpio on Pi5.
+        int rval = 0;
+        BoardModel model = BoardModelDetection.current().getBoardModel();
+        if(model.getSoc() == Soc.BCM2712) {
+            rval = 100;
+        }else{
+            rval = 50;
+        }
+        return(rval);
     }
 
     /**
@@ -71,7 +81,12 @@ public class LinuxFsPwmProviderImpl extends PwmProviderBase implements LinuxFsPw
         this.id = ID;
         this.name = NAME;
         this.pwmFileSystemPath = pwmFileSystemPath;
-        this.pwmChip = LinuxPwm.DEFAULT_PWM_CHIP;
+        BoardModel model = BoardModelDetection.current().getBoardModel();
+        if(model.getSoc() == Soc.BCM2712) {
+            this.pwmChip = LinuxPwm.DEFAULT_PI5_PWM_CHIP;
+        }else{
+            this.pwmChip = LinuxPwm.DEFAULT_LEGACY_PWM_CHIP;
+        }
     }
 
     /**

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/gpio/digital/PiGpioDigitalInputProviderImpl.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/gpio/digital/PiGpioDigitalInputProviderImpl.java
@@ -27,6 +27,9 @@ package com.pi4j.plugin.pigpio.provider.gpio.digital;
  * #L%
  */
 
+import com.pi4j.boardinfo.definition.BoardModel;
+import com.pi4j.boardinfo.definition.Soc;
+import com.pi4j.boardinfo.util.BoardModelDetection;
 import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.gpio.digital.DigitalInput;
 import com.pi4j.io.gpio.digital.DigitalInputConfig;
@@ -56,8 +59,15 @@ public class PiGpioDigitalInputProviderImpl extends DigitalInputProviderBase imp
 
     @Override
     public int getPriority() {
-        // the pigpio DI driver should be used over the default
-        return 100;
+        // the Pigpio driver should be higher priority when NOT on Pi5.
+        int rval = 0;
+        BoardModel model = BoardModelDetection.current().getBoardModel();
+        if(model.getSoc() != Soc.BCM2712) {
+            rval = 100;
+        }else{
+            rval = 50;
+        }
+        return(rval);
     }
 
     /**

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/gpio/digital/PiGpioDigitalInputProviderImpl.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/gpio/digital/PiGpioDigitalInputProviderImpl.java
@@ -27,10 +27,8 @@ package com.pi4j.plugin.pigpio.provider.gpio.digital;
  * #L%
  */
 
-import com.pi4j.boardinfo.definition.BoardModel;
-import com.pi4j.boardinfo.definition.Soc;
-import com.pi4j.boardinfo.util.BoardModelDetection;
-import com.pi4j.io.exception.IOAlreadyExistsException;
+
+import com.pi4j.boardinfo.util.BoardInfoHelper;
 import com.pi4j.io.gpio.digital.DigitalInput;
 import com.pi4j.io.gpio.digital.DigitalInputConfig;
 import com.pi4j.io.gpio.digital.DigitalInputProviderBase;
@@ -59,10 +57,9 @@ public class PiGpioDigitalInputProviderImpl extends DigitalInputProviderBase imp
 
     @Override
     public int getPriority() {
-        // the Pigpio driver should be higher priority when NOT on Pi5.
+        // the Pigpio driver should be higher priority when NOT on RP1 chip
         int rval = 0;
-        BoardModel model = BoardModelDetection.current().getBoardModel();
-        if(model.getSoc() != Soc.BCM2712) {
+        if(!BoardInfoHelper.usesRP1()) {
             rval = 100;
         }else{
             rval = 50;

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/gpio/digital/PiGpioDigitalOutputProviderImpl.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/gpio/digital/PiGpioDigitalOutputProviderImpl.java
@@ -27,10 +27,8 @@ package com.pi4j.plugin.pigpio.provider.gpio.digital;
  * #L%
  */
 
-import com.pi4j.boardinfo.definition.BoardModel;
-import com.pi4j.boardinfo.definition.Soc;
-import com.pi4j.boardinfo.util.BoardModelDetection;
-import com.pi4j.io.exception.IOAlreadyExistsException;
+
+import com.pi4j.boardinfo.util.BoardInfoHelper;
 import com.pi4j.io.gpio.digital.DigitalOutput;
 import com.pi4j.io.gpio.digital.DigitalOutputConfig;
 import com.pi4j.io.gpio.digital.DigitalOutputProviderBase;
@@ -59,10 +57,9 @@ public class PiGpioDigitalOutputProviderImpl extends DigitalOutputProviderBase i
 
     @Override
     public int getPriority() {
-        // the Pigpio driver should be higher priority when NOT on Pi5.
+        // the Pigpio driver should be higher priority when NOT on RP1 chip.
         int rval = 0;
-        BoardModel model = BoardModelDetection.current().getBoardModel();
-        if(model.getSoc() != Soc.BCM2712) {
+        if(!BoardInfoHelper.usesRP1()) {
             rval = 100;
         }else{
             rval = 50;

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/gpio/digital/PiGpioDigitalOutputProviderImpl.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/gpio/digital/PiGpioDigitalOutputProviderImpl.java
@@ -27,6 +27,9 @@ package com.pi4j.plugin.pigpio.provider.gpio.digital;
  * #L%
  */
 
+import com.pi4j.boardinfo.definition.BoardModel;
+import com.pi4j.boardinfo.definition.Soc;
+import com.pi4j.boardinfo.util.BoardModelDetection;
 import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.gpio.digital.DigitalOutput;
 import com.pi4j.io.gpio.digital.DigitalOutputConfig;
@@ -56,8 +59,15 @@ public class PiGpioDigitalOutputProviderImpl extends DigitalOutputProviderBase i
 
     @Override
     public int getPriority() {
-        // the pigpio DO driver should be used over the default
-        return 100;
+        // the Pigpio driver should be higher priority when NOT on Pi5.
+        int rval = 0;
+        BoardModel model = BoardModelDetection.current().getBoardModel();
+        if(model.getSoc() != Soc.BCM2712) {
+            rval = 100;
+        }else{
+            rval = 50;
+        }
+        return(rval);
     }
 
     /**

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/i2c/PiGpioI2CProviderImpl.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/i2c/PiGpioI2CProviderImpl.java
@@ -27,6 +27,9 @@ package com.pi4j.plugin.pigpio.provider.i2c;
  * #L%
  */
 
+import com.pi4j.boardinfo.definition.BoardModel;
+import com.pi4j.boardinfo.definition.Soc;
+import com.pi4j.boardinfo.util.BoardModelDetection;
 import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.i2c.I2C;
 import com.pi4j.io.i2c.I2CConfig;
@@ -56,8 +59,15 @@ public class PiGpioI2CProviderImpl extends I2CProviderBase implements PiGpioI2CP
 
     @Override
     public int getPriority() {
-        // the pigpio I2C driver should be used over the default
-        return 100;
+        // the Pigpio driver should be higher priority when NOT on Pi5.
+        int rval = 0;
+        BoardModel model = BoardModelDetection.current().getBoardModel();
+        if(model.getSoc() != Soc.BCM2712) {
+            rval = 100;
+        }else{
+            rval = 50;
+        }
+        return(rval);
     }
 
     /**

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/i2c/PiGpioI2CProviderImpl.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/i2c/PiGpioI2CProviderImpl.java
@@ -27,10 +27,8 @@ package com.pi4j.plugin.pigpio.provider.i2c;
  * #L%
  */
 
-import com.pi4j.boardinfo.definition.BoardModel;
-import com.pi4j.boardinfo.definition.Soc;
-import com.pi4j.boardinfo.util.BoardModelDetection;
-import com.pi4j.io.exception.IOAlreadyExistsException;
+
+import com.pi4j.boardinfo.util.BoardInfoHelper;
 import com.pi4j.io.i2c.I2C;
 import com.pi4j.io.i2c.I2CConfig;
 import com.pi4j.io.i2c.I2CProviderBase;
@@ -59,10 +57,9 @@ public class PiGpioI2CProviderImpl extends I2CProviderBase implements PiGpioI2CP
 
     @Override
     public int getPriority() {
-        // the Pigpio driver should be higher priority when NOT on Pi5.
+        // the Pigpio driver should be higher priority when NOT on RP1 chip
         int rval = 0;
-        BoardModel model = BoardModelDetection.current().getBoardModel();
-        if(model.getSoc() != Soc.BCM2712) {
+        if(!BoardInfoHelper.usesRP1()) {
             rval = 100;
         }else{
             rval = 50;

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/pwm/PiGpioPwmProviderImpl.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/pwm/PiGpioPwmProviderImpl.java
@@ -27,6 +27,9 @@ package com.pi4j.plugin.pigpio.provider.pwm;
  * #L%
  */
 
+import com.pi4j.boardinfo.definition.BoardModel;
+import com.pi4j.boardinfo.definition.Soc;
+import com.pi4j.boardinfo.util.BoardModelDetection;
 import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.pwm.Pwm;
 import com.pi4j.io.pwm.PwmConfig;
@@ -57,8 +60,15 @@ public class PiGpioPwmProviderImpl extends PwmProviderBase implements PiGpioPwmP
 
     @Override
     public int getPriority() {
-        // the pigpio PWM driver should be used over the default
-        return 100;
+        // the Pigpio driver should be higher priority when NOT on Pi5.
+        int rval = 0;
+        BoardModel model = BoardModelDetection.current().getBoardModel();
+        if(model.getSoc() != Soc.BCM2712) {
+            rval = 100;
+        }else{
+            rval = 50;
+        }
+        return(rval);
     }
 
     /**

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/pwm/PiGpioPwmProviderImpl.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/pwm/PiGpioPwmProviderImpl.java
@@ -27,10 +27,8 @@ package com.pi4j.plugin.pigpio.provider.pwm;
  * #L%
  */
 
-import com.pi4j.boardinfo.definition.BoardModel;
-import com.pi4j.boardinfo.definition.Soc;
-import com.pi4j.boardinfo.util.BoardModelDetection;
-import com.pi4j.io.exception.IOAlreadyExistsException;
+
+import com.pi4j.boardinfo.util.BoardInfoHelper;
 import com.pi4j.io.pwm.Pwm;
 import com.pi4j.io.pwm.PwmConfig;
 import com.pi4j.io.pwm.PwmProviderBase;
@@ -60,10 +58,9 @@ public class PiGpioPwmProviderImpl extends PwmProviderBase implements PiGpioPwmP
 
     @Override
     public int getPriority() {
-        // the Pigpio driver should be higher priority when NOT on Pi5.
+        // the Pigpio driver should be higher priority when NOT on RP1 chip.
         int rval = 0;
-        BoardModel model = BoardModelDetection.current().getBoardModel();
-        if(model.getSoc() != Soc.BCM2712) {
+        if(!BoardInfoHelper.usesRP1()) {
             rval = 100;
         }else{
             rval = 50;

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/serial/PiGpioSerialProviderImpl.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/serial/PiGpioSerialProviderImpl.java
@@ -27,10 +27,7 @@ package com.pi4j.plugin.pigpio.provider.serial;
  * #L%
  */
 
-import com.pi4j.boardinfo.definition.BoardModel;
-import com.pi4j.boardinfo.definition.Soc;
-import com.pi4j.boardinfo.util.BoardModelDetection;
-import com.pi4j.io.exception.IOAlreadyExistsException;
+import com.pi4j.boardinfo.util.BoardInfoHelper;
 import com.pi4j.io.serial.Serial;
 import com.pi4j.io.serial.SerialConfig;
 import com.pi4j.io.serial.SerialProviderBase;
@@ -59,10 +56,9 @@ public class PiGpioSerialProviderImpl extends SerialProviderBase implements PiGp
 
     @Override
     public int getPriority() {
-        // the Pigpio driver should be higher priority when NOT on Pi5.
+        // the Pigpio driver should be higher priority when NOT on Rp1 chip.
         int rval = 0;
-        BoardModel model = BoardModelDetection.current().getBoardModel();
-        if(model.getSoc() != Soc.BCM2712) {
+        if(!BoardInfoHelper.usesRP1()) {
             rval = 100;
         }else{
             rval = 50;

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/serial/PiGpioSerialProviderImpl.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/serial/PiGpioSerialProviderImpl.java
@@ -27,6 +27,9 @@ package com.pi4j.plugin.pigpio.provider.serial;
  * #L%
  */
 
+import com.pi4j.boardinfo.definition.BoardModel;
+import com.pi4j.boardinfo.definition.Soc;
+import com.pi4j.boardinfo.util.BoardModelDetection;
 import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.serial.Serial;
 import com.pi4j.io.serial.SerialConfig;
@@ -56,8 +59,15 @@ public class PiGpioSerialProviderImpl extends SerialProviderBase implements PiGp
 
     @Override
     public int getPriority() {
-        // the pigpio Serial driver should be used over the default
-        return 100;
+        // the Pigpio driver should be higher priority when NOT on Pi5.
+        int rval = 0;
+        BoardModel model = BoardModelDetection.current().getBoardModel();
+        if(model.getSoc() != Soc.BCM2712) {
+            rval = 100;
+        }else{
+            rval = 50;
+        }
+        return(rval);
     }
 
     /**

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/spi/PiGpioSpiProviderImpl.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/spi/PiGpioSpiProviderImpl.java
@@ -27,10 +27,7 @@ package com.pi4j.plugin.pigpio.provider.spi;
  * #L%
  */
 
-import com.pi4j.boardinfo.definition.BoardModel;
-import com.pi4j.boardinfo.definition.Soc;
-import com.pi4j.boardinfo.util.BoardModelDetection;
-import com.pi4j.io.exception.IOAlreadyExistsException;
+import com.pi4j.boardinfo.util.BoardInfoHelper;
 import com.pi4j.io.spi.Spi;
 import com.pi4j.io.spi.SpiConfig;
 import com.pi4j.io.spi.SpiProviderBase;
@@ -59,10 +56,9 @@ public class PiGpioSpiProviderImpl extends SpiProviderBase implements PiGpioSpiP
 
     @Override
     public int getPriority() {
-        // the Pigpio driver should be higher priority when NOT on Pi5.
+        // the Pigpio driver should be higher priority when NOT on RP1 chip.
         int rval = 0;
-        BoardModel model = BoardModelDetection.current().getBoardModel();
-        if(model.getSoc() != Soc.BCM2712) {
+       if(!BoardInfoHelper.usesRP1()) {
             rval = 100;
         }else{
             rval = 50;

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/spi/PiGpioSpiProviderImpl.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/spi/PiGpioSpiProviderImpl.java
@@ -27,6 +27,9 @@ package com.pi4j.plugin.pigpio.provider.spi;
  * #L%
  */
 
+import com.pi4j.boardinfo.definition.BoardModel;
+import com.pi4j.boardinfo.definition.Soc;
+import com.pi4j.boardinfo.util.BoardModelDetection;
 import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.spi.Spi;
 import com.pi4j.io.spi.SpiConfig;
@@ -56,8 +59,16 @@ public class PiGpioSpiProviderImpl extends SpiProviderBase implements PiGpioSpiP
 
     @Override
     public int getPriority() {
-        // the pigpio SPI driver should be used over the default
-        return 100;
+        // the Pigpio driver should be higher priority when NOT on Pi5.
+        int rval = 0;
+        BoardModel model = BoardModelDetection.current().getBoardModel();
+        if(model.getSoc() != Soc.BCM2712) {
+            rval = 100;
+        }else{
+            rval = 50;
+        }
+        return(rval);
+
     }
 
     /**


### PR DESCRIPTION
…of Gpiod input/output, linuxFS i2c & pwm,  so they are loaded and Pigpio is not.  On all legacy Pi (! Pi5) do the opposite priority and pwmchip is 0. I still have the WEB pages updates to do.            

@eitch Result, I also had to use the static way to set the Board info for selecting the pwmchip value.  Repeated runs showed occasionally the Context was not set in the class, same as I hit with getPriority.                                                                                                                                                                           

I decided on Pi5 to make the GpioD provider a higher priority then the linuxfs digital.   Both higher than Pigpio on Pi5.  Below are the providers loaded when all are available 

```
Pi4
---------------------------------------------------------
PI4J PROVIDERS
----------------------------------------------------------
PROVIDERS: [6] "I/O Providers" <com.pi4j.provider.impl.DefaultProviders> 
├─ANALOG_INPUT: [0] <com.pi4j.io.gpio.analog.AnalogInputProvider> 
├─PWM: [1] <com.pi4j.io.pwm.PwmProvider> 
│ └─PROVIDER: "PiGpio PWM Provider" {pigpio-pwm} <com.pi4j.plugin.pigpio.provider.pwm.PiGpioPwmProviderImpl> {com.pi4j.plugin.pigpio.provider.pwm.PiGpioPwmProviderImpl} 
├─DIGITAL_OUTPUT: [1] <com.pi4j.io.gpio.digital.DigitalOutputProvider> 
│ └─PROVIDER: "PiGpio Digital Output (GPIO) Provider" {pigpio-digital-output} <com.pi4j.plugin.pigpio.provider.gpio.digital.PiGpioDigitalOutputProviderImpl> {com.pi4j.plugin.pigpio.provider.gpio.digital.PiGpioDigitalOutputProviderImpl} 
├─SERIAL: [1] <com.pi4j.io.serial.SerialProvider> 
│ └─PROVIDER: "PiGpio Serial Provider" {pigpio-serial} <com.pi4j.plugin.pigpio.provider.serial.PiGpioSerialProviderImpl> {com.pi4j.plugin.pigpio.provider.serial.PiGpioSerialProviderImpl} 
├─ANALOG_OUTPUT: [0] <com.pi4j.io.gpio.analog.AnalogOutputProvider> 
├─SPI: [1] <com.pi4j.io.spi.SpiProvider> 
│ └─PROVIDER: "PiGpio SPI Provider" {pigpio-spi} <com.pi4j.plugin.pigpio.provider.spi.PiGpioSpiProviderImpl> {com.pi4j.plugin.pigpio.provider.spi.PiGpioSpiProviderImpl} 
├─DIGITAL_INPUT: [1] <com.pi4j.io.gpio.digital.DigitalInputProvider> 
│ └─PROVIDER: "PiGpio Digital Input (GPIO) Provider" {pigpio-digital-input} <com.pi4j.plugin.pigpio.provider.gpio.digital.PiGpioDigitalInputProviderImpl> {com.pi4j.plugin.pigpio.provider.gpio.digital.PiGpioDigitalInputProviderImpl} 
└─I2C: [1] <com.pi4j.io.i2c.I2CProvider> 
  └─PROVIDER: "PiGpio I2C Provider" {pigpio-i2c} <com.pi4j.plugin.pigpio.provider.i2c.PiGpioI2CProviderImpl> {com.pi4j.plugin.pigpio.provider.i2c.PiGpioI2CProviderImpl} 
----------------------------------------------------------


Pi5
Pi4J PROVIDERS
----------------------------------------------------------
PROVIDERS: [6] "I/O Providers" <com.pi4j.provider.impl.DefaultProviders> 
├─ANALOG_OUTPUT: [0] <com.pi4j.io.gpio.analog.AnalogOutputProvider> 
├─DIGITAL_OUTPUT: [1] <com.pi4j.io.gpio.digital.DigitalOutputProvider> 
│ └─PROVIDER: "GpioD Digital Output (GPIO) Provider" {gpiod-digital-output} <com.pi4j.plugin.gpiod.provider.gpio.digital.GpioDDigitalOutputProviderImpl> {com.pi4j.plugin.gpiod.provider.gpio.digital.GpioDDigitalOutputProviderImpl} 
├─SPI: [1] <com.pi4j.io.spi.SpiProvider> 
│ └─PROVIDER: "PiGpio SPI Provider" {pigpio-spi} <com.pi4j.plugin.pigpio.provider.spi.PiGpioSpiProviderImpl> {com.pi4j.plugin.pigpio.provider.spi.PiGpioSpiProviderImpl} 
├─PWM: [1] <com.pi4j.io.pwm.PwmProvider> 
│ └─PROVIDER: "LinuxFS PWM Provider" {linuxfs-pwm} <com.pi4j.plugin.linuxfs.provider.pwm.LinuxFsPwmProviderImpl> {com.pi4j.plugin.linuxfs.provider.pwm.LinuxFsPwmProviderImpl} 
├─ANALOG_INPUT: [0] <com.pi4j.io.gpio.analog.AnalogInputProvider> 
├─DIGITAL_INPUT: [1] <com.pi4j.io.gpio.digital.DigitalInputProvider> 
│ └─PROVIDER: "GpioD Digital Input (GPIO) Provider" {gpiod-digital-input} <com.pi4j.plugin.gpiod.provider.gpio.digital.GpioDDigitalInputProviderImpl> {com.pi4j.plugin.gpiod.provider.gpio.digital.GpioDDigitalInputProviderImpl} 
├─SERIAL: [1] <com.pi4j.io.serial.SerialProvider> 
│ └─PROVIDER: "PiGpio Serial Provider" {pigpio-serial} <com.pi4j.plugin.pigpio.provider.serial.PiGpioSerialProviderImpl> {com.pi4j.plugin.pigpio.provider.serial.PiGpioSerialProviderImpl} 
└─I2C: [1] <com.pi4j.io.i2c.I2CProvider> 
  └─PROVIDER: "LinuxFS I2C Provider" {linuxfs-i2c} <com.pi4j.plugin.linuxfs.provider.i2c.LinuxFsI2CProviderImpl> {com.pi4j.plugin.linuxfs.provider.i2c.LinuxFsI2CProviderImpl} 
```