### PR TITLE
fix(io): IOBase constructor do not update the fields id, name & description

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/IOBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IOBase.java
@@ -60,6 +60,9 @@ public abstract class IOBase<IO_TYPE extends IO, CONFIG_TYPE extends IOConfig, P
      */
     public IOBase(PROVIDER_TYPE provider, CONFIG_TYPE config){
         super();
+        this.id = config.id();
+        this.name = config.name();
+        this.description = config.description();
         this.provider = provider;
         this.config = config;
     }

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioBase.java
@@ -47,9 +47,6 @@ public abstract class GpioBase<IO_TYPE extends Gpio<IO_TYPE, CONFIG_TYPE, PROVID
      */
     public GpioBase(PROVIDER_TYPE provider, CONFIG_TYPE config){
         super(provider, config);
-        this.name = config.name();
-        this.id = config.id();
-        this.description = config.description();
     }
 
     /** {@inheritDoc} */

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBase.java
@@ -48,9 +48,6 @@ public abstract class I2CBase extends IOBase<I2C, I2CConfig, I2CProvider> implem
      */
     public I2CBase(I2CProvider provider, I2CConfig config) {
         super(provider, config);
-        this.name = config.name();
-        this.id = config.id();
-        this.description = config.description();
         this.isOpen = true;
     }
 

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmBase.java
@@ -57,9 +57,6 @@ public abstract class PwmBase extends IOBase<Pwm, PwmConfig, PwmProvider> implem
      */
     public PwmBase(PwmProvider provider, PwmConfig config) {
         super(provider, config);
-        this.name = config.name();
-        this.id = config.id();
-        this.description = config.description();
         for(PwmPreset preset : config.presets()){
             this.presets.put(preset.name().toLowerCase().trim(), preset);
         }

--- a/pi4j-core/src/main/java/com/pi4j/io/spi/SpiBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/SpiBase.java
@@ -48,9 +48,6 @@ public abstract class SpiBase extends IOBase<Spi, SpiConfig, SpiProvider> implem
      */
     public SpiBase(SpiProvider provider, SpiConfig config) {
         super(provider, config);
-        this.name = config.name();
-        this.id = config.id();
-        this.description = config.description();
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
The classes extending IOBase were already updating those fields (except SerialBase). SerialBase was the only class missing this change.

These changes allow the user to use multiple Serial interface at the same time. It was impossible before, as Pi4J would throw IOAlreadyExistsException.

This commit "moves" the fixes for the similar issues in the SPI interface. It also moves the similar code found in the dependency classes in the IOBase class.

Ref: #244, #257
Closes: #257