### PR TITLE
Don't load native code when not running on a recognized board

### DIFF
--- a/libraries/pi4j-library-gpiod/src/main/java/com/pi4j/library/gpiod/internal/GpioDContext.java
+++ b/libraries/pi4j-library-gpiod/src/main/java/com/pi4j/library/gpiod/internal/GpioDContext.java
@@ -1,10 +1,15 @@
 package com.pi4j.library.gpiod.internal;
 
+import com.pi4j.boardinfo.definition.BoardModel;
+import com.pi4j.boardinfo.util.BoardInfoHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public class GpioDContext implements Closeable {
 
@@ -31,6 +36,11 @@ public class GpioDContext implements Closeable {
     }
 
     public synchronized void initialize() {
+        if (BoardInfoHelper.current().getBoardModel() == BoardModel.UNKNOWN) {
+            logger.warn("Can't initialize GpioD context, board model is unknown");
+            return;
+        }
+
         // already initialized
         if (this.gpioChip != null)
             return;

--- a/libraries/pi4j-library-gpiod/src/main/java/com/pi4j/library/gpiod/util/NativeLibraryLoader.java
+++ b/libraries/pi4j-library-gpiod/src/main/java/com/pi4j/library/gpiod/util/NativeLibraryLoader.java
@@ -26,6 +26,8 @@ package com.pi4j.library.gpiod.util;
  * #L%
  */
 
+import com.pi4j.boardinfo.definition.BoardModel;
+import com.pi4j.boardinfo.util.BoardInfoHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -252,7 +254,12 @@ public class NativeLibraryLoader {
             }
             Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
         }
+
         // Finally, load the library
-        System.load(target.toAbsolutePath().toString());
+        if (BoardInfoHelper.current().getBoardModel() == BoardModel.UNKNOWN) {
+            logger.warn("Can't load the library, board model is unknown");
+        } else {
+            System.load(target.toAbsolutePath().toString());
+        }
     }
 }

--- a/pi4j-test/src/main/java/com/pi4j/test/About.java
+++ b/pi4j-test/src/main/java/com/pi4j/test/About.java
@@ -105,12 +105,16 @@ public class About {
      * @param context a {@link com.pi4j.context.Context} object.
      * @throws Pi4JException if any.
      */
-    public void describeDeafultPlatform(Context context) throws Pi4JException {
+    public void describeDefaultPlatform(Context context) throws Pi4JException {
         logger.info("=====================================================");
         logger.info("DEFAULT (RUNTIME) PLATFORM ");
         logger.info("=====================================================");
-        logger.info("  " + context.platform().name() + " [" + context.platform().id() + "]");
-        context.platform().describe().print(System.out);
+        if (context.platform() == null) {
+            logger.warn("  NOT DEFINED");
+        } else {
+            logger.info("  {}} [{}}]", context.platform().name(), context.platform().id());
+            context.platform().describe().print(System.out);
+        }
     }
 
 //    public void enumeratePlatformProviders() throws Pi4JException {

--- a/pi4j-test/src/main/java/com/pi4j/test/Main.java
+++ b/pi4j-test/src/main/java/com/pi4j/test/Main.java
@@ -67,7 +67,7 @@ public class Main {
         About about = new About();
         about.enumerateProviders(pi4j);
         about.enumeratePlatforms(pi4j);
-        about.describeDeafultPlatform(pi4j);
+        about.describeDefaultPlatform(pi4j);
         for(var ioType : IOType.values()){
             about.enumerateProviders(pi4j, ioType);
         }


### PR DESCRIPTION
Use board type to prevent errors while loading native libraries during development on non-Raspberry Pi.

@eitch can you please review if these are the right places to implement this? I have the feeling it should be somewhere "on a higher level", but not sure where...