### PR TITLE
allowing configuring shutdown hook

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/context/ContextBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/context/ContextBuilder.java
@@ -148,6 +148,34 @@ public interface ContextBuilder extends Builder<Context> {
     }
 
     /**
+     * <p>enableShutdownHook.</p>
+     *
+     * @return a {@link com.pi4j.context.ContextBuilder} object.
+     */
+    ContextBuilder enableShutdownHook();
+
+    /**
+     * <p>disableShutdownHook.</p>
+     *
+     * @return a {@link com.pi4j.context.ContextBuilder} object.
+     */
+    ContextBuilder disableShutdownHook();
+
+    /**
+     * <p>setShutdownHook.</p>
+     *
+     * @param enableShutdownHook a boolean.
+     *
+     * @return a {@link com.pi4j.context.ContextBuilder} object.
+     */
+    default ContextBuilder setShutdownHook(boolean enableShutdownHook) {
+        if (enableShutdownHook)
+            return enableShutdownHook();
+        else
+            return disableShutdownHook();
+    }
+
+    /**
      * <p>toConfig.</p>
      *
      * @return a {@link com.pi4j.context.ContextConfig} object.

--- a/pi4j-core/src/main/java/com/pi4j/context/ContextConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/context/ContextConfig.java
@@ -87,6 +87,12 @@ public interface ContextConfig {
      */
     boolean autoInject();
     /**
+     * <p>enableShutdownHook.</p>
+     *
+     * @return a boolean.
+     */
+    boolean enableShutdownHook();
+    /**
      * <p>getAutoInject.</p>
      *
      * @return a boolean.

--- a/pi4j-core/src/main/java/com/pi4j/context/impl/DefaultContextBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/context/impl/DefaultContextBuilder.java
@@ -54,7 +54,7 @@ public class DefaultContextBuilder implements ContextBuilder {
     protected boolean autoDetectPlatforms = false;
     protected boolean autoDetectProviders = false;
     protected boolean autoInject = false;
-    protected boolean enableShutdownHook = true;
+    protected boolean enableShutdownHook = false;
 
     // default platform identifier
     protected String defaultPlatformId = null;

--- a/pi4j-core/src/main/java/com/pi4j/context/impl/DefaultContextBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/context/impl/DefaultContextBuilder.java
@@ -54,6 +54,7 @@ public class DefaultContextBuilder implements ContextBuilder {
     protected boolean autoDetectPlatforms = false;
     protected boolean autoDetectProviders = false;
     protected boolean autoInject = false;
+    protected boolean enableShutdownHook = true;
 
     // default platform identifier
     protected String defaultPlatformId = null;
@@ -159,6 +160,20 @@ public class DefaultContextBuilder implements ContextBuilder {
 
     /** {@inheritDoc} */
     @Override
+    public ContextBuilder enableShutdownHook() {
+        this.enableShutdownHook = true;
+        return this;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ContextBuilder disableShutdownHook() {
+        this.enableShutdownHook = false;
+        return this;
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public ContextBuilder property(String key, String value){
         this.properties.put(key, value);
         return this;
@@ -258,9 +273,15 @@ public class DefaultContextBuilder implements ContextBuilder {
             public boolean autoDetectMockPlugins() {
                 return builder.autoDetectMockPlugins;
             }
+
             @Override
             public boolean autoDetectPlatforms() {
                 return builder.autoDetectPlatforms;
+            }
+
+            @Override
+            public boolean enableShutdownHook() {
+                return builder.enableShutdownHook;
             }
 
             @Override

--- a/pi4j-core/src/main/java/com/pi4j/runtime/impl/DefaultRuntime.java
+++ b/pi4j-core/src/main/java/com/pi4j/runtime/impl/DefaultRuntime.java
@@ -110,15 +110,17 @@ public class DefaultRuntime implements Runtime {
 
         // listen for shutdown to properly clean up
         // TODO :: ADD PI4J INTERNAL SHUTDOWN CALLBACKS/EVENTS
-        java.lang.Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            try {
-                // shutdown Pi4J
-                if (!isShutdown)
-                    shutdown();
-            } catch (Exception e) {
-                logger.error("Failed to shutdown Pi4J runtime", e);
-            }
-        }, "pi4j-shutdown"));
+        if (this.context.config().enableShutdownHook()) {
+            java.lang.Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                try {
+                    // shutdown Pi4J
+                    if (!isShutdown)
+                        shutdown();
+                } catch (Exception e) {
+                    logger.error("Failed to shutdown Pi4J runtime", e);
+                }
+            }, "pi4j-shutdown"));
+        }
     }
 
     /**


### PR DESCRIPTION
The shutdown hook is hooked into the JVM and is executed when the JVM stops.

This can be beneficial when the application is not managing pi4j's life cycle, but when an application wants to properly manage the life cycle, then this can be detrimental to the shutdown sequence of the application.

This change allows such an application to disable this feature.

The shutdown hook is still enabled by default, a future version might decide to disable it by default.