### PR TITLE
[Major] allow to load mocks on non-rpi systems

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/Pi4J.java
+++ b/pi4j-core/src/main/java/com/pi4j/Pi4J.java
@@ -63,29 +63,11 @@ public class Pi4J {
      * state and lifecycle.   This 'Context' instance will automatically
      * load all detected 'Platforms' and 'Providers' that are detected
      * in the application's class-path.</p>
-     *
-     * <p>This method does not allow mock plugins to be used. If this is required, e.g. for testing then use {@link #newAutoContextAllowMocks()}</p>
-     *
      * @return Context
      */
     public static Context newAutoContext() {
         logger.info("New auto context");
         return newContextBuilder().autoDetect().build();
-    }
-
-    /**
-     * <p>Returns a new 'Context' instance which represents the Pi4J runtime
-     * state and lifecycle.   This 'Context' instance will automatically
-     * load all detected 'Platforms' and 'Providers' that are detected
-     * in the application's class-path.</p>
-     *
-     * <p>In contrast to {@link #newAutoContext()} this method will allow mocks to be added to the runtime.</p>
-     *
-     * @return Context
-     */
-    public static Context newAutoContextAllowMocks() {
-        logger.info("New auto context");
-        return newContextBuilder().autoDetect().autoDetectMockPlugins().build();
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/context/ContextBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/context/ContextBuilder.java
@@ -148,6 +148,34 @@ public interface ContextBuilder extends Builder<Context> {
     }
 
     /**
+     * <p>enableShutdownHook.</p>
+     *
+     * @return a {@link com.pi4j.context.ContextBuilder} object.
+     */
+    ContextBuilder enableShutdownHook();
+
+    /**
+     * <p>disableShutdownHook.</p>
+     *
+     * @return a {@link com.pi4j.context.ContextBuilder} object.
+     */
+    ContextBuilder disableShutdownHook();
+
+    /**
+     * <p>setShutdownHook.</p>
+     *
+     * @param enableShutdownHook a boolean.
+     *
+     * @return a {@link com.pi4j.context.ContextBuilder} object.
+     */
+    default ContextBuilder setShutdownHook(boolean enableShutdownHook) {
+        if (enableShutdownHook)
+            return enableShutdownHook();
+        else
+            return disableShutdownHook();
+    }
+
+    /**
      * <p>toConfig.</p>
      *
      * @return a {@link com.pi4j.context.ContextConfig} object.

--- a/pi4j-core/src/main/java/com/pi4j/context/ContextConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/context/ContextConfig.java
@@ -87,6 +87,12 @@ public interface ContextConfig {
      */
     boolean autoInject();
     /**
+     * <p>enableShutdownHook.</p>
+     *
+     * @return a boolean.
+     */
+    boolean enableShutdownHook();
+    /**
      * <p>getAutoInject.</p>
      *
      * @return a boolean.

--- a/pi4j-core/src/main/java/com/pi4j/context/impl/DefaultContextBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/context/impl/DefaultContextBuilder.java
@@ -54,7 +54,7 @@ public class DefaultContextBuilder implements ContextBuilder {
     protected boolean autoDetectPlatforms = false;
     protected boolean autoDetectProviders = false;
     protected boolean autoInject = false;
-    protected boolean enableShutdownHook = true;
+    protected boolean enableShutdownHook = false;
 
     // default platform identifier
     protected String defaultPlatformId = null;

--- a/pi4j-core/src/main/java/com/pi4j/context/impl/DefaultContextBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/context/impl/DefaultContextBuilder.java
@@ -25,6 +25,7 @@ package com.pi4j.context.impl;
  * #L%
  */
 
+import com.pi4j.boardinfo.util.BoardInfoHelper;
 import com.pi4j.context.Context;
 import com.pi4j.context.ContextBuilder;
 import com.pi4j.context.ContextConfig;
@@ -50,7 +51,7 @@ public class DefaultContextBuilder implements ContextBuilder {
     protected Logger logger = LoggerFactory.getLogger(DefaultContextBuilder.class);
 
     // auto detection flags
-    protected boolean autoDetectMockPlugins = false;
+    protected boolean autoDetectMockPlugins = !BoardInfoHelper.runningOnRaspberryPi();
     protected boolean autoDetectPlatforms = false;
     protected boolean autoDetectProviders = false;
     protected boolean autoInject = false;

--- a/pi4j-core/src/main/java/com/pi4j/context/impl/DefaultContextBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/context/impl/DefaultContextBuilder.java
@@ -54,6 +54,7 @@ public class DefaultContextBuilder implements ContextBuilder {
     protected boolean autoDetectPlatforms = false;
     protected boolean autoDetectProviders = false;
     protected boolean autoInject = false;
+    protected boolean enableShutdownHook = true;
 
     // default platform identifier
     protected String defaultPlatformId = null;
@@ -159,6 +160,20 @@ public class DefaultContextBuilder implements ContextBuilder {
 
     /** {@inheritDoc} */
     @Override
+    public ContextBuilder enableShutdownHook() {
+        this.enableShutdownHook = true;
+        return this;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ContextBuilder disableShutdownHook() {
+        this.enableShutdownHook = false;
+        return this;
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public ContextBuilder property(String key, String value){
         this.properties.put(key, value);
         return this;
@@ -258,9 +273,15 @@ public class DefaultContextBuilder implements ContextBuilder {
             public boolean autoDetectMockPlugins() {
                 return builder.autoDetectMockPlugins;
             }
+
             @Override
             public boolean autoDetectPlatforms() {
                 return builder.autoDetectPlatforms;
+            }
+
+            @Override
+            public boolean enableShutdownHook() {
+                return builder.enableShutdownHook;
             }
 
             @Override

--- a/pi4j-core/src/main/java/com/pi4j/runtime/impl/DefaultRuntime.java
+++ b/pi4j-core/src/main/java/com/pi4j/runtime/impl/DefaultRuntime.java
@@ -110,15 +110,17 @@ public class DefaultRuntime implements Runtime {
 
         // listen for shutdown to properly clean up
         // TODO :: ADD PI4J INTERNAL SHUTDOWN CALLBACKS/EVENTS
-        java.lang.Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            try {
-                // shutdown Pi4J
-                if (!isShutdown)
-                    shutdown();
-            } catch (Exception e) {
-                logger.error("Failed to shutdown Pi4J runtime", e);
-            }
-        }, "pi4j-shutdown"));
+        if (this.context.config().enableShutdownHook()) {
+            java.lang.Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                try {
+                    // shutdown Pi4J
+                    if (!isShutdown)
+                        shutdown();
+                } catch (Exception e) {
+                    logger.error("Failed to shutdown Pi4J runtime", e);
+                }
+            }, "pi4j-shutdown"));
+        }
     }
 
     /**

--- a/pi4j-test/src/test/java/com/pi4j/test/context/ContextTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/context/ContextTest.java
@@ -51,7 +51,7 @@ public class ContextTest {
         // An auto context includes AUTO-DETECT BINDINGS enabled
         // which will load all detected Pi4J extension libraries
         // (Platforms and Providers) in the class path
-        pi4j = Pi4J.newAutoContextAllowMocks();
+        pi4j = Pi4J.newAutoContext();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/io/i2c/I2CRawDataTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/i2c/I2CRawDataTest.java
@@ -67,7 +67,7 @@ public class I2CRawDataTest {
         // An auto context enabled AUTO-DETECT loading
         // which will load any detected Pi4J extension
         // libraries (Platforms and Providers) from the class path
-        pi4j = Pi4J.newAutoContextAllowMocks();
+        pi4j = Pi4J.newAutoContext();
     }
 
     @AfterEach

--- a/pi4j-test/src/test/java/com/pi4j/test/io/i2c/I2CRegisterDataTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/i2c/I2CRegisterDataTest.java
@@ -68,7 +68,7 @@ public class I2CRegisterDataTest {
         // An auto context enabled AUTO-DETECT loading
         // which will load any detected Pi4J extension
         // libraries (Platforms and Providers) from the class path
-        pi4j = Pi4J.newAutoContextAllowMocks();
+        pi4j = Pi4J.newAutoContext();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/io/spi/SpiRawDataTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/spi/SpiRawDataTest.java
@@ -66,7 +66,7 @@ public class SpiRawDataTest {
         // An auto context enabled AUTO-DETECT loading
         // which will load any detected Pi4J extension
         // libraries (Platforms and Providers) from the class path
-        pi4j = Pi4J.newAutoContextAllowMocks();
+        pi4j = Pi4J.newAutoContext();
     }
 
     @AfterEach

--- a/pi4j-test/src/test/java/com/pi4j/test/platform/AutoPlatformsTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/platform/AutoPlatformsTest.java
@@ -48,7 +48,7 @@ public class AutoPlatformsTest {
         // An auto context includes AUTO-DETECT BINDINGS enabled
         // which will load all detected Pi4J extension libraries
         // (Platforms and Providers) in the class path
-        pi4j = Pi4J.newAutoContextAllowMocks();
+        pi4j = Pi4J.newAutoContext();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/provider/AutoProvidersTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/provider/AutoProvidersTest.java
@@ -51,7 +51,7 @@ public class AutoProvidersTest {
         // An auto context includes AUTO-DETECT BINDINGS enabled
         // which will load all detected Pi4J extension libraries
         // (Platforms and Providers) in the class path
-        pi4j = Pi4J.newAutoContextAllowMocks();
+        pi4j = Pi4J.newAutoContext();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryGetIoInstance.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryGetIoInstance.java
@@ -53,7 +53,7 @@ public class RegistryGetIoInstance {
         // An auto context includes AUTO-DETECT BINDINGS enabled
         // which will load all detected Pi4J extension libraries
         // (Platforms and Providers) in the class path
-        pi4j = Pi4J.newAutoContextAllowMocks();
+        pi4j = Pi4J.newAutoContext();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
@@ -52,7 +52,7 @@ public class RegistryTest {
         // An auto context includes AUTO-DETECT BINDINGS enabled
         // which will load all detected Pi4J extension libraries
         // (Platforms and Providers) in the class path
-        pi4j = Pi4J.newAutoContextAllowMocks();
+        pi4j = Pi4J.newAutoContext();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/runtime/RuntimeTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/runtime/RuntimeTest.java
@@ -52,7 +52,7 @@ public class RuntimeTest {
         // An auto context includes AUTO-DETECT BINDINGS enabled
         // which will load all detected Pi4J extension libraries
         // (Platforms and Providers) in the class path
-        Context pi4j = Pi4J.newAutoContextAllowMocks();
+        Context pi4j = Pi4J.newAutoContext();
 
         logger.info("-------------------------------------------------");
         logger.info("Pi4J CONTEXT <acquired via factory accessor>");


### PR DESCRIPTION
This removes the

    Pi4J.newAutoContextAllowMocks()

function, as we now detect these systems using:

    BoardInfoHelper.runningOnRaspberryPi()

This is a breaking API change, but should satisfy people having to write special code to load the mock in tests, as this happens automatically now.

If a mock is to be loaded on the Raspberry Pi, then one can still do this using the following code:

    Pi4J.newContextBuilder().autoDetectMockPlugins().build();
