### PR TITLE
Add Checkstyle Plugin to Enforce Import Rules

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="UnusedImports"/>
+        <module name="RedundantImport"/>
+        <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+    </module>
+</module>

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpio_Servo.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpio_Servo.java
@@ -27,8 +27,6 @@ package com.pi4j.library.pigpio;
  * #L%
  */
 
-import java.io.IOException;
-
 /**
  * <p>PiGpio_Servo interface.</p>
  *

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DigitalConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DigitalConfigBuilderBase.java
@@ -28,7 +28,6 @@ package com.pi4j.io.gpio.digital.impl;
 import com.pi4j.context.Context;
 import com.pi4j.io.gpio.digital.DigitalConfig;
 import com.pi4j.io.gpio.digital.DigitalConfigBuilder;
-import com.pi4j.io.gpio.digital.DigitalOutputConfigBuilder;
 import com.pi4j.io.gpio.digital.DigitalState;
 import com.pi4j.io.impl.IOAddressConfigBuilderBase;
 

--- a/pi4j-test/src/test/java/com/pi4j/test/platform/ManualPlatformsCtorTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/platform/ManualPlatformsCtorTest.java
@@ -30,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.pi4j.Pi4J;
 import com.pi4j.context.Context;
-import com.pi4j.exception.Pi4JException;
 import com.pi4j.test.provider.TestI2CProvider;
 import com.pi4j.test.provider.TestPwmProvider;
 import com.pi4j.test.provider.TestSerialProvider;

--- a/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalInputProviderImpl.java
+++ b/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalInputProviderImpl.java
@@ -1,7 +1,6 @@
 package com.pi4j.plugin.gpiod.provider.gpio.digital;
 
 
-import com.pi4j.boardinfo.util.BoardInfoHelper;
 import com.pi4j.context.Context;
 import com.pi4j.exception.InitializeException;
 import com.pi4j.exception.ShutdownException;

--- a/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalOutputProviderImpl.java
+++ b/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalOutputProviderImpl.java
@@ -27,7 +27,6 @@ package com.pi4j.plugin.gpiod.provider.gpio.digital;
  * #L%
  */
 
-import com.pi4j.boardinfo.util.BoardInfoHelper;
 import com.pi4j.context.Context;
 import com.pi4j.exception.InitializeException;
 import com.pi4j.exception.ShutdownException;

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/i2c/LinuxFsI2CProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/i2c/LinuxFsI2CProviderImpl.java
@@ -28,7 +28,6 @@ package com.pi4j.plugin.linuxfs.provider.i2c;
  */
 
 
-import com.pi4j.boardinfo.util.BoardInfoHelper;
 import com.pi4j.context.Context;
 import com.pi4j.exception.ShutdownException;
 import com.pi4j.io.i2c.I2C;

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/analog/MockAnalogInputProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/analog/MockAnalogInputProviderImpl.java
@@ -27,7 +27,6 @@ package com.pi4j.plugin.mock.provider.gpio.analog;
  * #L%
  */
 
-import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.gpio.analog.AnalogInput;
 import com.pi4j.io.gpio.analog.AnalogInputConfig;
 import com.pi4j.io.gpio.analog.AnalogInputProviderBase;

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/analog/MockAnalogOutputProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/analog/MockAnalogOutputProviderImpl.java
@@ -27,7 +27,6 @@ package com.pi4j.plugin.mock.provider.gpio.analog;
  * #L%
  */
 
-import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.gpio.analog.AnalogOutput;
 import com.pi4j.io.gpio.analog.AnalogOutputConfig;
 import com.pi4j.io.gpio.analog.AnalogOutputProviderBase;

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/digital/MockDigitalInputProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/digital/MockDigitalInputProviderImpl.java
@@ -27,7 +27,6 @@ package com.pi4j.plugin.mock.provider.gpio.digital;
  * #L%
  */
 
-import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.gpio.digital.DigitalInput;
 import com.pi4j.io.gpio.digital.DigitalInputConfig;
 import com.pi4j.io.gpio.digital.DigitalInputProviderBase;

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/digital/MockDigitalOutputProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/digital/MockDigitalOutputProviderImpl.java
@@ -27,7 +27,6 @@ package com.pi4j.plugin.mock.provider.gpio.digital;
  * #L%
  */
 
-import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.gpio.digital.DigitalOutput;
 import com.pi4j.io.gpio.digital.DigitalOutputConfig;
 import com.pi4j.io.gpio.digital.DigitalOutputProviderBase;

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/i2c/MockI2CProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/i2c/MockI2CProviderImpl.java
@@ -27,7 +27,6 @@ package com.pi4j.plugin.mock.provider.i2c;
  * #L%
  */
 
-import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.i2c.I2C;
 import com.pi4j.io.i2c.I2CConfig;
 import com.pi4j.io.i2c.I2CProviderBase;

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/pwm/MockPwmProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/pwm/MockPwmProviderImpl.java
@@ -27,7 +27,6 @@ package com.pi4j.plugin.mock.provider.pwm;
  * #L%
  */
 
-import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.pwm.Pwm;
 import com.pi4j.io.pwm.PwmConfig;
 import com.pi4j.io.pwm.PwmProviderBase;

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/serial/MockSerialProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/serial/MockSerialProviderImpl.java
@@ -27,7 +27,6 @@ package com.pi4j.plugin.mock.provider.serial;
  * #L%
  */
 
-import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.serial.Serial;
 import com.pi4j.io.serial.SerialConfig;
 import com.pi4j.io.serial.SerialProviderBase;

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/spi/MockSpiProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/spi/MockSpiProviderImpl.java
@@ -27,7 +27,6 @@ package com.pi4j.plugin.mock.provider.spi;
  * #L%
  */
 
-import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.spi.Spi;
 import com.pi4j.io.spi.SpiConfig;
 import com.pi4j.io.spi.SpiProviderBase;

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/serial/PiGpioSerial.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/serial/PiGpioSerial.java
@@ -37,8 +37,6 @@ import com.pi4j.io.serial.SerialProvider;
 import com.pi4j.library.pigpio.PiGpio;
 import com.pi4j.library.pigpio.PiGpioMode;
 
-import java.io.IOException;
-
 /**
  * <p>PiGpioSerial class.</p>
  *

--- a/plugins/pi4j-plugin-raspberrypi/src/main/java/com/pi4j/plugin/raspberrypi/provider/gpio/digital/RpiDigitalInputProviderImpl.java
+++ b/plugins/pi4j-plugin-raspberrypi/src/main/java/com/pi4j/plugin/raspberrypi/provider/gpio/digital/RpiDigitalInputProviderImpl.java
@@ -27,7 +27,6 @@ package com.pi4j.plugin.raspberrypi.provider.gpio.digital;
  * #L%
  */
 
-import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.gpio.digital.DigitalInput;
 import com.pi4j.io.gpio.digital.DigitalInputConfig;
 import com.pi4j.io.gpio.digital.DigitalInputProviderBase;

--- a/plugins/pi4j-plugin-raspberrypi/src/main/java/com/pi4j/plugin/raspberrypi/provider/gpio/digital/RpiDigitalOutputProviderImpl.java
+++ b/plugins/pi4j-plugin-raspberrypi/src/main/java/com/pi4j/plugin/raspberrypi/provider/gpio/digital/RpiDigitalOutputProviderImpl.java
@@ -27,7 +27,6 @@ package com.pi4j.plugin.raspberrypi.provider.gpio.digital;
  * #L%
  */
 
-import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.gpio.digital.DigitalOutput;
 import com.pi4j.io.gpio.digital.DigitalOutputConfig;
 import com.pi4j.io.gpio.digital.DigitalOutputProviderBase;

--- a/plugins/pi4j-plugin-raspberrypi/src/main/java/com/pi4j/plugin/raspberrypi/provider/i2c/RpiI2CProviderImpl.java
+++ b/plugins/pi4j-plugin-raspberrypi/src/main/java/com/pi4j/plugin/raspberrypi/provider/i2c/RpiI2CProviderImpl.java
@@ -27,7 +27,6 @@ package com.pi4j.plugin.raspberrypi.provider.i2c;
  * #L%
  */
 
-import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.i2c.I2C;
 import com.pi4j.io.i2c.I2CConfig;
 import com.pi4j.io.i2c.I2CProviderBase;

--- a/plugins/pi4j-plugin-raspberrypi/src/main/java/com/pi4j/plugin/raspberrypi/provider/pwm/RpiPwmProviderImpl.java
+++ b/plugins/pi4j-plugin-raspberrypi/src/main/java/com/pi4j/plugin/raspberrypi/provider/pwm/RpiPwmProviderImpl.java
@@ -27,7 +27,6 @@ package com.pi4j.plugin.raspberrypi.provider.pwm;
  * #L%
  */
 
-import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.pwm.Pwm;
 import com.pi4j.io.pwm.PwmConfig;
 import com.pi4j.io.pwm.PwmProviderBase;

--- a/plugins/pi4j-plugin-raspberrypi/src/main/java/com/pi4j/plugin/raspberrypi/provider/serial/RpiSerialProviderImpl.java
+++ b/plugins/pi4j-plugin-raspberrypi/src/main/java/com/pi4j/plugin/raspberrypi/provider/serial/RpiSerialProviderImpl.java
@@ -27,7 +27,6 @@ package com.pi4j.plugin.raspberrypi.provider.serial;
  * #L%
  */
 
-import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.serial.Serial;
 import com.pi4j.io.serial.SerialConfig;
 import com.pi4j.io.serial.SerialProviderBase;

--- a/plugins/pi4j-plugin-raspberrypi/src/main/java/com/pi4j/plugin/raspberrypi/provider/spi/RpiSpiProviderImpl.java
+++ b/plugins/pi4j-plugin-raspberrypi/src/main/java/com/pi4j/plugin/raspberrypi/provider/spi/RpiSpiProviderImpl.java
@@ -27,7 +27,6 @@ package com.pi4j.plugin.raspberrypi.provider.spi;
  * #L%
  */
 
-import com.pi4j.io.exception.IOAlreadyExistsException;
 import com.pi4j.io.spi.Spi;
 import com.pi4j.io.spi.SpiConfig;
 import com.pi4j.io.spi.SpiProviderBase;

--- a/pom.xml
+++ b/pom.xml
@@ -760,6 +760,25 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>checkstyle-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>validate</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <failsOnError>true</failsOnError>
+                    <configLocation>config/checkstyle/checkstyle.xml</configLocation>
+                    <excludes>**/module-info.java</excludes>
+                </configuration>
+            </plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
While analyzing the project, I found several unused and redundant import statements. To improve the code quality and ensure that best practices are followed going forward, I have added the Checkstyle plugin with rules to:

- Detect and remove unused imports.
- Prevent redundant imports (e.g., duplicate imports of the same class).
- Disallow illegal imports such as sun.* packages by default.

This configuration will help maintain clean and compliant code, and the build will fail if any violations are detected.