### PR TITLE
Fixed Checkstyle Issues

### DIFF
--- a/libraries/pi4j-library-gpiod/src/main/java/com/pi4j/library/gpiod/util/NativeLibraryLoader.java
+++ b/libraries/pi4j-library-gpiod/src/main/java/com/pi4j/library/gpiod/util/NativeLibraryLoader.java
@@ -212,7 +212,7 @@ public class NativeLibraryLoader {
 
     /**
      * Loads library from classpath
-     *
+     * <p>
      * The file from classpath is copied into system temporary directory and then loaded. The temporary file is
      * deleted after exiting. Method uses String as filename because the pathname is
      * "abstract", not system-dependent.

--- a/libraries/pi4j-library-linuxfs/src/main/java/com/pi4j/library/linuxfs/LinuxFile.java
+++ b/libraries/pi4j-library-linuxfs/src/main/java/com/pi4j/library/linuxfs/LinuxFile.java
@@ -82,7 +82,7 @@ public class LinuxFile extends RandomAccessFile {
      * Runs an ioctl on a file descriptor. Uses special offset buffer to produce real C-like structures with pointers.
      * Advanced use only! Must be able to produce byte-perfect data structures just as gcc would on this system,
      * including struct padding and pointer size.
-     *
+     * <p>
      * The data ByteBuffer uses the current position to determine the head point of data passed to the ioctl. This is
      * useful for appending entry-point data structures at the end of the buffer, while referring to other
      * structures/data that come before them in the buffer.
@@ -93,7 +93,7 @@ public class LinuxFile extends RandomAccessFile {
      * pointer. Also be sure to consider GCC padding and structure alignment. GCC will try a field to its word size (32b
      * ints align at 4-byte, etc), and will align the structure size with the native word size (4-byte for 32b, 8-byte
      * for 64b).
-     *
+     * <p>
      * Provided IntBuffer offsets must use native byte order (endianness).
      *
      * <pre>

--- a/libraries/pi4j-library-linuxfs/src/main/java/com/pi4j/library/linuxfs/util/NativeLibraryLoader.java
+++ b/libraries/pi4j-library-linuxfs/src/main/java/com/pi4j/library/linuxfs/util/NativeLibraryLoader.java
@@ -212,7 +212,7 @@ public class NativeLibraryLoader {
 
 	/**
 	 * Loads library from classpath
-     *
+     * <p>
 	 * The file from classpath is copied into system temporary directory and then loaded. The temporary file is
      * deleted after exiting. Method uses String as filename because the pathname is
 	 * "abstract", not system-dependent.

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpio.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpio.java
@@ -132,7 +132,7 @@ public interface PiGpio extends
     
     /**
      * Initialises the library.
-     *
+     * <p>
      * Returns the pigpio version number if OK, otherwise PI_INIT_FAILED.
      * gpioInitialise must be called before using the other library functions with the following exceptions:
      * - gpioCfg*
@@ -146,7 +146,7 @@ public interface PiGpio extends
 
     /**
      * Initialises the library.
-     *
+     * <p>
      * Returns the pigpio version number if OK, otherwise PI_INIT_FAILED.
      * gpioInitialise must be called before using the other library functions with the following exceptions:
      * - gpioCfg*
@@ -160,7 +160,7 @@ public interface PiGpio extends
 
     /**
      * Initialises the library.
-     *
+     * <p>
      * Returns the pigpio version number if OK, otherwise PI_INIT_FAILED.
      * gpioInitialise must be called before using the other library functions with the following exceptions:
      * - gpioCfg*
@@ -174,7 +174,7 @@ public interface PiGpio extends
 
     /**
      * Initialises the library.
-     *
+     * <p>
      * Returns the pigpio version number if OK, otherwise PI_INIT_FAILED.
      * gpioInitialise must be called before using the other library functions with the following exceptions:
      * - gpioCfg*
@@ -188,7 +188,7 @@ public interface PiGpio extends
 
     /**
      * Shutdown/Terminate the library.
-     *
+     * <p>
      * Returns nothing.
      * Call before program exit.
      * This function resets the used DMA channels, releases memory, and terminates any running threads.
@@ -199,7 +199,7 @@ public interface PiGpio extends
 
     /**
      * Shutdown/Terminate the library.
-     *
+     * <p>
      * Returns nothing.
      * Call before program exit.
      * This function resets the used DMA channels, releases memory, and terminates any running threads.
@@ -210,7 +210,7 @@ public interface PiGpio extends
 
     /**
      * Shutdown/Terminate the library.
-     *
+     * <p>
      * Returns nothing.
      * Call before program exit.
      * This function resets the used DMA channels, releases memory, and terminates any running threads.
@@ -227,16 +227,16 @@ public interface PiGpio extends
 
     /**
      * Returns the hardware revision.
-     *
+     * <p>
      * If the hardware revision can not be found or is not a valid hexadecimal number the function returns 0.
      * The hardware revision is the last few characters on the Revision line of /proc/cpuinfo.
      * The revision number can be used to determine the assignment of GPIO to pins (see gpio).
-     *
+     * <p>
      * There are at least three types of board.
      *  - Type 1 boards have hardware revision numbers of 2 and 3.
      *  - Type 2 boards have hardware revision numbers of 4, 5, 6, and 15.
      *  - Type 3 boards have hardware revision numbers of 16 or greater.
-     *
+     * <p>
      *     for "Revision : 0002" the function returns 2.
      *     for "Revision : 000f" the function returns 15.
      *     for "Revision : 000g" the function returns 0.
@@ -249,16 +249,16 @@ public interface PiGpio extends
 
     /**
      * Returns the hardware revision (as hexadecimal string).
-     *
+     * <p>
      * If the hardware revision can not be found or is not a valid hexadecimal number the function returns 0.
      * The hardware revision is the last few characters on the Revision line of /proc/cpuinfo.
      * The revision number can be used to determine the assignment of GPIO to pins (see gpio).
-     *
+     * <p>
      * There are at least three types of board.
      *  - Type 1 boards have hardware revision numbers of 2 and 3.
      *  - Type 2 boards have hardware revision numbers of 4, 5, 6, and 15.
      *  - Type 3 boards have hardware revision numbers of 16 or greater.
-     *
+     * <p>
      *     for "Revision : 0002" the function returns 2.
      *     for "Revision : 000f" the function returns 15.
      *     for "Revision : 000g" the function returns 0.
@@ -299,17 +299,17 @@ public interface PiGpio extends
     /**
      * Returns the current system tick.
      * Tick is the number of microseconds since system boot.
-     *
+     * <p>
      * As tick is an unsigned 32 bit quantity it wraps around after 2^32 microseconds, which is
      * approximately 1 hour 12 minutes.  You don't need to worry about the wrap around as long as you
      * take a tick (uint32_t) from another tick, i.e. the following code will always provide the
      * correct difference.
-     *
+     * <p>
      * Example
      *   uint32_t startTick, endTick;
      *   int diffTick;
      *   startTick = gpioTick();
-     *
+     * <p>
      *   // do some processing
      *   endTick = gpioTick();
      *   diffTick = endTick - startTick;

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpioPacket.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpioPacket.java
@@ -377,7 +377,7 @@ public class PiGpioPacket {
 
     /**
      * The packet may indicate the number of bytes to expect from the stream.
-     *
+     * <p>
      * E.g. I2C packets provide this value via {@link PiGpioPacket#p3}
      *
      * @param packet the packet being read

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpio_GPIO.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpio_GPIO.java
@@ -104,20 +104,20 @@ public interface PiGpio_GPIO {
 
     /**
      * Sets a glitch filter on a GPIO.  (AKA Debounce)
-     *
+     * <p>
      * Level changes on the GPIO are not reported unless the level has been stable for at
      * least 'steady' microseconds. The level is then reported. Level changes of less
      * than 'steady' microseconds are ignored.
-     *
+     * <p>
      * This filter affects the GPIO samples returned to callbacks set up with:
      *  - gpioSetAlertFunc
      *  - gpioSetAlertFuncEx
      *  - gpioSetGetSamplesFunc
      *  - gpioSetGetSamplesFuncEx.
-     *
+     * <p>
      * It does not affect interrupts set up with gpioSetISRFunc, gpioSetISRFuncEx, or
      * levels read by gpioRead, gpioRead_Bits_0_31, or gpioRead_Bits_32_53.
-     *
+     * <p>
      * Each (stable) edge will be timestamped steady microseconds after it was first detected.
      *
      * @param pin gpio pin address (valid pins are 0-31)
@@ -128,11 +128,11 @@ public interface PiGpio_GPIO {
 
     /**
      * Sets a noise filter on a GPIO.
-     *
+     * <p>
      * Level changes on the GPIO are ignored until a level which has been stable for 'steady'
      * microseconds is detected. Level changes on the GPIO are then reported for 'active'
      * microseconds after which the process repeats.
-     *
+     * <p>
      * This filter affects the GPIO samples returned to callbacks set up with:
      *  - gpioSetAlertFunc
      *  - gpioSetAlertFuncEx
@@ -140,7 +140,7 @@ public interface PiGpio_GPIO {
      *  - gpioSetGetSamplesFuncEx.     *
      * It does not affect interrupts set up with gpioSetISRFunc, gpioSetISRFuncEx, or
      * levels read by gpioRead, gpioRead_Bits_0_31, or gpioRead_Bits_32_53.
-     *
+     * <p>
      * Level changes before and after the active period may be reported.
      * Your software must be designed to cope with such reports.
      *

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpio_I2C.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpio_I2C.java
@@ -44,7 +44,7 @@ public interface PiGpio_I2C {
      * This returns a handle for the device at the address on the I2C bus.
      * Physically buses 0 and 1 are available on the Pi.
      * Higher numbered buses will be available if a kernel supported bus multiplexor is being used.
-     *
+     * <p>
      * The GPIO used are given in the following table.
      *         SDA   SCL
      * I2C0     0     1
@@ -63,7 +63,7 @@ public interface PiGpio_I2C {
      * This returns a handle for the device at the address on the I2C bus.
      * Physically buses 0 and 1 are available on the Pi.
      * Higher numbered buses will be available if a kernel supported bus multiplexor is being used.
-     *
+     * <p>
      * The GPIO used are given in the following table.
      *         SDA   SCL
      * I2C0     0     1
@@ -216,7 +216,7 @@ public interface PiGpio_I2C {
     /**
      * This writes up to 32 bytes to the specified I2C register of the device
      * associated with the handle from the given offset index to the specified length.
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is not
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is
@@ -244,7 +244,7 @@ public interface PiGpio_I2C {
     /**
      * This writes up to 32 bytes to the specified I2C register of the device
      * associated with the handle from the current position to the specified length.
-     *
+     * <p>
      * NOTE:  The contents from the byte buffer is read
      *        from the current position index up to the length
      *        requested or up to the buffer's remaining limit;
@@ -276,7 +276,7 @@ public interface PiGpio_I2C {
      * This writes up to 32 bytes to the specified I2C register of the device
      * associated with the handle.  The contents of the byte buffer are written from
      * the buffer's current position to the buffer's limit.
-     *
+     * <p>
      * NOTE:  The contents from the byte buffer is read
      *        from the current position index up to the buffer's
      *        remaining limit.  If the buffer's current position
@@ -447,7 +447,7 @@ public interface PiGpio_I2C {
      * This reads a block of up to 32 bytes from the specified register of the device associated with the handle
      * into the provided byte buffer at the given offset and up to the specified data length (number of bytes).
      * (The amount of returned data is set by the device.)
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is not
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is
@@ -493,7 +493,7 @@ public interface PiGpio_I2C {
      * This reads a block of up to 32 bytes from the specified register of the device associated with the handle
      * and copies the data bytes into the provided byte buffer starting with the current buffer position.
      * (The amount of returned data is set by the device.)
-     *
+     * <p>
      * NOTE:  The data bytes read from the serial device are copied/
      *        inserted into the byte buffer starting at the current
      *        position index up to the length requested or up to the
@@ -526,7 +526,7 @@ public interface PiGpio_I2C {
      * This reads a block of up to 32 bytes from the specified register of the device associated with the handle
      * and copies the data bytes into the provided byte buffer starting with the current buffer position up to
      * the available space remaining in the buffer.  (The amount of returned data is set by the device.)
-     *
+     * <p>
      * NOTE:  The data bytes read from the serial device are copied/
      *        inserted into the byte buffer starting at the current
      *        position index up to the buffer's remaining limit. If
@@ -553,7 +553,7 @@ public interface PiGpio_I2C {
     /**
      * This writes data bytes to the specified register of the device associated with the handle and reads a
      * device specified number of bytes of data in return.
-     *
+     * <p>
      * The SMBus 2.0 documentation states that a minimum of 1 byte may be sent and a minimum of 1 byte may be received.
      * The total number of bytes sent/received must be 32 or less.
      *
@@ -573,7 +573,7 @@ public interface PiGpio_I2C {
     /**
      * This writes data bytes to the specified register of the device associated with the handle and reads a
      * device specified number of bytes of data in return.
-     *
+     * <p>
      * The SMBus 2.0 documentation states that a minimum of 1 byte may be sent and a minimum of 1 byte may be received.
      * The total number of bytes sent/received must be 32 or less.
      *
@@ -594,7 +594,7 @@ public interface PiGpio_I2C {
     /**
      * This writes data bytes to the specified register of the device associated with the handle and reads a
      * device specified number of bytes of data in return.
-     *
+     * <p>
      * The SMBus 2.0 documentation states that a minimum of 1 byte may be sent and a minimum of 1 byte may be received.
      * The total number of bytes sent/received must be 32 or less.
      *
@@ -614,7 +614,7 @@ public interface PiGpio_I2C {
     /**
      * This writes data bytes to the specified register of the device associated with the handle and reads a
      * device specified number of bytes of data in return.
-     *
+     * <p>
      * The SMBus 2.0 documentation states that a minimum of 1 byte may be sent and a minimum of 1 byte may be received.
      * The total number of bytes sent/received must be 32 or less.
      *
@@ -633,7 +633,7 @@ public interface PiGpio_I2C {
     /**
      * This writes data bytes to the specified register of the device associated with the handle and reads a
      * device specified number of bytes of data in return.
-     *
+     * <p>
      * The SMBus 2.0 documentation states that a minimum of 1 byte may be sent and a minimum of 1 byte may be received.
      * The total number of bytes sent/received must be 32 or less.
      *
@@ -651,7 +651,7 @@ public interface PiGpio_I2C {
     /**
      * This writes data bytes to the specified register of the device associated with the handle and reads a
      * device specified number of bytes of data in return.
-     *
+     * <p>
      * The SMBus 2.0 documentation states that a minimum of 1 byte may be sent and a minimum of 1 byte may be received.
      * The total number of bytes sent/received must be 32 or less.
      *
@@ -670,7 +670,7 @@ public interface PiGpio_I2C {
     /**
      * This writes data bytes to the specified register of the device associated with the handle and reads a
      * device specified number of bytes of data in return.
-     *
+     * <p>
      * The SMBus 2.0 documentation states that a minimum of 1 byte may be sent and a minimum of 1 byte may be received.
      * The total number of bytes sent/received must be 32 or less.
      *
@@ -688,7 +688,7 @@ public interface PiGpio_I2C {
     /**
      * This writes data bytes to the specified register of the device associated with the handle and reads a
      * device specified number of bytes of data in return.
-     *
+     * <p>
      * The SMBus 2.0 documentation states that a minimum of 1 byte may be sent and a minimum of 1 byte may be received.
      * The total number of bytes sent/received must be 32 or less.
      *
@@ -711,7 +711,7 @@ public interface PiGpio_I2C {
     /**
      * This writes data bytes to the specified register of the device associated with the handle and reads a
      * device specified number of bytes of data in return.
-     *
+     * <p>
      * The SMBus 2.0 documentation states that a minimum of 1 byte may be sent and a minimum of 1 byte may be received.
      * The total number of bytes sent/received must be 32 or less.
      *
@@ -733,7 +733,7 @@ public interface PiGpio_I2C {
     /**
      * This writes data bytes to the specified register of the device associated with the handle and reads a
      * device specified number of bytes of data in return.
-     *
+     * <p>
      * The SMBus 2.0 documentation states that a minimum of 1 byte may be sent and a minimum of 1 byte may be received.
      * The total number of bytes sent/received must be 32 or less.
      *
@@ -754,7 +754,7 @@ public interface PiGpio_I2C {
     /**
      * This writes data bytes to the specified register of the device associated with the handle and reads a
      * device specified number of bytes of data in return.
-     *
+     * <p>
      * The SMBus 2.0 documentation states that a minimum of 1 byte may be sent and a minimum of 1 byte may be received.
      * The total number of bytes sent/received must be 32 or less.
      *
@@ -774,7 +774,7 @@ public interface PiGpio_I2C {
     /**
      * This writes data bytes to the specified register of the device associated with the handle and reads a
      * device specified number of bytes of data in return.
-     *
+     * <p>
      * The SMBus 2.0 documentation states that a minimum of 1 byte may be sent and a minimum of 1 byte may be received.
      * The total number of bytes sent/received must be 32 or less.
      *
@@ -795,7 +795,7 @@ public interface PiGpio_I2C {
     /**
      * This writes data bytes to the specified register of the device associated with the handle and reads a
      * device specified number of bytes of data in return.
-     *
+     * <p>
      * The SMBus 2.0 documentation states that a minimum of 1 byte may be sent and a minimum of 1 byte may be received.
      * The total number of bytes sent/received must be 32 or less.
      *
@@ -815,7 +815,7 @@ public interface PiGpio_I2C {
     /**
      * This writes data bytes to the specified register of the device associated with the handle and reads a
      * device specified number of bytes of data in return.
-     *
+     * <p>
      * The SMBus 2.0 documentation states that a minimum of 1 byte may be sent and a minimum of 1 byte may be received.
      * The total number of bytes sent/received must be 32 or less.
      *
@@ -880,7 +880,7 @@ public interface PiGpio_I2C {
      * This reads a block of up to 32 bytes from the specified register of the device associated with the handle
      * into the provided byte buffer at the given offset and up to the specified data length (number of bytes).
      * (The amount of returned data is set by the device.)
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is not
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is
@@ -926,7 +926,7 @@ public interface PiGpio_I2C {
      * This reads a block of up to 32 bytes from the specified register of the device associated with the handle
      * and copies the data bytes into the provided byte buffer starting with the current buffer position.
      * (The amount of returned data is set by the device.)
-     *
+     * <p>
      * NOTE:  The data bytes read from the serial device are copied/
      *        inserted into the byte buffer starting at the current
      *        position index up to the length requested or up to the
@@ -959,7 +959,7 @@ public interface PiGpio_I2C {
      * This reads a block of up to 32 bytes from the specified register of the device associated with the handle
      * and copies the data bytes into the provided byte buffer starting with the current buffer position up to
      * the available space remaining in the buffer.  (The amount of returned data is set by the device.)
-     *
+     * <p>
      * NOTE:  The data bytes read from the serial device are copied/
      *        inserted into the byte buffer starting at the current
      *        position index up to the buffer's remaining limit. If
@@ -1029,7 +1029,7 @@ public interface PiGpio_I2C {
     /**
      * This writes up to 32 bytes to the specified I2C register of the device
      * associated with the handle from the given offset index to the specified length.
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is not
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is
@@ -1057,7 +1057,7 @@ public interface PiGpio_I2C {
     /**
      * This writes up to 32 bytes to the specified I2C register of the device
      * associated with the handle from the current position to the specified length.
-     *
+     * <p>
      * NOTE:  The contents from the byte buffer is read
      *        from the current position index up to the length
      *        requested or up to the buffer's remaining limit;
@@ -1089,7 +1089,7 @@ public interface PiGpio_I2C {
      * This writes up to 32 bytes to the specified I2C register of the device
      * associated with the handle.  The contents of the byte buffer are written from
      * the buffer's current position to the buffer's limit.
-     *
+     * <p>
      * NOTE:  The contents from the byte buffer is read
      *        from the current position index up to the buffer's
      *        remaining limit.  If the buffer's current position
@@ -1246,7 +1246,7 @@ public interface PiGpio_I2C {
     /**
      * This reads multiple bytes from the raw I2C device associated with the handle into the provided
      * byte buffer at the given offset and up to the specified data length (number of bytes).
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is not
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is
@@ -1289,7 +1289,7 @@ public interface PiGpio_I2C {
     /**
      * This reads multiple bytes from the raw I2C device associated with the handle and copies
      * the data bytes into the provided byte buffer starting with the current buffer position.
-     *
+     * <p>
      * NOTE:  The data bytes read from the serial device are copied/
      *        inserted into the byte buffer starting at the current
      *        position index up to the length requested or up to the
@@ -1321,7 +1321,7 @@ public interface PiGpio_I2C {
      * This reads multiple bytes from the raw I2C associated with the handle and copies the
      * data bytes into the provided byte buffer starting with the current buffer position up to
      * the available space remaining in the buffer.
-     *
+     * <p>
      * NOTE:  The data bytes read from the serial device are copied/
      *        inserted into the byte buffer starting at the current
      *        position index up to the buffer's remaining limit. If
@@ -1387,7 +1387,7 @@ public interface PiGpio_I2C {
     /**
      * This writes multiple bytes from the provided byte buffer to the raw I2C device
      * associated with the handle from the given offset index to the specified length.
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is not
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is
@@ -1414,7 +1414,7 @@ public interface PiGpio_I2C {
     /**
      * This writes multiple bytes from the provided byte buffer to the raw I2C device
      * associated with the handle from the current position to the specified length.
-     *
+     * <p>
      * NOTE:  The contents from the byte buffer is read
      *        from the current position index up to the length
      *        requested or up to the buffer's remaining limit;
@@ -1445,7 +1445,7 @@ public interface PiGpio_I2C {
      * This writes multiple bytes from the provided byte buffer to the raw I2C device
      * associated with the handle.  The contents of the byte buffer are written from
      * the buffer's current position to the buffer's limit.
-     *
+     * <p>
      * NOTE:  The contents from the byte buffer is read
      *        from the current position index up to the buffer's
      *        remaining limit.  If the buffer's current position

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpio_PWM.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpio_PWM.java
@@ -37,7 +37,7 @@ public interface PiGpio_PWM {
 
     /**
      * Starts PWM on the GPIO, duty-cycle between 0 (off) and range (fully on). Range defaults to 255.
-     *
+     * <p>
      * This and the servo functionality use the DMA and PWM or PCM peripherals to control and schedule
      * the pulse lengths and duty cycles.
      *
@@ -49,7 +49,7 @@ public interface PiGpio_PWM {
 
     /**
      * Starts PWM on the GPIO, duty-cycle between 0 (off) and range (fully on). Range defaults to 255.
-     *
+     * <p>
      * This and the servo functionality use the DMA and PWM or PCM peripherals to control and schedule
      * the pulse lengths and duty cycles.
      *
@@ -64,11 +64,11 @@ public interface PiGpio_PWM {
 
     /**
      * Returns the PWM dutycycle setting for the GPIO.
-     *
+     * <p>
      * For normal PWM the dutycycle will be out of the defined range for the GPIO (see gpioGetPWMrange).
      * If a hardware clock is active on the GPIO the reported dutycycle will be 500000 (500k) out of 1000000 (1M).
      * If hardware PWM is active on the GPIO the reported dutycycle will be out of a 1000000 (1M).
-     *
+     * <p>
      * Normal PWM range defaults to 255.
      *
      * @param pin user_gpio: 0-31
@@ -82,10 +82,10 @@ public interface PiGpio_PWM {
      * Selects the dutycycle range to be used for the GPIO. Subsequent calls to gpioPWM will use a dutycycle
      * between 0 (off) and range (fully on.  If PWM is currently active on the GPIO its dutycycle will be
      * scaled to reflect the new range.
-     *
+     * <p>
      * The real range, the number of steps between fully off and fully on for each frequency,
      * is given in the following table.
-     *
+     * <p>
      *  -------------------------------------------------------
      *   #1	   #2	 #3	   #4	 #5	   #6	 #7	    #8	   #9
      *   25,   50,  100,  125,  200,  250,  400,   500,   625,
@@ -93,9 +93,9 @@ public interface PiGpio_PWM {
      *  #10   #11   #12   #13   #14   #15    #16   #17    #18
      *  800, 1000, 1250, 2000, 2500, 4000, 5000, 10000, 20000
      *  -------------------------------------------------------
-     *
+     * <p>
      * The real value set by gpioPWM is (dutycycle * real range) / range.
-     *
+     * <p>
      * Example
      *   gpioSetPWMrange(24, 2000); // Now 2000 is fully on
      *                              //     1000 is half on
@@ -132,34 +132,34 @@ public interface PiGpio_PWM {
 
     /**
      * Sets the frequency in hertz to be used for the GPIO.
-     *
+     * <p>
      * If PWM is currently active on the GPIO it will be switched off and then back on at the new frequency.
      * Each GPIO can be independently set to one of 18 different PWM frequencies.
      * The selectable frequencies depend upon the sample rate which may be 1, 2, 4, 5, 8, or 10 microseconds (default 5).
-     *
+     * <p>
      * The frequencies for each sample rate are:
-     *
+     * <p>
      *                        Hertz
-     *
+     * <p>
      *        1: 40000 20000 10000 8000 5000 4000 2500 2000 1600
      *            1250  1000   800  500  400  250  200  100   50
-     *
+     * <p>
      *        2: 20000 10000  5000 4000 2500 2000 1250 1000  800
      *             625   500   400  250  200  125  100   50   25
-     *
+     * <p>
      *        4: 10000  5000  2500 2000 1250 1000  625  500  400
      *             313   250   200  125  100   63   50   25   13
      * sample
      *  rate
      *  (us)  5:  8000  4000  2000 1600 1000  800  500  400  320
      *             250   200   160  100   80   50   40   20   10
-     *
+     * <p>
      *        8:  5000  2500  1250 1000  625  500  313  250  200
      *             156   125   100   63   50   31   25   13    6
-     *
+     * <p>
      *       10:  4000  2000  1000  800  500  400  250  200  160
      *             125   100    80   50   40   25   20   10    5
-     *
+     * <p>
      *
      * Example:
      *    gpioSetPWMfrequency(23, 0); // Set GPIO23 to lowest frequency.
@@ -176,11 +176,11 @@ public interface PiGpio_PWM {
 
     /**
      * Returns the frequency (in hertz) used for the GPIO
-     *
+     * <p>
      * For normal PWM the frequency will be that defined for the GPIO by gpioSetPWMfrequency.
      * If a hardware clock is active on the GPIO the reported frequency will be that set by gpioHardwareClock.
      * If hardware PWM is active on the GPIO the reported frequency will be that set by gpioHardwarePWM.
-     *
+     * <p>
      * Example:
      *    f = gpioGetPWMfrequency(23); // Get frequency used for GPIO23.
      *
@@ -194,28 +194,28 @@ public interface PiGpio_PWM {
     /**
      * Starts hardware PWM on a GPIO at the specified frequency and duty-cycle.
      * Frequencies above 30MHz are unlikely to work.
-     *
+     * <p>
      * NOTE: Any waveform started by gpioWaveTxSend, or gpioWaveChain will be cancelled.
-     *
+     * <p>
      * This function is only valid if the pigpio main clock is PCM.
      * The main clock defaults to PCM but may be overridden by a call to gpioCfgClock.
-     *
+     * <p>
      * The same PWM channel is available on multiple GPIO. The latest frequency and duty-cycle
      * setting will be used by all GPIO which share a PWM channel.
-     *
+     * <p>
      * The GPIO must be one of the following.
-     *
+     * <p>
      *   12  PWM channel 0  All models but A and B
      *   13  PWM channel 1  All models but A and B
      *   18  PWM channel 0  All models
      *   19  PWM channel 1  All models but A and B
-     *
+     * <p>
      *   40  PWM channel 0  Compute module only
      *   41  PWM channel 1  Compute module only
      *   45  PWM channel 1  Compute module only
      *   52  PWM channel 0  Compute module only
      *   53  PWM channel 1  Compute module only
-     *
+     * <p>
      *
      * The actual number of steps between off and fully on is the integral part of
      * 250M/PWMfreq (375M/PWMfreq for the BCM2711).

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpio_SPI.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpio_SPI.java
@@ -43,39 +43,39 @@ public interface PiGpio_SPI {
      * This function opens a SPI device channel at a specified baud rate and with specified flags.
      * Data will be transferred at baud bits per second.
      * The flags may be used to modify the default behaviour of 4-wire operation, mode 0, active low chip select.
-     *
+     * <p>
      * The Pi has two SPI peripherals: main and auxiliary.
      * The main SPI has two chip selects (channels), the auxiliary has three.
      * The auxiliary SPI is available on all models but the A and B.
-     *
+     * <p>
      * The GPIO pins used are given in the following table.
-     *
+     * <p>
      *             MISO    MOSI   SCLK   CE0   CE1   CE2
      *             -------------------------------------
      *   Main SPI    9      10     11      8	 7	   -
      *   Aux SPI    19      20     21     18	17    16
-     *
+     * <p>
      *
      *  spiChan  : 0-1 (0-2 for the auxiliary SPI)
      *  baud     : 32K-125M (values above 30M are unlikely to work)
      *  spiFlags : see below
-     *
+     * <p>
      * spiFlags consists of the least significant 22 bits.
      * -----------------------------------------------------------------
      * 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0
      *  b  b  b  b  b  b  R  T  n  n  n  n  W  A u2 u1 u0 p2 p1 p0  m  m
      * -----------------------------------------------------------------
-     *
+     * <p>
      * [mm] defines the SPI mode.
      *      (Warning: modes 1 and 3 do not appear to work on the auxiliary SPI.)
-     *
+     * <p>
      *      Mode POL  PHA
      *      -------------
      *       0    0    0
      *       1    0    1
      *       2    1    0
      *       3    1    1
-     *
+     * <p>
      * [px] is 0 if CEx is active low (default) and 1 for active high.
      * [ux] is 0 if the CEx GPIO is reserved for SPI (default) and 1 otherwise.
      * [A] is 0 for the main SPI, 1 for the auxiliary SPI.
@@ -84,12 +84,12 @@ public interface PiGpio_SPI {
      * [T] is 1 if the least significant bit is transmitted on MOSI first, the default (0) shifts the most significant bit out first. Auxiliary SPI only.
      * [R] is 1 if the least significant bit is received on MISO first, the default (0) receives the most significant bit first. Auxiliary SPI only.
      * [bbbbbb] defines the word size in bits (0-32). The default (0) sets 8 bits per word. Auxiliary SPI only.
-     *
+     * <p>
      * The spiRead, spiWrite, and spiXfer functions transfer data packed into 1, 2, or 4 bytes according to the word size in bits.
      *  - For bits 1-8 there will be one byte per word.
      *  - For bits 9-16 there will be two bytes per word.
      *  - For bits 17-32 there will be four bytes per word.
-     *
+     * <p>
      * Multi-byte transfers are made in least significant byte first order.
      * E.g. to transfer 32 11-bit words buf should contain 64 bytes and count should be 64.
      * E.g. to transfer the 14 bit value 0x1ABC send the bytes 0xBC followed by 0x1A.
@@ -106,27 +106,27 @@ public interface PiGpio_SPI {
     /**
      * This function opens a SPI device channel at a specified baud rate and with default options using SPI mode 0.
      * Data will be transferred at baud bits per second.
-     *
+     * <p>
      * The Pi has two SPI peripherals: main and auxiliary.
      * The main SPI has two chip selects (channels), the auxiliary has three.
      * The auxiliary SPI is available on all models but the A and B.
-     *
+     * <p>
      * The GPIO pins used are given in the following table.
-     *
+     * <p>
      *             MISO    MOSI   SCLK   CE0   CE1   CE2
      *             -------------------------------------
      *   Main SPI    9      10     11      8	 7	   -
      *   Aux SPI    19      20     21     18	17    16
-     *
+     * <p>
      *
      *  spiChan  : 0-1 (0-2 for the auxiliary SPI)
      *  baud     : 32K-125M (values above 30M are unlikely to work)
-     *
+     * <p>
      * The spiRead, spiWrite, and spiXfer functions transfer data packed into 1, 2, or 4 bytes according to the word size in bits.
      *  - For bits 1-8 there will be one byte per word.
      *  - For bits 9-16 there will be two bytes per word.
      *  - For bits 17-32 there will be four bytes per word.
-     *
+     * <p>
      * Multi-byte transfers are made in least significant byte first order.
      * E.g. to transfer 32 11-bit words buf should contain 64 bytes and count should be 64.
      * E.g. to transfer the 14 bit value 0x1ABC send the bytes 0xBC followed by 0x1A.
@@ -264,7 +264,7 @@ public interface PiGpio_SPI {
     /**
      * This function writes multiple bytes from the byte buffer to the SPI device
      * associated with the handle from the given offset index to the specified length.
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is not
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is
@@ -291,7 +291,7 @@ public interface PiGpio_SPI {
     /**
      * This function writes multiple bytes from the byte buffer to the SPI device
      * associated with the handle from the current buffer position to the specified length.
-     *
+     * <p>
      * NOTE:  The contents from the byte buffer is read
      *        from the current position index up to the length
      *        requested or up to the buffer's remaining limit;
@@ -322,7 +322,7 @@ public interface PiGpio_SPI {
      * This function writes multiple bytes from the byte buffer to the SPI device
      * associated with the handle.  The contents of the byte buffer are written from
      * the buffer's current position to the buffer's limit.
-     *
+     * <p>
      * NOTE:  The contents from the byte buffer is read
      *        from the current position index up to the buffer's
      *        remaining limit.  If the buffer's current position
@@ -493,7 +493,7 @@ public interface PiGpio_SPI {
     /**
      * Read data from the SPI device into the provided byte buffer at the given
      * offset and up to the specified data length (number of bytes).
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is not
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is
@@ -536,7 +536,7 @@ public interface PiGpio_SPI {
     /**
      * Read data from the SPI device into the provided byte buffer starting
      * with the buffer's current position up to the provided length.
-     *
+     * <p>
      * NOTE:  The data bytes read from the SPI device are copied/
      *        inserted into the byte buffer starting at the current
      *        position index up to the length requested or up to the
@@ -567,7 +567,7 @@ public interface PiGpio_SPI {
     /**
      * Read data from the SPI device into the provided byte buffer starting with
      * the buffer's current position up to available space remaining in the buffer.
-     *
+     * <p>
      * NOTE:  The data bytes read from the SPI device are copied/
      *        inserted into the byte buffer starting at the current
      *        position index up to the buffer's remaining limit. If
@@ -719,7 +719,7 @@ public interface PiGpio_SPI {
      * using the same length ('numberOfBytes').  Both the 'write' and 'read' byte buffers must
      * at least have the available capacity of the defined 'numberOfBytes' + their corresponding
      * offsets.
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is not
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is
@@ -771,7 +771,7 @@ public interface PiGpio_SPI {
      * current position using the same length ('numberOfBytes').  Both the 'write' and 'read'
      * byte buffers must at least have the available capacity of the defined 'numberOfBytes' +
      * their corresponding current positions.
-     *
+     * <p>
      * NOTE:  The contents from the 'write' byte buffer is read
      *        from the current position index up to the length
      *        requested or up to the buffer's remaining limit;
@@ -779,7 +779,7 @@ public interface PiGpio_SPI {
      *        position is already at the buffer's limit, then we
      *        will automatically flip the buffer to begin reading
      *        data from the zero position up to the buffer's limit     *
-     *
+     * <p>
      * NOTE:  The data bytes read from the SPI device are copied/
      *        inserted into the 'read' byte buffer starting at the current
      *        position index up to the length requested or up to the
@@ -819,7 +819,7 @@ public interface PiGpio_SPI {
      * read from the SPI device is then copied to the byte buffer at the given 'offset'
      * using the same length (number of bytes). The byte buffer must at least have the
      * available capacity of the defined 'length' + 'offset'.
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is not
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpio_Serial.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpio_Serial.java
@@ -156,7 +156,7 @@ public interface PiGpio_Serial {
     /**
      * This function writes multiple bytes from the byte buffer to the serial device
      * associated with the handle from the given offset index to the specified length.
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is not
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is
@@ -183,7 +183,7 @@ public interface PiGpio_Serial {
     /**
      * This function writes multiple bytes from the byte buffer to the serial device
      * associated with the handle from the current buffer position to the specified length.
-     *
+     * <p>
      * NOTE:  The contents from the byte buffer is read
      *        from the current position index up to the length
      *        requested or up to the buffer's remaining limit;
@@ -214,7 +214,7 @@ public interface PiGpio_Serial {
      * This function writes multiple bytes from the byte buffer to the serial device
      * associated with the handle.  The contents of the byte buffer are written from
      * the buffer's current position to the buffer's limit.
-     *
+     * <p>
      * NOTE:  The contents from the byte buffer is read
      *        from the current position index up to the buffer's
      *        remaining limit.  If the buffer's current position
@@ -385,7 +385,7 @@ public interface PiGpio_Serial {
     /**
      * Read data from the serial device into the provided byte buffer at the given
      * offset and up to the specified data length (number of bytes).
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is not
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is
@@ -428,7 +428,7 @@ public interface PiGpio_Serial {
     /**
      * Read data from the serial device into the provided byte buffer starting
      * with the current buffer position to the provided length.
-     *
+     * <p>
      * NOTE:  The data bytes read from the serial device are copied/
      *        inserted into the byte buffer starting at the current
      *        position index up to the length requested or up to the
@@ -459,7 +459,7 @@ public interface PiGpio_Serial {
     /**
      * Read data from the serial device into the provided byte buffer starting with
      * the buffer's current position up to available space remaining in the buffer.
-     *
+     * <p>
      * NOTE:  The data bytes read from the serial device are copied/
      *        inserted into the byte buffer starting at the current
      *        position index up to the buffer's remaining limit. If

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpio_Servo.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpio_Servo.java
@@ -37,35 +37,35 @@ public interface PiGpio_Servo {
 
     /**
      * Starts servo pulses on the GPIO, 0 (off), 500 (most anti-clockwise) to 2500 (most clockwise).
-     *
+     * <p>
      * The range supported by servos varies and should probably be determined by experiment. A value
      * of 1500 should always be safe and represents the mid-point of rotation. You can DAMAGE a servo
      * if you command it to move beyond its limits.
-     *
+     * <p>
      * The following causes an on pulse of 1500 microseconds duration to be transmitted on GPIO 17 at
      * a rate of 50 times per second. This will command a servo connected to GPIO 17 to rotate to its
      * mid-point.
-     *
+     * <p>
      * Example:
      *  - gpioServo(17, 1000); // Move servo to safe position anti-clockwise.
      *  - gpioServo(23, 1500); // Move servo to centre position.
      *  - gpioServo(25, 2000); // Move servo to safe position clockwise.
-     *
+     * <p>
      * OTHER UPDATE RATES:
      * This function updates servos at 50Hz. If you wish to use a different
      * update frequency you will have to use the PWM functions.
-     *
+     * <p>
      *    PWM Hz      50     100    200    400    500
      *    1E6/Hz   20000   10000   5000   2500   2000
-     *
+     * <p>
      * Firstly set the desired PWM frequency using gpioSetPWMfrequency.
      * Then set the PWM range using gpioSetPWMrange to 1E6/frequency. Doing this
      * allows you to use units of microseconds when setting the servo pulsewidth.
-     *
+     * <p>
      * E.g. If you want to update a servo connected to GPIO25 at 400Hz*
      *  - gpioSetPWMfrequency(25, 400);
      *  - gpioSetPWMrange(25, 2500);
-     *
+     * <p>
      * Thereafter use the PWM command to move the servo, e.g. gpioPWM(25, 1500) will set a 1500 us pulse.
      *
      * @param pin user_gpio: 0-31
@@ -76,35 +76,35 @@ public interface PiGpio_Servo {
 
     /**
      * Starts servo pulses on the GPIO, 0 (off), 500 (most anti-clockwise) to 2500 (most clockwise).
-     *
+     * <p>
      * The range supported by servos varies and should probably be determined by experiment. A value
      * of 1500 should always be safe and represents the mid-point of rotation. You can DAMAGE a servo
      * if you command it to move beyond its limits.
-     *
+     * <p>
      * The following causes an on pulse of 1500 microseconds duration to be transmitted on GPIO 17 at
      * a rate of 50 times per second. This will command a servo connected to GPIO 17 to rotate to its
      * mid-point.
-     *
+     * <p>
      * Example:
      *  - gpioServo(17, 1000); // Move servo to safe position anti-clockwise.
      *  - gpioServo(23, 1500); // Move servo to centre position.
      *  - gpioServo(25, 2000); // Move servo to safe position clockwise.
-     *
+     * <p>
      * OTHER UPDATE RATES:
      * This function updates servos at 50Hz. If you wish to use a different
      * update frequency you will have to use the PWM functions.
-     *
+     * <p>
      *    PWM Hz      50     100    200    400    500
      *    1E6/Hz   20000   10000   5000   2500   2000
-     *
+     * <p>
      * Firstly set the desired PWM frequency using gpioSetPWMfrequency.
      * Then set the PWM range using gpioSetPWMrange to 1E6/frequency. Doing this
      * allows you to use units of microseconds when setting the servo pulsewidth.
-     *
+     * <p>
      * E.g. If you want to update a servo connected to GPIO25 at 400Hz*
      *  - gpioSetPWMfrequency(25, 400);
      *  - gpioSetPWMrange(25, 2500);
-     *
+     * <p>
      * Thereafter use the PWM command to move the servo, e.g. gpioPWM(25, 1500) will set a 1500 us pulse.
      *
      * @param pin user_gpio: 0-31

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/impl/PiGpioBase.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/impl/PiGpioBase.java
@@ -99,25 +99,25 @@ public abstract class PiGpioBase implements PiGpio {
      * GPIO PINS
      * --------------------------------------------------------------------------
      * A Broadcom numbered GPIO, in the range 0-53.
-     *
+     * <p>
      * There are 54 General Purpose Input Outputs (GPIO) named GPIO0 through GPIO53.
-     *
+     * <p>
      * They are split into two banks. Bank 1 consists of GPIO0 through GPIO31.
      * Bank 2 consists of GPIO32 through GPIO53.
-     *
+     * <p>
      * All the GPIO which are safe for the user to read and write are in bank 1.
      * Not all GPIO in bank 1 are safe though. Type 1 boards have 17 safe GPIO.
      * Type 2 boards have 21. Type 3 boards have 26.
-     *
+     * <p>
      * See gpioHardwareRevision.
-     *
+     * <p>
      * The user GPIO are marked with an X in the following table.
-     *
+     * <p>
      *           0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15
      * Type 1    X  X  -  -  X  -  -  X  X  X  X  X  -  -  X  X
      * Type 2    -  -  X  X  X  -  -  X  X  X  X  X  -  -  X  X
      * Type 3          X  X  X  X  X  X  X  X  X  X  X  X  X  X
-     *
+     * <p>
      *          16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
      * Type 1    -  X  X  -  -  X  X  X  X  X  -  -  -  -  -  -
      * Type 2    -  X  X  -  -  -  X  X  X  X  -  X  X  X  X  X
@@ -506,16 +506,16 @@ public abstract class PiGpioBase implements PiGpio {
      * {@inheritDoc}
      *
      * Returns the hardware revision (as hexadecimal string).
-     *
+     * <p>
      * If the hardware revision can not be found or is not a valid hexadecimal number the function returns 0.
      * The hardware revision is the last few characters on the Revision line of /proc/cpuinfo.
      * The revision number can be used to determine the assignment of GPIO to pins (see gpio).
-     *
+     * <p>
      * There are at least three types of board.
      *  - Type 1 boards have hardware revision numbers of 2 and 3.
      *  - Type 2 boards have hardware revision numbers of 4, 5, 6, and 15.
      *  - Type 3 boards have hardware revision numbers of 16 or greater.
-     *
+     * <p>
      *     for "Revision : 0002" the function returns 2.
      *     for "Revision : 000f" the function returns 15.
      *     for "Revision : 000g" the function returns 0.

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/impl/PiGpioNativeImpl.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/impl/PiGpioNativeImpl.java
@@ -87,7 +87,7 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      *
      * Initializes the library.
      * (The Java implementation of this function does not return a value)
-     *
+     * <p>
      * gpioInitialise must be called before using the other library functions with the following exceptions:
      * - gpioCfg*
      * - gpioVersion
@@ -134,7 +134,7 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      * {@inheritDoc}
      *
      * Shutdown the library.
-     *
+     * <p>
      * Returns nothing.
      * Call before program exit.
      * This function resets the used DMA channels, releases memory, and terminates any running threads.
@@ -174,16 +174,16 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      * {@inheritDoc}
      *
      * Returns the hardware revision.
-     *
+     * <p>
      * If the hardware revision can not be found or is not a valid hexadecimal number the function returns 0.
      * The hardware revision is the last few characters on the Revision line of /proc/cpuinfo.
      * The revision number can be used to determine the assignment of GPIO to pins (see gpio).
-     *
+     * <p>
      * There are at least three types of board.
      *  - Type 1 boards have hardware revision numbers of 2 and 3.
      *  - Type 2 boards have hardware revision numbers of 4, 5, 6, and 15.
      *  - Type 3 boards have hardware revision numbers of 16 or greater.
-     *
+     * <p>
      *     for "Revision : 0002" the function returns 2.
      *     for "Revision : 000f" the function returns 15.
      *     for "Revision : 000g" the function returns 0.
@@ -243,7 +243,7 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      * {@inheritDoc}
      *
      * Sets the GPIO mode, typically input or output.
-     *
+     * <p>
      * gpio: 0-53
      * mode: 0-7
      * @see <a href="http://abyz.me.uk/rpi/pigpio/cif.html#gpioSetMode">PIGPIO::gpioSetMode</a>
@@ -296,17 +296,17 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      * {@inheritDoc}
      *
      * Sets a glitch filter on a GPIO.  (AKA Debounce)
-     *
+     * <p>
      * Level changes on the GPIO are not reported unless the level has been stable for at
      * least 'steady' microseconds. The level is then reported. Level changes of less
      * than 'steady' microseconds are ignored.
-     *
+     * <p>
      * This filter affects the GPIO samples returned to callbacks set up with:
      *  - gpioSetAlertFunc
      *  - gpioSetAlertFuncEx
      *  - gpioSetGetSamplesFunc
      *  - gpioSetGetSamplesFuncEx.
-     *
+     * <p>
      * It does not affect interrupts set up with gpioSetISRFunc, gpioSetISRFuncEx, or
      * levels read by gpioRead, gpioRead_Bits_0_31, or gpioRead_Bits_32_53.
      * Each (stable) edge will be timestamped steady microseconds after it was first detected.
@@ -326,11 +326,11 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      * {@inheritDoc}
      *
      * Sets a noise filter on a GPIO.
-     *
+     * <p>
      * Level changes on the GPIO are ignored until a level which has been stable for 'steady'
      * microseconds is detected. Level changes on the GPIO are then reported for 'active'
      * microseconds after which the process repeats.
-     *
+     * <p>
      * This filter affects the GPIO samples returned to callbacks set up with:
      *  - gpioSetAlertFunc
      *  - gpioSetAlertFuncEx
@@ -338,7 +338,7 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      *  - gpioSetGetSamplesFuncEx.     *
      * It does not affect interrupts set up with gpioSetISRFunc, gpioSetISRFuncEx, or
      * levels read by gpioRead, gpioRead_Bits_0_31, or gpioRead_Bits_32_53.
-     *
+     * <p>
      * Level changes before and after the active period may be reported.
      * Your software must be designed to cope with such reports.
      * @see <a href="http://abyz.me.uk/rpi/pigpio/cif.html#gpioGlitchFilter">PIGPIO::gpioGlitchFilter</a>
@@ -364,7 +364,7 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      * {@inheritDoc}
      *
      * Starts PWM on the GPIO, dutycycle between 0 (off) and range (fully on). Range defaults to 255.
-     *
+     * <p>
      * This and the servo functionality use the DMA and PWM or PCM peripherals to control and schedule
      * the pulse lengths and duty cycles.
      * @see <a href="http://abyz.me.uk/rpi/pigpio/cif.html#gpioPWM">PIGPIO::gpioPWM</a>
@@ -384,11 +384,11 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      * {@inheritDoc}
      *
      * Returns the PWM dutycycle setting for the GPIO.
-     *
+     * <p>
      * For normal PWM the dutycycle will be out of the defined range for the GPIO (see gpioGetPWMrange).
      * If a hardware clock is active on the GPIO the reported dutycycle will be 500000 (500k) out of 1000000 (1M).
      * If hardware PWM is active on the GPIO the reported dutycycle will be out of a 1000000 (1M).
-     *
+     * <p>
      * Normal PWM range defaults to 255.
      * @see <a href="http://abyz.me.uk/rpi/pigpio/cif.html#gpioGetPWMdutycycle">PIGPIO::gpioGetPWMdutycycle</a>
      */
@@ -409,10 +409,10 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      * Selects the dutycycle range to be used for the GPIO. Subsequent calls to gpioPWM will use a dutycycle
      * between 0 (off) and range (fully on.  If PWM is currently active on the GPIO its dutycycle will be
      * scaled to reflect the new range.
-     *
+     * <p>
      * The real range, the number of steps between fully off and fully on for each frequency,
      * is given in the following table.
-     *
+     * <p>
      *  -------------------------------------------------------
      *   #1	   #2	 #3	   #4	 #5	   #6	 #7	    #8	   #9
      *   25,   50,  100,  125,  200,  250,  400,   500,   625,
@@ -420,9 +420,9 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      *  #10   #11   #12   #13   #14   #15    #16   #17    #18
      *  800, 1000, 1250, 2000, 2500, 4000, 5000, 10000, 20000
      *  -------------------------------------------------------
-     *
+     * <p>
      * The real value set by gpioPWM is (dutycycle * real range) / range.
-     *
+     * <p>
      * Example
      *   gpioSetPWMrange(24, 2000); // Now 2000 is fully on
      *                              //     1000 is half on
@@ -483,34 +483,34 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      * {@inheritDoc}
      *
      * Sets the frequency in hertz to be used for the GPIO.
-     *
+     * <p>
      * If PWM is currently active on the GPIO it will be switched off and then back on at the new frequency.
      * Each GPIO can be independently set to one of 18 different PWM frequencies.
      * The selectable frequencies depend upon the sample rate which may be 1, 2, 4, 5, 8, or 10 microseconds (default 5).
-     *
+     * <p>
      * The frequencies for each sample rate are:
-     *
+     * <p>
      *                        Hertz
-     *
+     * <p>
      *        1: 40000 20000 10000 8000 5000 4000 2500 2000 1600
      *            1250  1000   800  500  400  250  200  100   50
-     *
+     * <p>
      *        2: 20000 10000  5000 4000 2500 2000 1250 1000  800
      *             625   500   400  250  200  125  100   50   25
-     *
+     * <p>
      *        4: 10000  5000  2500 2000 1250 1000  625  500  400
      *             313   250   200  125  100   63   50   25   13
      * sample
      *  rate
      *  (us)  5:  8000  4000  2000 1600 1000  800  500  400  320
      *             250   200   160  100   80   50   40   20   10
-     *
+     * <p>
      *        8:  5000  2500  1250 1000  625  500  313  250  200
      *             156   125   100   63   50   31   25   13    6
-     *
+     * <p>
      *       10:  4000  2000  1000  800  500  400  250  200  160
      *             125   100    80   50   40   25   20   10    5
-     *
+     * <p>
      *
      * Example:
      *    gpioSetPWMfrequency(23, 0); // Set GPIO23 to lowest frequency.
@@ -534,11 +534,11 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      * {@inheritDoc}
      *
      * Returns the frequency (in hertz) used for the GPIO
-     *
+     * <p>
      * For normal PWM the frequency will be that defined for the GPIO by gpioSetPWMfrequency.
      * If a hardware clock is active on the GPIO the reported frequency will be that set by gpioHardwareClock.
      * If hardware PWM is active on the GPIO the reported frequency will be that set by gpioHardwarePWM.
-     *
+     * <p>
      * Example:
      *    f = gpioGetPWMfrequency(23); // Get frequency used for GPIO23.
      * @see <a href="http://abyz.me.uk/rpi/pigpio/cif.html#gpioGetPWMfrequency">PIGPIO::gpioGetPWMfrequency</a>
@@ -559,28 +559,28 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      *
      * Starts hardware PWM on a GPIO at the specified frequency and duty-cycle.
      * Frequencies above 30MHz are unlikely to work.
-     *
+     * <p>
      * NOTE: Any waveform started by gpioWaveTxSend, or gpioWaveChain will be cancelled.
-     *
+     * <p>
      * This function is only valid if the pigpio main clock is PCM.
      * The main clock defaults to PCM but may be overridden by a call to gpioCfgClock.
-     *
+     * <p>
      * The same PWM channel is available on multiple GPIO. The latest frequency and duty-cycle
      * setting will be used by all GPIO which share a PWM channel.
-     *
+     * <p>
      * The GPIO must be one of the following.
-     *
+     * <p>
      *   12  PWM channel 0  All models but A and B
      *   13  PWM channel 1  All models but A and B
      *   18  PWM channel 0  All models
      *   19  PWM channel 1  All models but A and B
-     *
+     * <p>
      *   40  PWM channel 0  Compute module only
      *   41  PWM channel 1  Compute module only
      *   45  PWM channel 1  Compute module only
      *   52  PWM channel 0  Compute module only
      *   53  PWM channel 1  Compute module only
-     *
+     * <p>
      *
      * The actual number of steps between off and fully on is the integral part of
      * 250M/PWMfreq (375M/PWMfreq for the BCM2711).
@@ -634,35 +634,35 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      * {@inheritDoc}
      *
      * Starts servo pulses on the GPIO, 0 (off), 500 (most anti-clockwise) to 2500 (most clockwise).
-     *
+     * <p>
      * The range supported by servos varies and should probably be determined by experiment. A value
      * of 1500 should always be safe and represents the mid-point of rotation. You can DAMAGE a servo
      * if you command it to move beyond its limits.
-     *
+     * <p>
      * The following causes an on pulse of 1500 microseconds duration to be transmitted on GPIO 17 at
      * a rate of 50 times per second. This will command a servo connected to GPIO 17 to rotate to its
      * mid-point.
-     *
+     * <p>
      * Example:
      *  - gpioServo(17, 1000); // Move servo to safe position anti-clockwise.
      *  - gpioServo(23, 1500); // Move servo to centre position.
      *  - gpioServo(25, 2000); // Move servo to safe position clockwise.
-     *
+     * <p>
      * OTHER UPDATE RATES:
      * This function updates servos at 50Hz. If you wish to use a different
      * update frequency you will have to use the PWM functions.
-     *
+     * <p>
      *    PWM Hz      50     100    200    400    500
      *    1E6/Hz   20000   10000   5000   2500   2000
-     *
+     * <p>
      * Firstly set the desired PWM frequency using gpioSetPWMfrequency.
      * Then set the PWM range using gpioSetPWMrange to 1E6/frequency. Doing this
      * allows you to use units of microseconds when setting the servo pulsewidth.
-     *
+     * <p>
      * E.g. If you want to update a servo connected to GPIO25 at 400Hz*
      *  - gpioSetPWMfrequency(25, 400);
      *  - gpioSetPWMrange(25, 2500);
-     *
+     * <p>
      * Thereafter use the PWM command to move the servo, e.g. gpioPWM(25, 1500) will set a 1500 us pulse.
      * @see <a href="http://abyz.me.uk/rpi/pigpio/cif.html#gpioServo">PIGPIO::gpioServo</a>
      */
@@ -747,17 +747,17 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      *
      * Returns the current system tick.
      * Tick is the number of microseconds since system boot.
-     *
+     * <p>
      * As tick is an unsigned 32 bit quantity it wraps around after 2^32 microseconds, which is
      * approximately 1 hour 12 minutes.  You don't need to worry about the wrap around as long as you
      * take a tick (uint32_t) from another tick, i.e. the following code will always provide the
      * correct difference.
-     *
+     * <p>
      * Example
      *   uint32_t startTick, endTick;
      *   int diffTick;
      *   startTick = gpioTick();
-     *
+     * <p>
      *   // do some processing
      *   endTick = gpioTick();
      *   diffTick = endTick - startTick;
@@ -786,7 +786,7 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      * This returns a handle for the device at the address on the I2C bus.
      * Physically buses 0 and 1 are available on the Pi.
      * Higher numbered buses will be available if a kernel supported bus multiplexor is being used.
-     *
+     * <p>
      * The GPIO used are given in the following table.
      *         SDA   SCL
      * I2C0     0     1
@@ -1033,7 +1033,7 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      *
      * This writes data bytes to the specified register of the device associated with the handle and reads a
      * device specified number of bytes of data in return.
-     *
+     * <p>
      * The SMBus 2.0 documentation states that a minimum of 1 byte may be sent and a minimum of 1 byte may be received.
      * The total number of bytes sent/received must be 32 or less.
      */
@@ -1057,7 +1057,7 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      *
      * This writes data bytes to the specified register of the device associated with handle and reads a
      * device specified number of bytes of data in return.
-     *
+     * <p>
      * The SMBus 2.0 documentation states that a minimum of 1 byte may be sent and a minimum of 1 byte may be received.
      * The total number of bytes sent/received must be 32 or less.
      * @see <a href="http://abyz.me.uk/rpi/pigpio/cif.html#i2cBlockProcessCall">PIGPIO::i2cBlockProcessCall</a>
@@ -1361,39 +1361,39 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      * This function opens a SPI device channel at a specified baud rate and with specified flags.
      * Data will be transferred at baud bits per second.
      * The flags may be used to modify the default behaviour of 4-wire operation, mode 0, active low chip select.
-     *
+     * <p>
      * The Pi has two SPI peripherals: main and auxiliary.
      * The main SPI has two chip selects (channels), the auxiliary has three.
      * The auxiliary SPI is available on all models but the A and B.
-     *
+     * <p>
      * The GPIO pins used are given in the following table.
-     *
+     * <p>
      *             MISO    MOSI   SCLK   CE0   CE1   CE2
      *             -------------------------------------
      *   Main SPI    9      10     11      8	 7	   -
      *   Aux SPI    19      20     21     18	17    16
-     *
+     * <p>
      *
      *  spiChan  : 0-1 (0-2 for the auxiliary SPI)
      *  baud     : 32K-125M (values above 30M are unlikely to work)
      *  spiFlags : see below
-     *
+     * <p>
      * spiFlags consists of the least significant 22 bits.
      * -----------------------------------------------------------------
      * 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0
      *  b  b  b  b  b  b  R  T  n  n  n  n  W  A u2 u1 u0 p2 p1 p0  m  m
      * -----------------------------------------------------------------
-     *
+     * <p>
      * [mm] defines the SPI mode.
      *      (Warning: modes 1 and 3 do not appear to work on the auxiliary SPI.)
-     *
+     * <p>
      *      Mode POL  PHA
      *      -------------
      *       0    0    0
      *       1    0    1
      *       2    1    0
      *       3    1    1
-     *
+     * <p>
      * [px] is 0 if CEx is active low (default) and 1 for active high.
      * [ux] is 0 if the CEx GPIO is reserved for SPI (default) and 1 otherwise.
      * [A] is 0 for the main SPI, 1 for the auxiliary SPI.
@@ -1402,12 +1402,12 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
      * [T] is 1 if the least significant bit is transmitted on MOSI first, the default (0) shifts the most significant bit out first. Auxiliary SPI only.
      * [R] is 1 if the least significant bit is received on MISO first, the default (0) receives the most significant bit first. Auxiliary SPI only.
      * [bbbbbb] defines the word size in bits (0-32). The default (0) sets 8 bits per word. Auxiliary SPI only.
-     *
+     * <p>
      * The spiRead, spiWrite, and spiXfer functions transfer data packed into 1, 2, or 4 bytes according to the word size in bits.
      *  - For bits 1-8 there will be one byte per word.
      *  - For bits 9-16 there will be two bytes per word.
      *  - For bits 17-32 there will be four bytes per word.
-     *
+     * <p>
      * Multi-byte transfers are made in least significant byte first order.
      * E.g. to transfer 32 11-bit words buf should contain 64 bytes and count should be 64.
      * E.g. to transfer the 14 bit value 0x1ABC send the bytes 0xBC followed by 0x1A.

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/impl/PiGpioSocketBase.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/impl/PiGpioSocketBase.java
@@ -62,7 +62,7 @@ public abstract class PiGpioSocketBase extends PiGpioBase implements PiGpio {
 
     /**
      * ALTERNATE CONSTRUCTOR
-     *
+     * <p>
      * Connects to a user specified socket hostname/ip address and port.
      *
      * @param host hostname or IP address of the RaspberryPi to connect to via TCP/IP socket.
@@ -81,7 +81,7 @@ public abstract class PiGpioSocketBase extends PiGpioBase implements PiGpio {
      *
      * Initializes the library.
      * (The Java implementation of this function does not return a value)
-     *
+     * <p>
      * gpioInitialise must be called before using the other library functions with the following exceptions:
      * - gpioCfg*
      * - gpioVersion
@@ -120,7 +120,7 @@ public abstract class PiGpioSocketBase extends PiGpioBase implements PiGpio {
      * {@inheritDoc}
      *
      * Shutdown the library.
-     *
+     * <p>
      * Returns nothing.
      * Call before program exit.
      * This function resets the used DMA channels, releases memory, and terminates any running threads.

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/impl/PiGpioSocketImpl.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/impl/PiGpioSocketImpl.java
@@ -94,7 +94,7 @@ public class PiGpioSocketImpl extends PiGpioSocketBase implements PiGpio {
 
     /**
      * DEFAULT PRIVATE CONSTRUCTOR
-     *
+     * <p>
      * Connects to a user specified socket hostname/ip address and port.
      *
      * @param host hostname or IP address of the RaspberryPi to connect to via TCP/IP socket.
@@ -124,16 +124,16 @@ public class PiGpioSocketImpl extends PiGpioSocketBase implements PiGpio {
      * {@inheritDoc}
      *
      * Returns the hardware revision.
-     *
+     * <p>
      * If the hardware revision can not be found or is not a valid hexadecimal number the function returns 0.
      * The hardware revision is the last few characters on the Revision line of /proc/cpuinfo.
      * The revision number can be used to determine the assignment of GPIO to pins (see gpio).
-     *
+     * <p>
      * There are at least three types of board.
      *  - Type 1 boards have hardware revision numbers of 2 and 3.
      *  - Type 2 boards have hardware revision numbers of 4, 5, 6, and 15.
      *  - Type 3 boards have hardware revision numbers of 16 or greater.
-     *
+     * <p>
      *     for "Revision : 0002" the function returns 2.
      *     for "Revision : 000f" the function returns 15.
      *     for "Revision : 000g" the function returns 0.
@@ -194,7 +194,7 @@ public class PiGpioSocketImpl extends PiGpioSocketBase implements PiGpio {
      * {@inheritDoc}
      *
      * Sets the GPIO mode, typically input or output.
-     *
+     * <p>
      * gpio: 0-53
      * mode: 0-7
      * @see <a href="http://abyz.me.uk/rpi/pigpio/cif.html#gpioSetMode">PIGPIO::gpioSetMode</a>
@@ -247,17 +247,17 @@ public class PiGpioSocketImpl extends PiGpioSocketBase implements PiGpio {
      * {@inheritDoc}
      *
      * Sets a glitch filter on a GPIO.  (AKA Debounce)
-     *
+     * <p>
      * Level changes on the GPIO are not reported unless the level has been stable for at
      * least 'steady' microseconds. The level is then reported. Level changes of less
      * than 'steady' microseconds are ignored.
-     *
+     * <p>
      * This filter affects the GPIO samples returned to callbacks set up with:
      *  - gpioSetAlertFunc
      *  - gpioSetAlertFuncEx
      *  - gpioSetGetSamplesFunc
      *  - gpioSetGetSamplesFuncEx.
-     *
+     * <p>
      * It does not affect interrupts set up with gpioSetISRFunc, gpioSetISRFuncEx, or
      * levels read by gpioRead, gpioRead_Bits_0_31, or gpioRead_Bits_32_53.
      * Each (stable) edge will be timestamped steady microseconds after it was first detected.
@@ -277,11 +277,11 @@ public class PiGpioSocketImpl extends PiGpioSocketBase implements PiGpio {
      * {@inheritDoc}
      *
      * Sets a noise filter on a GPIO.
-     *
+     * <p>
      * Level changes on the GPIO are ignored until a level which has been stable for 'steady'
      * microseconds is detected. Level changes on the GPIO are then reported for 'active'
      * microseconds after which the process repeats.
-     *
+     * <p>
      * This filter affects the GPIO samples returned to callbacks set up with:
      *  - gpioSetAlertFunc
      *  - gpioSetAlertFuncEx
@@ -289,7 +289,7 @@ public class PiGpioSocketImpl extends PiGpioSocketBase implements PiGpio {
      *  - gpioSetGetSamplesFuncEx.     *
      * It does not affect interrupts set up with gpioSetISRFunc, gpioSetISRFuncEx, or
      * levels read by gpioRead, gpioRead_Bits_0_31, or gpioRead_Bits_32_53.
-     *
+     * <p>
      * Level changes before and after the active period may be reported.
      * Your software must be designed to cope with such reports.
      * @see <a href="http://abyz.me.uk/rpi/pigpio/cif.html#gpioGlitchFilter">PIGPIO::gpioGlitchFilter</a>
@@ -315,7 +315,7 @@ public class PiGpioSocketImpl extends PiGpioSocketBase implements PiGpio {
      * {@inheritDoc}
      *
      * Starts PWM on the GPIO, dutycycle between 0 (off) and range (fully on). Range defaults to 255.
-     *
+     * <p>
      * This and the servo functionality use the DMA and PWM or PCM peripherals to control and schedule
      * the pulse lengths and duty cycles.
      * @see <a href="http://abyz.me.uk/rpi/pigpio/cif.html#gpioPWM">PIGPIO::gpioPWM</a>
@@ -335,11 +335,11 @@ public class PiGpioSocketImpl extends PiGpioSocketBase implements PiGpio {
      * {@inheritDoc}
      *
      * Returns the PWM dutycycle setting for the GPIO.
-     *
+     * <p>
      * For normal PWM the dutycycle will be out of the defined range for the GPIO (see gpioGetPWMrange).
      * If a hardware clock is active on the GPIO the reported dutycycle will be 500000 (500k) out of 1000000 (1M).
      * If hardware PWM is active on the GPIO the reported dutycycle will be out of a 1000000 (1M).
-     *
+     * <p>
      * Normal PWM range defaults to 255.
      * @see <a href="http://abyz.me.uk/rpi/pigpio/cif.html#gpioGetPWMdutycycle">PIGPIO::gpioGetPWMdutycycle</a>
      */
@@ -361,10 +361,10 @@ public class PiGpioSocketImpl extends PiGpioSocketBase implements PiGpio {
      * Selects the dutycycle range to be used for the GPIO. Subsequent calls to gpioPWM will use a dutycycle
      * between 0 (off) and range (fully on.  If PWM is currently active on the GPIO its dutycycle will be
      * scaled to reflect the new range.
-     *
+     * <p>
      * The real range, the number of steps between fully off and fully on for each frequency,
      * is given in the following table.
-     *
+     * <p>
      *  -------------------------------------------------------
      *   #1	   #2	 #3	   #4	 #5	   #6	 #7	    #8	   #9
      *   25,   50,  100,  125,  200,  250,  400,   500,   625,
@@ -372,9 +372,9 @@ public class PiGpioSocketImpl extends PiGpioSocketBase implements PiGpio {
      *  #10   #11   #12   #13   #14   #15    #16   #17    #18
      *  800, 1000, 1250, 2000, 2500, 4000, 5000, 10000, 20000
      *  -------------------------------------------------------
-     *
+     * <p>
      * The real value set by gpioPWM is (dutycycle * real range) / range.
-     *
+     * <p>
      * Example
      *   gpioSetPWMrange(24, 2000); // Now 2000 is fully on
      *                              //     1000 is half on
@@ -438,34 +438,34 @@ public class PiGpioSocketImpl extends PiGpioSocketBase implements PiGpio {
      * {@inheritDoc}
      *
      * Sets the frequency in hertz to be used for the GPIO.
-     *
+     * <p>
      * If PWM is currently active on the GPIO it will be switched off and then back on at the new frequency.
      * Each GPIO can be independently set to one of 18 different PWM frequencies.
      * The selectable frequencies depend upon the sample rate which may be 1, 2, 4, 5, 8, or 10 microseconds (default 5).
-     *
+     * <p>
      * The frequencies for each sample rate are:
-     *
+     * <p>
      *                        Hertz
-     *
+     * <p>
      *        1: 40000 20000 10000 8000 5000 4000 2500 2000 1600
      *            1250  1000   800  500  400  250  200  100   50
-     *
+     * <p>
      *        2: 20000 10000  5000 4000 2500 2000 1250 1000  800
      *             625   500   400  250  200  125  100   50   25
-     *
+     * <p>
      *        4: 10000  5000  2500 2000 1250 1000  625  500  400
      *             313   250   200  125  100   63   50   25   13
      * sample
      *  rate
      *  (us)  5:  8000  4000  2000 1600 1000  800  500  400  320
      *             250   200   160  100   80   50   40   20   10
-     *
+     * <p>
      *        8:  5000  2500  1250 1000  625  500  313  250  200
      *             156   125   100   63   50   31   25   13    6
-     *
+     * <p>
      *       10:  4000  2000  1000  800  500  400  250  200  160
      *             125   100    80   50   40   25   20   10    5
-     *
+     * <p>
      *
      * Example:
      *    gpioSetPWMfrequency(23, 0); // Set GPIO23 to lowest frequency.
@@ -490,11 +490,11 @@ public class PiGpioSocketImpl extends PiGpioSocketBase implements PiGpio {
      * {@inheritDoc}
      *
      * Returns the frequency (in hertz) used for the GPIO
-     *
+     * <p>
      * For normal PWM the frequency will be that defined for the GPIO by gpioSetPWMfrequency.
      * If a hardware clock is active on the GPIO the reported frequency will be that set by gpioHardwareClock.
      * If hardware PWM is active on the GPIO the reported frequency will be that set by gpioHardwarePWM.
-     *
+     * <p>
      * Example:
      *    f = gpioGetPWMfrequency(23); // Get frequency used for GPIO23.
      * @see <a href="http://abyz.me.uk/rpi/pigpio/cif.html#gpioGetPWMfrequency">PIGPIO::gpioGetPWMfrequency</a>
@@ -516,28 +516,28 @@ public class PiGpioSocketImpl extends PiGpioSocketBase implements PiGpio {
      *
      * Starts hardware PWM on a GPIO at the specified frequency and duty-cycle.
      * Frequencies above 30MHz are unlikely to work.
-     *
+     * <p>
      * NOTE: Any waveform started by gpioWaveTxSend, or gpioWaveChain will be cancelled.
-     *
+     * <p>
      * This function is only valid if the pigpio main clock is PCM.
      * The main clock defaults to PCM but may be overridden by a call to gpioCfgClock.
-     *
+     * <p>
      * The same PWM channel is available on multiple GPIO. The latest frequency and duty-cycle
      * setting will be used by all GPIO which share a PWM channel.
-     *
+     * <p>
      * The GPIO must be one of the following.
-     *
+     * <p>
      *   12  PWM channel 0  All models but A and B
      *   13  PWM channel 1  All models but A and B
      *   18  PWM channel 0  All models
      *   19  PWM channel 1  All models but A and B
-     *
+     * <p>
      *   40  PWM channel 0  Compute module only
      *   41  PWM channel 1  Compute module only
      *   45  PWM channel 1  Compute module only
      *   52  PWM channel 0  Compute module only
      *   53  PWM channel 1  Compute module only
-     *
+     * <p>
      *
      * The actual number of steps between off and fully on is the integral part of
      * 250M/PWMfreq (375M/PWMfreq for the BCM2711).
@@ -568,35 +568,35 @@ public class PiGpioSocketImpl extends PiGpioSocketBase implements PiGpio {
      * {@inheritDoc}
      *
      * Starts servo pulses on the GPIO, 0 (off), 500 (most anti-clockwise) to 2500 (most clockwise).
-     *
+     * <p>
      * The range supported by servos varies and should probably be determined by experiment. A value
      * of 1500 should always be safe and represents the mid-point of rotation. You can DAMAGE a servo
      * if you command it to move beyond its limits.
-     *
+     * <p>
      * The following causes an on pulse of 1500 microseconds duration to be transmitted on GPIO 17 at
      * a rate of 50 times per second. This will command a servo connected to GPIO 17 to rotate to its
      * mid-point.
-     *
+     * <p>
      * Example:
      *  - gpioServo(17, 1000); // Move servo to safe position anti-clockwise.
      *  - gpioServo(23, 1500); // Move servo to centre position.
      *  - gpioServo(25, 2000); // Move servo to safe position clockwise.
-     *
+     * <p>
      * OTHER UPDATE RATES:
      * This function updates servos at 50Hz. If you wish to use a different
      * update frequency you will have to use the PWM functions.
-     *
+     * <p>
      *    PWM Hz      50     100    200    400    500
      *    1E6/Hz   20000   10000   5000   2500   2000
-     *
+     * <p>
      * Firstly set the desired PWM frequency using gpioSetPWMfrequency.
      * Then set the PWM range using gpioSetPWMrange to 1E6/frequency. Doing this
      * allows you to use units of microseconds when setting the servo pulsewidth.
-     *
+     * <p>
      * E.g. If you want to update a servo connected to GPIO25 at 400Hz*
      *  - gpioSetPWMfrequency(25, 400);
      *  - gpioSetPWMrange(25, 2500);
-     *
+     * <p>
      * Thereafter use the PWM command to move the servo, e.g. gpioPWM(25, 1500) will set a 1500 us pulse.
      * @see <a href="http://abyz.me.uk/rpi/pigpio/cif.html#gpioServo">PIGPIO::gpioServo</a>
      */
@@ -677,17 +677,17 @@ public class PiGpioSocketImpl extends PiGpioSocketBase implements PiGpio {
      *
      * Returns the current system tick.
      * Tick is the number of microseconds since system boot.
-     *
+     * <p>
      * As tick is an unsigned 32 bit quantity it wraps around after 2^32 microseconds, which is
      * approximately 1 hour 12 minutes.  You don't need to worry about the wrap around as long as you
      * take a tick (uint32_t) from another tick, i.e. the following code will always provide the
      * correct difference.
-     *
+     * <p>
      * Example
      *   uint32_t startTick, endTick;
      *   int diffTick;
      *   startTick = gpioTick();
-     *
+     * <p>
      *   // do some processing
      *   endTick = gpioTick();
      *   diffTick = endTick - startTick;
@@ -718,7 +718,7 @@ public class PiGpioSocketImpl extends PiGpioSocketBase implements PiGpio {
      * This returns a handle for the device at the address on the I2C bus.
      * Physically buses 0 and 1 are available on the Pi.
      * Higher numbered buses will be available if a kernel supported bus multiplexor is being used.
-     *
+     * <p>
      * The GPIO used are given in the following table.
      *         SDA   SCL
      * I2C0     0     1
@@ -969,7 +969,7 @@ public class PiGpioSocketImpl extends PiGpioSocketBase implements PiGpio {
      *
      * This writes data bytes to the specified register of the device associated with handle and reads a
      * device specified number of bytes of data in return.
-     *
+     * <p>
      * The SMBus 2.0 documentation states that a minimum of 1 byte may be sent and a minimum of 1 byte may be received.
      * The total number of bytes sent/received must be 32 or less.
      * @see <a href="http://abyz.me.uk/rpi/pigpio/cif.html#i2cBlockProcessCall">PIGPIO::i2cBlockProcessCall</a>
@@ -1009,7 +1009,7 @@ public class PiGpioSocketImpl extends PiGpioSocketBase implements PiGpio {
      *
      * This writes data bytes to the specified register of the device associated with the handle and reads a
      * device specified number of bytes of data in return.
-     *
+     * <p>
      * The SMBus 2.0 documentation states that a minimum of 1 byte may be sent and a minimum of 1 byte may be received.
      * The total number of bytes sent/received must be 32 or less.
      */
@@ -1309,39 +1309,39 @@ public class PiGpioSocketImpl extends PiGpioSocketBase implements PiGpio {
      * This function opens a SPI device channel at a specified baud rate and with specified flags.
      * Data will be transferred at baud bits per second.
      * The flags may be used to modify the default behaviour of 4-wire operation, mode 0, active low chip select.
-     *
+     * <p>
      * The Pi has two SPI peripherals: main and auxiliary.
      * The main SPI has two chip selects (channels), the auxiliary has three.
      * The auxiliary SPI is available on all models but the A and B.
-     *
+     * <p>
      * The GPIO pins used are given in the following table.
-     *
+     * <p>
      *             MISO    MOSI   SCLK   CE0   CE1   CE2
      *             -------------------------------------
      *   Main SPI    9      10     11      8	 7	   -
      *   Aux SPI    19      20     21     18	17    16
-     *
+     * <p>
      *
      *  spiChan  : 0-1 (0-2 for the auxiliary SPI)
      *  baud     : 32K-125M (values above 30M are unlikely to work)
      *  spiFlags : see below
-     *
+     * <p>
      * spiFlags consists of the least significant 22 bits.
      * -----------------------------------------------------------------
      * 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0
      *  b  b  b  b  b  b  R  T  n  n  n  n  W  A u2 u1 u0 p2 p1 p0  m  m
      * -----------------------------------------------------------------
-     *
+     * <p>
      * [mm] defines the SPI mode.
      *      (Warning: modes 1 and 3 do not appear to work on the auxiliary SPI.)
-     *
+     * <p>
      *      Mode POL  PHA
      *      -------------
      *       0    0    0
      *       1    0    1
      *       2    1    0
      *       3    1    1
-     *
+     * <p>
      * [px] is 0 if CEx is active low (default) and 1 for active high.
      * [ux] is 0 if the CEx GPIO is reserved for SPI (default) and 1 otherwise.
      * [A] is 0 for the main SPI, 1 for the auxiliary SPI.
@@ -1350,12 +1350,12 @@ public class PiGpioSocketImpl extends PiGpioSocketBase implements PiGpio {
      * [T] is 1 if the least significant bit is transmitted on MOSI first, the default (0) shifts the most significant bit out first. Auxiliary SPI only.
      * [R] is 1 if the least significant bit is received on MISO first, the default (0) receives the most significant bit first. Auxiliary SPI only.
      * [bbbbbb] defines the word size in bits (0-32). The default (0) sets 8 bits per word. Auxiliary SPI only.
-     *
+     * <p>
      * The spiRead, spiWrite, and spiXfer functions transfer data packed into 1, 2, or 4 bytes according to the word size in bits.
      *  - For bits 1-8 there will be one byte per word.
      *  - For bits 9-16 there will be two bytes per word.
      *  - For bits 17-32 there will be four bytes per word.
-     *
+     * <p>
      * Multi-byte transfers are made in least significant byte first order.
      * E.g. to transfer 32 11-bit words buf should contain 64 bytes and count should be 64.
      * E.g. to transfer the 14 bit value 0x1ABC send the bytes 0xBC followed by 0x1A.

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/test/TestGpioAlert.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/test/TestGpioAlert.java
@@ -49,6 +49,7 @@ public class TestGpioAlert {
      * <p>main.</p>
      *
      * @param args an array of {@link String} objects.
+     * @throws IOException
      */
     public static void main(String[] args) throws IOException {
         String loglevel = "INFO";

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/test/TestGpioAlertRaw.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/test/TestGpioAlertRaw.java
@@ -52,6 +52,7 @@ public class TestGpioAlertRaw {
      * <p>main.</p>
      *
      * @param args an array of {@link String} objects.
+     * @throws IOException
      */
     public static void main(String[] args) throws IOException {
         String loglevel = "INFO";

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/test/TestGpioIsrRaw.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/test/TestGpioIsrRaw.java
@@ -52,6 +52,7 @@ public class TestGpioIsrRaw {
      * <p>main.</p>
      *
      * @param args an array of {@link String} objects.
+     * @throws IOException
      */
     public static void main(String[] args) throws IOException {
         String loglevel = "INFO";

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/test/TestPwmHardware.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/test/TestPwmHardware.java
@@ -50,6 +50,7 @@ public class TestPwmHardware {
      * <p>main.</p>
      *
      * @param args an array of {@link String} objects.
+     * @throws IOException
      */
     public static void main(String[] args) throws IOException {
         String loglevel = "INFO";

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/test/TestSerialRaw.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/test/TestSerialRaw.java
@@ -51,6 +51,7 @@ public class TestSerialRaw {
      * <p>main.</p>
      *
      * @param args an array of {@link String} objects.
+     * @throws InterruptedException
      */
     public static void main(String[] args) throws InterruptedException {
         logger.info("PIGPIO VERSION   : {}", PIGPIO.gpioVersion());

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/util/NativeLibraryLoader.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/util/NativeLibraryLoader.java
@@ -215,7 +215,7 @@ public class NativeLibraryLoader {
 
 	/**
 	 * Loads library from classpath
-	 *
+	 * <p>
 	 * The file from classpath is copied into system temporary directory and then loaded. The temporary file is
      * deleted after exiting. Method uses String as filename because the pathname is
 	 * "abstract", not system-dependent.

--- a/pi4j-core/src/main/java/com/pi4j/boardinfo/definition/HeaderVersion.java
+++ b/pi4j-core/src/main/java/com/pi4j/boardinfo/definition/HeaderVersion.java
@@ -1,7 +1,6 @@
 package com.pi4j.boardinfo.definition;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/pi4j-core/src/main/java/com/pi4j/boardinfo/util/BoardInfoHelper.java
+++ b/pi4j-core/src/main/java/com/pi4j/boardinfo/util/BoardInfoHelper.java
@@ -62,7 +62,8 @@ public class BoardInfoHelper {
 
     /**
      * Flag indicating that the board is using the RP1 chip for GPIO.
-     * https://www.raspberrypi.com/documentation/microcontrollers/rp1.html
+     * <a href="https://www.raspberrypi.com/documentation/microcontrollers/rp1.html">...</a>
+     * @return
      */
     public static boolean usesRP1() {
         return instance.boardInfo.getBoardModel() == BoardModel.MODEL_5_B;

--- a/pi4j-core/src/main/java/com/pi4j/boardinfo/util/BoardInfoHelper.java
+++ b/pi4j-core/src/main/java/com/pi4j/boardinfo/util/BoardInfoHelper.java
@@ -62,7 +62,7 @@ public class BoardInfoHelper {
 
     /**
      * Flag indicating that the board is using the RP1 chip for GPIO.
-     * <a href="https://www.raspberrypi.com/documentation/microcontrollers/rp1.html">...</a>
+     * <a href="https://www.raspberrypi.com/documentation/microcontrollers/rp1.html">https://www.raspberrypi.com/documentation/microcontrollers/rp1.html</a>
      * @return
      */
     public static boolean usesRP1() {

--- a/pi4j-core/src/main/java/com/pi4j/common/IdentityBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/common/IdentityBase.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <T>
  */
 public abstract class IdentityBase<T> implements Extension<T> {
 

--- a/pi4j-core/src/main/java/com/pi4j/common/Lifecycle.java
+++ b/pi4j-core/src/main/java/com/pi4j/common/Lifecycle.java
@@ -34,6 +34,7 @@ import com.pi4j.exception.ShutdownException;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <T>
  */
 public interface Lifecycle<T> {
     /**

--- a/pi4j-core/src/main/java/com/pi4j/config/AddressConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/AddressConfig.java
@@ -30,6 +30,7 @@ package com.pi4j.config;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
  */
 public interface AddressConfig<CONFIG_TYPE extends Config> extends Config<CONFIG_TYPE> {
     /** Constant <code>ADDRESS_KEY="address"</code> */

--- a/pi4j-core/src/main/java/com/pi4j/config/AddressConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/AddressConfigBuilder.java
@@ -30,6 +30,8 @@ package com.pi4j.config;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BUILDER_TYPE>
+ * @param <CONFIG_TYPE>
  */
 public interface AddressConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> extends ConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {
     /**

--- a/pi4j-core/src/main/java/com/pi4j/config/Builder.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/Builder.java
@@ -30,6 +30,7 @@ package com.pi4j.config;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BUILT_TYPE>
  */
 public interface Builder<BUILT_TYPE> {
     /**

--- a/pi4j-core/src/main/java/com/pi4j/config/Config.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/Config.java
@@ -32,6 +32,7 @@ import java.util.Map;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
  */
 public interface Config<CONFIG_TYPE> {
     /** Constant <code>ID_KEY="id"</code> */

--- a/pi4j-core/src/main/java/com/pi4j/config/ConfigBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/ConfigBase.java
@@ -37,6 +37,7 @@ import java.util.Map;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
  */
 public class ConfigBase<CONFIG_TYPE extends Config> implements Config<CONFIG_TYPE> {
 

--- a/pi4j-core/src/main/java/com/pi4j/config/ConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/ConfigBuilder.java
@@ -37,6 +37,8 @@ import java.util.Properties;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BUILDER_TYPE>
+ * @param <CONFIG_TYPE>
  */
 public interface ConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> extends Builder<CONFIG_TYPE> {
     /**

--- a/pi4j-core/src/main/java/com/pi4j/config/DeviceConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/DeviceConfig.java
@@ -30,6 +30,7 @@ package com.pi4j.config;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
  */
 public interface DeviceConfig<CONFIG_TYPE extends Config> extends Config<CONFIG_TYPE> {
 

--- a/pi4j-core/src/main/java/com/pi4j/config/DeviceConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/DeviceConfigBuilder.java
@@ -30,6 +30,8 @@ package com.pi4j.config;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BUILDER_TYPE>
+ * @param <CONFIG_TYPE>
  */
 public interface DeviceConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> extends ConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {
     /**

--- a/pi4j-core/src/main/java/com/pi4j/config/impl/AddressConfigBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/impl/AddressConfigBase.java
@@ -37,6 +37,7 @@ import java.util.Map;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
  */
 public abstract class AddressConfigBase<CONFIG_TYPE extends Config>
         extends ConfigBase<CONFIG_TYPE>

--- a/pi4j-core/src/main/java/com/pi4j/config/impl/AddressConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/impl/AddressConfigBuilderBase.java
@@ -36,6 +36,8 @@ import com.pi4j.context.Context;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BUILDER_TYPE>
+ * @param <CONFIG_TYPE>
  */
 public abstract class AddressConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder, CONFIG_TYPE extends Config>
         extends ConfigBuilderBase<BUILDER_TYPE, CONFIG_TYPE>

--- a/pi4j-core/src/main/java/com/pi4j/config/impl/ConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/impl/ConfigBuilderBase.java
@@ -44,6 +44,8 @@ import java.util.stream.Collectors;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BUILDER_TYPE>
+ * @param <CONFIG_TYPE>
  */
 public abstract class ConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder, CONFIG_TYPE extends Config>
         implements ConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {

--- a/pi4j-core/src/main/java/com/pi4j/config/impl/DeviceConfigBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/impl/DeviceConfigBase.java
@@ -37,6 +37,7 @@ import java.util.Map;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
  */
 public abstract class DeviceConfigBase<CONFIG_TYPE extends Config<CONFIG_TYPE>>
         extends ConfigBase<CONFIG_TYPE>

--- a/pi4j-core/src/main/java/com/pi4j/config/impl/DeviceConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/impl/DeviceConfigBuilderBase.java
@@ -36,6 +36,8 @@ import com.pi4j.context.Context;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BUILDER_TYPE>
+ * @param <CONFIG_TYPE>
  */
 public abstract class DeviceConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder, CONFIG_TYPE extends Config>
         extends ConfigBuilderBase<BUILDER_TYPE, CONFIG_TYPE>

--- a/pi4j-core/src/main/java/com/pi4j/extension/Extension.java
+++ b/pi4j-core/src/main/java/com/pi4j/extension/Extension.java
@@ -34,6 +34,7 @@ import com.pi4j.common.Lifecycle;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <T>
  */
 public interface Extension<T> extends Identity, Lifecycle<T> {
 

--- a/pi4j-core/src/main/java/com/pi4j/extension/ExtensionBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/extension/ExtensionBase.java
@@ -32,6 +32,7 @@ import com.pi4j.common.IdentityBase;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <T>
  */
 public abstract class ExtensionBase<T> extends IdentityBase<T> implements Extension<T> {
 

--- a/pi4j-core/src/main/java/com/pi4j/internal/ProviderProvider.java
+++ b/pi4j-core/src/main/java/com/pi4j/internal/ProviderProvider.java
@@ -116,6 +116,7 @@ public interface ProviderProvider extends ProviderAliases {
      * <p>provider.</p>
      *
      * @param providerId a {@link java.lang.String} object.
+     * @param providerClass
      * @param <T> a T object.
      * @return a T object.
      * @throws ProviderNotFoundException if the provider specified by {@code providerId} can not be found.

--- a/pi4j-core/src/main/java/com/pi4j/io/IO.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IO.java
@@ -35,6 +35,9 @@ import com.pi4j.provider.Provider;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
+ * @param <IO_TYPE>
+ * @param <PROVIDER_TYPE>
  */
 public interface IO<IO_TYPE extends IO, CONFIG_TYPE extends IOConfig, PROVIDER_TYPE extends Provider>
         extends Describable, Lifecycle, Identity {

--- a/pi4j-core/src/main/java/com/pi4j/io/IOAddressConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IOAddressConfigBuilder.java
@@ -34,6 +34,8 @@ import com.pi4j.provider.Provider;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BUILDER_TYPE>
+ * @param <CONFIG_TYPE>
  */
 public interface IOAddressConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>
         extends IOConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>,

--- a/pi4j-core/src/main/java/com/pi4j/io/IOBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IOBase.java
@@ -38,6 +38,9 @@ import com.pi4j.provider.Provider;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
+ * @param <IO_TYPE>
+ * @param <PROVIDER_TYPE>
  */
 public abstract class IOBase<IO_TYPE extends IO, CONFIG_TYPE extends IOConfig, PROVIDER_TYPE extends Provider>
         extends IdentityBase implements IO<IO_TYPE,CONFIG_TYPE, PROVIDER_TYPE> {

--- a/pi4j-core/src/main/java/com/pi4j/io/IOConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IOConfig.java
@@ -32,6 +32,7 @@ import com.pi4j.config.Config;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
  */
 public interface IOConfig<CONFIG_TYPE> extends Config<CONFIG_TYPE> {
     String PLATFORM_KEY = "platform";

--- a/pi4j-core/src/main/java/com/pi4j/io/IOConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IOConfigBuilder.java
@@ -34,6 +34,8 @@ import com.pi4j.provider.Provider;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BUILDER_TYPE>
+ * @param <CONFIG_TYPE>
  */
 public interface IOConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> extends ConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {
     BUILDER_TYPE provider(String provider);

--- a/pi4j-core/src/main/java/com/pi4j/io/IODataReader.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IODataReader.java
@@ -39,7 +39,7 @@ import java.util.Objects;
  * Data Writer Interface for Pi4J Data Communications
  *
  * @author Robert Savage
- *
+ * <p>
  * Based on previous contributions from:
  *        Daniel Sendula,
  *        <a href="http://raspelikan.blogspot.co.at">RasPelikan</a>
@@ -109,7 +109,7 @@ public interface IODataReader extends Readable {
     /**
      * Read data from the I/O device into the provided byte buffer at the given
      * offset and up to the specified data length (number of bytes).
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is not
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is
@@ -151,7 +151,7 @@ public interface IODataReader extends Readable {
     /**
      * Read data from the I/O device into the provided byte buffer starting
      * with the first byte in the array up to the provided length.
-     *
+     * <p>
      * NOTE:  The data bytes read from the I/O device are copied/
      *        inserted into the byte buffer starting at the current
      *        position index up to the length requested or up to the
@@ -181,7 +181,7 @@ public interface IODataReader extends Readable {
     /**
      * Read data from the I/O device into the provided byte buffer starting with
      * the first byte in the array up to available space remaining in the buffer.
-     *
+     * <p>
      * NOTE:  The data bytes read from the I/O device are copied/
      *        inserted into the byte buffer starting at the current
      *        position index up to the buffer's remaining limit. If
@@ -331,7 +331,7 @@ public interface IODataReader extends Readable {
      * Read character data from the I/O device into the provided character buffer at the given
      * offset and up to the specified data length (number of characters).  Specify the character
      * set to be used to decode the bytes into chars.
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is not
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is
@@ -387,7 +387,7 @@ public interface IODataReader extends Readable {
      * Read character data from the I/O device into the provided character buffer starting
      * at the zero index (first position) up to the specified data length (number of characters).
      * Specify the character set to be used to decode the bytes into chars.
-     *
+     * <p>
      * NOTE:  The data characters read and decoded from the I/O device are
      *        copied/inserted into the character buffer starting at the current
      *        position index up to the length requested or up to the buffer's
@@ -413,7 +413,7 @@ public interface IODataReader extends Readable {
      * Read character data from the I/O device into the provided character buffer starting
      * at the zero index (first position) up to available space remaining in the buffer.
      * Specify the character set to be used to decode the bytes into chars.
-     *
+     * <p>
      * NOTE:  The data characters read from the I/O device are copied/
      *        inserted into the character buffer starting at the current
      *        position index up to the buffer's remaining limit. If
@@ -439,7 +439,7 @@ public interface IODataReader extends Readable {
      * Read ASCII character data from the I/O device into the provided character buffer at the given
      * offset and up to the specified data length (number of characters).  ASCII is the internal
      * character set used to decode the bytes into chars.
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is not
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is
@@ -462,7 +462,7 @@ public interface IODataReader extends Readable {
      * Read ASCII character data from the I/O device into the provided character buffer starting
      * at the zero index (first position) up to the specified data length (number of characters).
      * ASCII is the internal character set used to decode the bytes into chars.
-     *
+     * <p>
      * NOTE:  The data characters read and decoded from the I/O device are
      *        copied/inserted into the character buffer starting at the current
      *        position index up to the length requested or up to the buffer's
@@ -486,7 +486,7 @@ public interface IODataReader extends Readable {
      * Read ASCII character data from the I/O device into the provided character buffer starting
      * at the zero index (first position) up to available space remaining in the buffer.
      * ASCII is the internal character set used to decode the bytes into chars.
-     *
+     * <p>
      * NOTE:  The data characters read from the I/O device are copied/
      *        inserted into the character buffer starting at the current
      *        position index up to the buffer's remaining limit. If
@@ -520,7 +520,7 @@ public interface IODataReader extends Readable {
      * return the data read in a new byte array.  The 'offset' parameter allows you to skip
      * a certain number of bytes in the read data an excludes them from the returned
      * data byte array.
-     *
+     * <p>
      * Note: the resulting byte array size will be at most the 'length' -  'offset'.
      *
      * @param offset the offset index in the data read to start copying read data
@@ -562,7 +562,7 @@ public interface IODataReader extends Readable {
      * return the data read in a new ByteBuffer.  The 'offset' parameter allows you to skip
      * a certain number of bytes in the read data and excludes them from the returned
      * data ByteBuffer.
-     *
+     * <p>
      * Note: the resulting byte buffer size will be at most the 'length' -  'offset'.
      *
      * @param offset the offset index in the data read to start copying read data

--- a/pi4j-core/src/main/java/com/pi4j/io/IODataWriter.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IODataWriter.java
@@ -41,7 +41,7 @@ import com.pi4j.exception.Pi4JException;
  * Data Writer Interface for Pi4J Data Communications
  *
  * @author Robert Savage
- *
+ * <p>
  * Based on previous contributions from:
  *        Daniel Sendula,
  *        <a href="http://raspelikan.blogspot.co.at">RasPelikan</a>
@@ -148,7 +148,7 @@ public interface IODataWriter {
 
     /**
      * Write a buffer of byte values with given offset (starting position) and length in the provided data buffer.
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is not
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is
@@ -172,7 +172,7 @@ public interface IODataWriter {
 
     /**
      * Write a buffer of byte values starting with the first byte in the array up to the provided length.
-     *
+     * <p>
      * NOTE:  The contents from the byte buffer is read
      *        from the current position index up to the length
      *        requested or up to the buffer's remaining limit;
@@ -199,7 +199,7 @@ public interface IODataWriter {
 
     /**
      * Write a buffer of byte values (all bytes in buffer).
-     *
+     * <p>
      * NOTE:  The contents from the byte buffer is read
      *        from the current position index up to the buffer's
      *        remaining limit.  If the buffer's current position
@@ -222,7 +222,7 @@ public interface IODataWriter {
 
     /**
      * Write multiple byte buffers of data.
-     *
+     * <p>
      * NOTE:  The contents from each byte buffer is read
      *        from the current position index up to the buffer's
      *        remaining limit.  If the buffer's current position
@@ -491,7 +491,7 @@ public interface IODataWriter {
 
     /**
      * Writes an ASCII based character buffer with a given offset and length.
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is not
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is
@@ -511,7 +511,7 @@ public interface IODataWriter {
 
     /**
      * Writes an ASCII based character buffer starting at first index to a given length.
-     *
+     * <p>
      * NOTE:  The contents from the character buffer is read
      *        from the current position index up to the length
      *        requested or up to the buffer's remaining limit;
@@ -531,7 +531,7 @@ public interface IODataWriter {
 
     /**
      * Writes an ASCII based character buffer.
-     *
+     * <p>
      * NOTE:  The contents from the character buffer is read
      *        from the current position index up to the buffer's
      *        remaining limit.  If the buffer's current position
@@ -549,7 +549,7 @@ public interface IODataWriter {
 
     /**
      * Writes multiple ASCII based character buffers.
-     *
+     * <p>
      * NOTE:  The contents from each character buffer is read
      *        from the current position index up to the buffer's
      *        remaining limit.  If the buffer's current position
@@ -568,7 +568,7 @@ public interface IODataWriter {
     /**
      * Writes a character buffer with a given offset and length
      * using a specified character set to encode the chars into bytes.
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is not
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is
@@ -597,7 +597,7 @@ public interface IODataWriter {
     /**
      * Writes a character buffer starting at first index to a
      * given length using a specified character set to encode the chars into bytes.
-     *
+     * <p>
      * NOTE:  The contents from the character buffer is read
      *        from the current position index up to the length
      *        requested or up to the buffer's remaining limit;
@@ -626,7 +626,7 @@ public interface IODataWriter {
     /**
      * Writes character buffer using a specified
      * character set to encode the chars into bytes.
-     *
+     * <p>
      * NOTE:  The contents from the character buffer is read
      *        from the current position index up to the buffer's
      *        remaining limit.  If the buffer's current position
@@ -651,7 +651,7 @@ public interface IODataWriter {
     /**
      * Writes multiple character buffers using a specified
      * character set to encode the chars into bytes.
-     *
+     * <p>
      * NOTE:  The contents from each character buffer is read
      *        from the current position index up to the buffer's
      *        remaining limit.  If the buffer's current position

--- a/pi4j-core/src/main/java/com/pi4j/io/IODeviceConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IODeviceConfigBuilder.java
@@ -34,6 +34,8 @@ import com.pi4j.provider.Provider;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BUILDER_TYPE>
+ * @param <CONFIG_TYPE>
  */
 public interface IODeviceConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>
         extends IOConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>,

--- a/pi4j-core/src/main/java/com/pi4j/io/binding/AnalogBinding.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/binding/AnalogBinding.java
@@ -32,6 +32,8 @@ import com.pi4j.io.gpio.analog.AnalogValueChangeEvent;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BINDING_TYPE>
+ * @param <MEMBER_TYPE>
  */
 public interface AnalogBinding<BINDING_TYPE extends Binding, MEMBER_TYPE> extends Binding<BINDING_TYPE, MEMBER_TYPE> {
     /**

--- a/pi4j-core/src/main/java/com/pi4j/io/binding/Binding.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/binding/Binding.java
@@ -32,6 +32,8 @@ import java.util.Collection;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BINDING_TYPE>
+ * @param <MEMBER_TYPE>
  */
 public interface Binding<BINDING_TYPE extends Binding, MEMBER_TYPE> {
     BINDING_TYPE add(MEMBER_TYPE... member);

--- a/pi4j-core/src/main/java/com/pi4j/io/binding/DigitalBinding.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/binding/DigitalBinding.java
@@ -32,6 +32,8 @@ import com.pi4j.io.gpio.digital.DigitalStateChangeEvent;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BINDING_TYPE>
+ * @param <MEMBER_TYPE>
  */
 public interface DigitalBinding<BINDING_TYPE extends Binding, MEMBER_TYPE> extends Binding<BINDING_TYPE, MEMBER_TYPE> {
     /**

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/Gpio.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/Gpio.java
@@ -33,6 +33,9 @@ import com.pi4j.provider.Provider;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
+ * @param <IO_TYPE>
+ * @param <PROVIDER_TYPE>
  */
 public interface Gpio<IO_TYPE extends IO<IO_TYPE,CONFIG_TYPE, PROVIDER_TYPE>,
         CONFIG_TYPE extends GpioConfig,

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioBase.java
@@ -33,6 +33,9 @@ import com.pi4j.provider.Provider;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
+ * @param <IO_TYPE>
+ * @param <PROVIDER_TYPE>
  */
 public abstract class GpioBase<IO_TYPE extends Gpio<IO_TYPE, CONFIG_TYPE, PROVIDER_TYPE>,
         CONFIG_TYPE extends GpioConfig<CONFIG_TYPE>, PROVIDER_TYPE extends Provider>

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioConfig.java
@@ -34,6 +34,7 @@ import com.pi4j.io.IOConfig;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
  */
 public interface GpioConfig<CONFIG_TYPE extends Config>
         extends AddressConfig<CONFIG_TYPE>, IOConfig<CONFIG_TYPE> {

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioConfigBuilder.java
@@ -32,6 +32,8 @@ import com.pi4j.io.IOAddressConfigBuilder;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BUILDER_TYPE>
+ * @param <CONFIG_TYPE>
  */
 public interface GpioConfigBuilder<BUILDER_TYPE extends GpioConfigBuilder, CONFIG_TYPE extends GpioConfig>
         extends IOAddressConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioProvider.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioProvider.java
@@ -33,6 +33,9 @@ import com.pi4j.provider.Provider;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
+ * @param <IO_TYPE>
+ * @param <PROVIDER_TYPE>
  */
 public interface GpioProvider<PROVIDER_TYPE extends GpioProvider,
         IO_TYPE extends IO,

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioProviderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioProviderBase.java
@@ -32,6 +32,9 @@ import com.pi4j.provider.ProviderBase;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
+ * @param <IO_TYPE>
+ * @param <PROVIDER_TYPE>
  */
 public abstract class GpioProviderBase<
             PROVIDER_TYPE extends GpioProvider,

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/Analog.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/Analog.java
@@ -35,6 +35,9 @@ import com.pi4j.io.gpio.Gpio;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <ANALOG_TYPE>
+ * @param <CONFIG_TYPE>
+ * @param <PROVIDER_TYPE>
  */
 public interface Analog<ANALOG_TYPE
             extends Analog<ANALOG_TYPE, CONFIG_TYPE, PROVIDER_TYPE>,

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogBase.java
@@ -39,6 +39,9 @@ import com.pi4j.io.gpio.GpioBase;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <ANALOG_TYPE>
+ * @param <CONFIG_TYPE>
+ * @param <PROVIDER_TYPE>
  */
 public abstract class AnalogBase<ANALOG_TYPE
         extends Analog<ANALOG_TYPE, CONFIG_TYPE, PROVIDER_TYPE>,

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogConfig.java
@@ -33,6 +33,7 @@ import com.pi4j.io.gpio.GpioConfig;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
  */
 public interface AnalogConfig<CONFIG_TYPE extends Config> extends GpioConfig<CONFIG_TYPE> {
     /** Constant <code>RANGE_MIN_KEY="min"</code> */

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogConfigBuilder.java
@@ -32,6 +32,8 @@ import com.pi4j.io.gpio.GpioConfigBuilder;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BUILDER_TYPE>
+ * @param <CONFIG_TYPE>
  */
 public interface AnalogConfigBuilder<BUILDER_TYPE extends AnalogConfigBuilder, CONFIG_TYPE extends AnalogConfig>
         extends GpioConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogEvent.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogEvent.java
@@ -32,6 +32,9 @@ import com.pi4j.event.Event;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <ANALOG_TYPE>
+ * @param <CONFIG_TYPE>
+ * @param <PROVIDER_TYPE>
  */
 public interface AnalogEvent<ANALOG_TYPE extends Analog<ANALOG_TYPE, CONFIG_TYPE, PROVIDER_TYPE>,
         CONFIG_TYPE extends AnalogConfig<CONFIG_TYPE>,

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogListener.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogListener.java
@@ -32,6 +32,7 @@ import com.pi4j.event.Listener;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <EVENT_TYPE>
  */
 public interface AnalogListener<EVENT_TYPE extends AnalogEvent> extends Listener {
     // MARKER INTERFACE

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogProvider.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogProvider.java
@@ -32,6 +32,9 @@ import com.pi4j.io.gpio.GpioProvider;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <ANALOG_TYPE>
+ * @param <CONFIG_TYPE>
+ * @param <PROVIDER_TYPE>
  */
 public interface AnalogProvider<PROVIDER_TYPE extends AnalogProvider, ANALOG_TYPE extends Analog, CONFIG_TYPE
         extends AnalogConfig> extends GpioProvider<PROVIDER_TYPE, ANALOG_TYPE, CONFIG_TYPE> {

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogProviderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogProviderBase.java
@@ -31,6 +31,9 @@ import com.pi4j.io.gpio.GpioProviderBase;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <ANALOG_TYPE>
+ * @param <CONFIG_TYPE>
+ * @param <PROVIDER_TYPE>
  */
 public abstract class AnalogProviderBase<
             PROVIDER_TYPE extends AnalogProvider,

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogValueChangeEvent.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogValueChangeEvent.java
@@ -31,6 +31,7 @@ package com.pi4j.io.gpio.analog;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <ANALOG_TYPE>
  */
 public class AnalogValueChangeEvent<ANALOG_TYPE extends Analog> implements AnalogEvent {
 

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/impl/AnalogConfigBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/impl/AnalogConfigBase.java
@@ -36,6 +36,7 @@ import java.util.Map;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
  */
 public abstract class AnalogConfigBase<CONFIG_TYPE extends AnalogConfig>
         extends IOAddressConfigBase<CONFIG_TYPE>

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/impl/AnalogConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/impl/AnalogConfigBuilderBase.java
@@ -36,6 +36,8 @@ import com.pi4j.io.impl.IOAddressConfigBuilderBase;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BUILDER_TYPE>
+ * @param <CONFIG_TYPE>
  */
 public abstract class AnalogConfigBuilderBase<BUILDER_TYPE extends AnalogConfigBuilder, CONFIG_TYPE extends AnalogConfig>
         extends IOAddressConfigBuilderBase<BUILDER_TYPE, CONFIG_TYPE>

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/impl/DefaultAnalogInputConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/impl/DefaultAnalogInputConfigBuilder.java
@@ -49,6 +49,7 @@ public class DefaultAnalogInputConfigBuilder
     /**
      * <p>newInstance.</p>
      *
+     * @param context
      * @return a {@link com.pi4j.io.gpio.analog.AnalogInputConfigBuilder} object.
      */
     public static AnalogInputConfigBuilder newInstance(Context context) {

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/impl/DefaultAnalogOutputConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/impl/DefaultAnalogOutputConfigBuilder.java
@@ -49,6 +49,7 @@ public class DefaultAnalogOutputConfigBuilder
     /**
      * <p>newInstance.</p>
      *
+     * @param context
      * @return a {@link com.pi4j.io.gpio.analog.AnalogOutputConfigBuilder} object.
      */
     public static AnalogOutputConfigBuilder newInstance(Context context) {

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/Digital.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/Digital.java
@@ -35,6 +35,9 @@ import com.pi4j.io.gpio.Gpio;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
+ * @param <DIGITAL_TYPE>
+ * @param <PROVIDER_TYPE>
  */
 public interface Digital<DIGITAL_TYPE extends Digital<DIGITAL_TYPE, CONFIG_TYPE, PROVIDER_TYPE>,
         CONFIG_TYPE extends DigitalConfig<CONFIG_TYPE>,

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalBase.java
@@ -40,6 +40,9 @@ import com.pi4j.io.gpio.GpioBase;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
+ * @param <DIGITAL_TYPE>
+ * @param <PROVIDER_TYPE>
  */
 public abstract class DigitalBase<DIGITAL_TYPE extends Digital<DIGITAL_TYPE, CONFIG_TYPE, PROVIDER_TYPE>,
         CONFIG_TYPE extends DigitalConfig<CONFIG_TYPE>,

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalConfig.java
@@ -33,6 +33,7 @@ import com.pi4j.io.gpio.GpioConfig;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
  */
 public interface DigitalConfig<CONFIG_TYPE extends Config> extends GpioConfig<CONFIG_TYPE> {
 

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalConfigBuilder.java
@@ -32,6 +32,8 @@ import com.pi4j.io.gpio.GpioConfigBuilder;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BUILDER_TYPE>
+ * @param <CONFIG_TYPE>
  */
 public interface DigitalConfigBuilder<BUILDER_TYPE extends DigitalConfigBuilder, CONFIG_TYPE extends DigitalConfig>
         extends GpioConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalEvent.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalEvent.java
@@ -32,6 +32,9 @@ import com.pi4j.event.Event;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
+ * @param <DIGITAL_TYPE>
+ * @param <PROVIDER_TYPE>
  */
 public interface DigitalEvent<DIGITAL_TYPE extends Digital<DIGITAL_TYPE, CONFIG_TYPE, PROVIDER_TYPE>,
         CONFIG_TYPE extends DigitalConfig<CONFIG_TYPE>,

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalListener.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalListener.java
@@ -32,6 +32,7 @@ import com.pi4j.event.Listener;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <EVENT_TYPE>
  */
 public interface DigitalListener<EVENT_TYPE extends DigitalEvent> extends Listener {
     // MARKER INTERFACE

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalProvider.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalProvider.java
@@ -32,6 +32,9 @@ import com.pi4j.io.gpio.GpioProvider;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
+ * @param <DIGITAL_TYPE>
+ * @param <PROVIDER_TYPE>
  */
 public interface DigitalProvider<PROVIDER_TYPE extends DigitalProvider, DIGITAL_TYPE extends Digital, CONFIG_TYPE extends DigitalConfig>
         extends GpioProvider<PROVIDER_TYPE, DIGITAL_TYPE, CONFIG_TYPE> {

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalProviderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalProviderBase.java
@@ -31,6 +31,9 @@ import com.pi4j.io.gpio.GpioProviderBase;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
+ * @param <DIGITAL_TYPE>
+ * @param <PROVIDER_TYPE>
  */
 public abstract class DigitalProviderBase<
             PROVIDER_TYPE extends DigitalProvider,

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalStateChangeEvent.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalStateChangeEvent.java
@@ -32,6 +32,7 @@ package com.pi4j.io.gpio.digital;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <DIGITAL_TYPE>
  */
 public class DigitalStateChangeEvent<DIGITAL_TYPE extends Digital> implements DigitalEvent {
 

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalInputConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalInputConfigBuilder.java
@@ -52,6 +52,7 @@ public class DefaultDigitalInputConfigBuilder
     /**
      * <p>newInstance.</p>
      *
+     * @param context
      * @return a {@link com.pi4j.io.gpio.digital.DigitalInputConfigBuilder} object.
      */
     public static DigitalInputConfigBuilder newInstance(Context context) {

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalOutputBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalOutputBuilder.java
@@ -48,7 +48,12 @@ public class DefaultDigitalOutputBuilder implements DigitalOutputBuilder {
     private String providerId = null;
     private Class<? extends Provider> providerClass = null;
 
-    /** {@inheritDoc} */
+    /**
+     * Creates a new instance of {@link DefaultDigitalOutputBuilder} with the specified context.
+     *
+     * @param context the context used to initialize the digital output
+     * @return a new instance of {@link DigitalOutputBuilder}
+     */
     public static DigitalOutputBuilder newInstance(Context context) {
         return new DefaultDigitalOutputBuilder(context);
     }

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalOutputConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalOutputConfigBuilder.java
@@ -50,6 +50,7 @@ public class DefaultDigitalOutputConfigBuilder
     /**
      * <p>newInstance.</p>
      *
+     * @param context
      * @return a {@link com.pi4j.io.gpio.digital.DigitalOutputConfigBuilder} object.
      */
     public static DigitalOutputConfigBuilder newInstance(Context context) {

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DigitalConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DigitalConfigBuilderBase.java
@@ -36,6 +36,8 @@ import com.pi4j.io.impl.IOAddressConfigBuilderBase;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BUILDER_TYPE>
+ * @param <CONFIG_TYPE>
  */
 public abstract class DigitalConfigBuilderBase<BUILDER_TYPE extends DigitalConfigBuilder, CONFIG_TYPE extends DigitalConfig>
         extends IOAddressConfigBuilderBase<BUILDER_TYPE, CONFIG_TYPE>

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2C.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2C.java
@@ -186,6 +186,8 @@ public interface I2C
      * Executes the given runnable on the I2C bus, locking the bus for the duration of the given task
      *
      * @param action the action to perform, returning a value
+     * @param <T>
+     * @return
      */
     <T> T execute(Callable<T> action);
 }

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBase.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Callable;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <T>
  */
 public abstract class I2CBase<T extends I2CBus> extends IOBase<I2C, I2CConfig, I2CProvider> implements I2C {
 

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CRegisterDataReaderWriter.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CRegisterDataReaderWriter.java
@@ -29,7 +29,7 @@ package com.pi4j.io.i2c;
  * I2C Register Data Writer Interface for Pi4J Data Communications
  *
  * @author Robert Savage
- *
+ * <p>
  * Based on previous contributions from:
  *        Daniel Sendula,
  *        <a href="http://raspelikan.blogspot.co.at">RasPelikan</a>

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CRegisterDataWriter.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CRegisterDataWriter.java
@@ -38,7 +38,7 @@ import java.util.Collection;
  * I2C Register Data Writer Interface for Pi4J Data Communications
  *
  * @author Robert Savage
- *
+ * <p>
  * Based on previous contributions from:
  *        Daniel Sendula,
  *        <a href="http://raspelikan.blogspot.co.at">RasPelikan</a>
@@ -196,7 +196,7 @@ public interface I2CRegisterDataWriter {
     /**
      * Write a buffer of byte values starting from a given offset index in the
      * array up to the provided length to a specific I2C device register.
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is no
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is
@@ -224,7 +224,7 @@ public interface I2CRegisterDataWriter {
     /**
      * Write a buffer of byte values starting from the first byte in the buffer
      * up to the provided length to a specific I2C device register.
-     *
+     * <p>
      * NOTE:  The contents from the byte buffer is read
      *        from the current position index up to the length
      *        requested or up to the buffer's remaining limit;
@@ -253,7 +253,7 @@ public interface I2CRegisterDataWriter {
 
     /**
      * Write a buffer of byte values (all bytes in buffer) to a specific I2C device register.
-     *
+     * <p>
      * NOTE:  The contents from the byte buffer is read
      *        from the current position index up to the buffer's
      *        remaining limit.  If the buffer's current position
@@ -278,7 +278,7 @@ public interface I2CRegisterDataWriter {
 
     /**
      * Write multiple byte buffers to a specific I2C device register.
-     *
+     * <p>
      * NOTE:  The contents from each byte buffer is read
      *        from the current position index up to the buffer's
      *        remaining limit.  If the buffer's current position
@@ -615,7 +615,7 @@ public interface I2CRegisterDataWriter {
     /**
      * Writes a character buffer with a given offset and length using a specified
      * character set to encode the chars into bytes to a specific I2C device register.
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is no
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is
@@ -646,7 +646,7 @@ public interface I2CRegisterDataWriter {
     /**
      * Write a character buffer starting at first index to a given length using
      * a specified character set to encode the chars into bytes to a specific I2C device register.
-     *
+     * <p>
      * NOTE:  The contents from the character buffer is read
      *        from the current position index up to the length
      *        requested or up to the buffer's remaining limit;
@@ -677,7 +677,7 @@ public interface I2CRegisterDataWriter {
     /**
      * Write a character buffer using a specified character set
      * to encode the chars into bytes to a specific I2C device register.
-     *
+     * <p>
      * NOTE:  The contents from the character buffer is read
      *        from the current position index up to the buffer's
      *        remaining limit.  If the buffer's current position
@@ -704,7 +704,7 @@ public interface I2CRegisterDataWriter {
     /**
      * Writes multiple character buffers using a specified character
      * set to encode the chars into bytes to a specific I2C device register.
-     *
+     * <p>
      * NOTE:  The contents from each character buffer is read
      *        from the current position index up to the buffer's
      *        remaining limit.  If the buffer's current position

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/DefaultI2CConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/DefaultI2CConfigBuilder.java
@@ -50,6 +50,7 @@ public class DefaultI2CConfigBuilder
     /**
      * <p>newInstance.</p>
      *
+     * @param context
      * @return a {@link com.pi4j.io.i2c.I2CConfigBuilder} object.
      */
     public static I2CConfigBuilder newInstance(Context context) {

--- a/pi4j-core/src/main/java/com/pi4j/io/impl/IOAddressConfigBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/impl/IOAddressConfigBase.java
@@ -37,6 +37,7 @@ import java.util.Map;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
  */
 public class IOAddressConfigBase<CONFIG_TYPE extends Config>
         extends AddressConfigBase<CONFIG_TYPE>

--- a/pi4j-core/src/main/java/com/pi4j/io/impl/IOAddressConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/impl/IOAddressConfigBuilderBase.java
@@ -40,6 +40,8 @@ import com.pi4j.provider.Provider;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BUILDER_TYPE>
+ * @param <CONFIG_TYPE>
  */
 public abstract class IOAddressConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder, CONFIG_TYPE extends Config>
         extends AddressConfigBuilderBase<BUILDER_TYPE, CONFIG_TYPE>

--- a/pi4j-core/src/main/java/com/pi4j/io/impl/IOConfigBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/impl/IOConfigBase.java
@@ -36,6 +36,7 @@ import java.util.Map;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
  */
 public abstract class IOConfigBase<CONFIG_TYPE extends Config> extends ConfigBase<CONFIG_TYPE> implements IOConfig<CONFIG_TYPE> {
 

--- a/pi4j-core/src/main/java/com/pi4j/io/impl/IOConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/impl/IOConfigBuilderBase.java
@@ -39,6 +39,8 @@ import com.pi4j.provider.Provider;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BUILDER_TYPE>
+ * @param <CONFIG_TYPE>
  */
 public abstract class IOConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder, CONFIG_TYPE extends Config>
         extends ConfigBuilderBase<BUILDER_TYPE, CONFIG_TYPE>

--- a/pi4j-core/src/main/java/com/pi4j/io/impl/IODeviceConfigBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/impl/IODeviceConfigBase.java
@@ -37,6 +37,7 @@ import java.util.Map;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
  */
 public class IODeviceConfigBase<CONFIG_TYPE extends Config<CONFIG_TYPE>>
         extends DeviceConfigBase<CONFIG_TYPE>

--- a/pi4j-core/src/main/java/com/pi4j/io/impl/IODeviceConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/impl/IODeviceConfigBuilderBase.java
@@ -40,6 +40,8 @@ import com.pi4j.provider.Provider;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <BUILDER_TYPE>
+ * @param <CONFIG_TYPE>
  */
 public abstract class IODeviceConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder, CONFIG_TYPE extends Config>
         extends DeviceConfigBuilderBase<BUILDER_TYPE, CONFIG_TYPE>

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/Pwm.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/Pwm.java
@@ -209,7 +209,7 @@ public interface Pwm extends IO<Pwm, PwmConfig, PwmProvider>, OnOff<Pwm> {
      *  period.  The duty-cycle range is valid from 0 to 100 including
      *  factional values. (Values above 50% mean the signal will remain
      *  HIGH more time than LOW.)
-     *
+     * <p>
      *  Example: A value of 50 represents a duty-cycle where half of
      *  the time period the signal is LOW and the other half is HIGH.
      *
@@ -224,7 +224,7 @@ public interface Pwm extends IO<Pwm, PwmConfig, PwmProvider>, OnOff<Pwm> {
      *  period.  The duty-cycle range is valid from 0 to 100 including
      *  factional values. (Values above 50% mean the signal will remain
      *  HIGH more time than LOW.)
-     *
+     * <p>
      *  Example: A value of 50 represents a duty-cycle where half of
      *  the time period the signal is LOW and the other half is HIGH.
      *
@@ -242,7 +242,7 @@ public interface Pwm extends IO<Pwm, PwmConfig, PwmProvider>, OnOff<Pwm> {
      *  'Pwm::On()' method.  Call 'Pwm::On()' if you wish to make a live/
      *  immediate change to the duty-cycle on an existing PWM signal.
      *  (Values above 50% mean the signal will remain HIGH more time than LOW.)
-     *
+     * <p>
      *  Example: A value of 50 represents a duty-cycle where half of
      *  the time period the signal is LOW and the other half is HIGH.
      *
@@ -260,7 +260,7 @@ public interface Pwm extends IO<Pwm, PwmConfig, PwmProvider>, OnOff<Pwm> {
      *  'Pwm::On()' method.  Call 'Pwm::On()' if you wish to make a live/
      *  immediate change to the duty-cycle on an existing PWM signal.
      *  (Values above 50% mean the signal will remain HIGH more time than LOW.)
-     *
+     * <p>
      *  Example: A value of 50 represents a duty-cycle where half of
      *  the time period the signal is LOW and the other half is HIGH.
      *
@@ -274,7 +274,7 @@ public interface Pwm extends IO<Pwm, PwmConfig, PwmProvider>, OnOff<Pwm> {
      *  Get the configured frequency value in Hertz (number of cycles per second)
      *  that the PWM signal generator should attempt to output when the PWM signal
      *  is turned 'ON'.
-     *
+     * <p>
      *  Please note that certain PWM signal generators may be limited to specific
      *  frequency bands and may not generate all possible explicit frequency values.
      *  After enabling the PWM signal using the 'on(..) method, you can check the
@@ -291,7 +291,7 @@ public interface Pwm extends IO<Pwm, PwmConfig, PwmProvider>, OnOff<Pwm> {
      *  Get the configured frequency value in Hertz (number of cycles per second)
      *  that the PWM signal generator should attempt to output when the PWM signal
      *  is turned 'ON'.
-     *
+     * <p>
      *  Please note that certain PWM signal generators may be limited to specific
      *  frequency bands and may not generate all possible explicit frequency values.
      *  After enabling the PWM signal using the 'on(...)' method, you can check the
@@ -307,7 +307,7 @@ public interface Pwm extends IO<Pwm, PwmConfig, PwmProvider>, OnOff<Pwm> {
     /**
      *  Get the actual frequency value in Hertz (number of cycles per second)
      *  applied by the PWM signal generator after the PWM signal is turned 'ON'.
-     *
+     * <p>
      *  Please note that certain PWM signal generators may be limited to specific
      *  frequency bands and may not generate all possible explicit frequency values.
      *  After enabling the PWM signal using the 'on(...)' method, you can call this
@@ -322,7 +322,7 @@ public interface Pwm extends IO<Pwm, PwmConfig, PwmProvider>, OnOff<Pwm> {
     /**
      *  Get the actual frequency value in Hertz (number of cycles per second)
      *  applied by the PWM signal generator after the PWM signal is turned 'ON'.
-     *
+     * <p>
      *  Please note that certain PWM signal generators may be limited to specific
      *  frequency bands and may not generate all possible explicit frequency values.
      *  After enabling the PWM signal using the 'on(...)' method, you can call this
@@ -337,7 +337,7 @@ public interface Pwm extends IO<Pwm, PwmConfig, PwmProvider>, OnOff<Pwm> {
     /**
      *  Set the configured frequency value in Hertz (number of cycles per second)
      *  that the PWM signal generator should use when the PWM signal is turned 'ON'.
-     *
+     * <p>
      *  Note: This method will not update a live PWM signal, but rather stage the
      *  frequency value for subsequent call to the 'Pwm::On()' method.  Call 'Pwm::On()'
      *  if you wish to make a live/immediate change to the duty-cycle on an existing
@@ -351,7 +351,7 @@ public interface Pwm extends IO<Pwm, PwmConfig, PwmProvider>, OnOff<Pwm> {
     /**
      *  Set the configured frequency value in Hertz (number of cycles per second)
      *  that the PWM signal generator should use when the PWM signal is turned 'ON'.
-     *
+     * <p>
      *  Note: This method will not update a live PWM signal, but rather stage the
      *  frequency value for subsequent call to the 'Pwm::On()' method.  Call 'Pwm::On()'
      *  if you wish to make a live/immediate change to the duty-cycle on an existing

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmConfig.java
@@ -56,7 +56,7 @@ public interface PwmConfig extends GpioConfig<PwmConfig>, AddressConfig<PwmConfi
      *  the percentage of the ON vs OFF time of the PWM signal for each period.
      *  The duty-cycle range is valid from 0 to 100 including factional values.
      *  (Values above 50% mean the signal will remain HIGH more time than LOW.)
-     *
+     * <p>
      *  Example: A value of 50 represents a duty-cycle where half of
      *  the time period the signal is LOW and the other half is HIGH.
      *
@@ -69,7 +69,7 @@ public interface PwmConfig extends GpioConfig<PwmConfig>, AddressConfig<PwmConfi
      *  the percentage of the ON vs OFF time of the PWM signal for each period.
      *  The duty-cycle range is valid from 0 to 100 including factional values.
      *  (Values above 50% mean the signal will remain HIGH more time than LOW.)
-     *
+     * <p>
      *  Example: A value of 50 represents a duty-cycle where half of
      *  the time period the signal is LOW and the other half is HIGH.
      *
@@ -146,7 +146,7 @@ public interface PwmConfig extends GpioConfig<PwmConfig>, AddressConfig<PwmConfi
     /**
      * Get configured PWM duty-cycle value that is automatically applied
      * to the PWM instance when the Pi4J context is shutdown.
-     *
+     * <p>
      * This option can be helpful if you wish to do something like stop a PWM
      * signal (by configuring this 'shutdown' value to zero) when your application
      * is terminated an Pi4J is shutdown.
@@ -159,7 +159,7 @@ public interface PwmConfig extends GpioConfig<PwmConfig>, AddressConfig<PwmConfi
     /**
      * Get configured PWM duty-cycle value that is automatically applied
      * to the PWM instance when the Pi4J context is shutdown.
-     *
+     * <p>
      * This option can be helpful if you wish to do something like stop a PWM
      * signal (by configuring this 'shutdown' value to zero) when your application
      * is terminated an Pi4J is shutdown.
@@ -199,7 +199,7 @@ public interface PwmConfig extends GpioConfig<PwmConfig>, AddressConfig<PwmConfi
     /**
      * Get configured PWM duty-cycle value that is automatically applied to
      * the PWM instance when this PWM instance is created and initialized.
-     *
+     * <p>
      * This option can be helpful if you wish to do something like set a default PWM
      * signal (by configuring this 'initial' value to 50%) when your application
      * creates the PWM instance.  This just helps eliminate a second line of code
@@ -213,7 +213,7 @@ public interface PwmConfig extends GpioConfig<PwmConfig>, AddressConfig<PwmConfi
     /**
      * Get configured PWM duty-cycle value that is automatically applied to
      * the PWM instance when this PWM instance is created and initialized.
-     *
+     * <p>
      * This option can be helpful if you wish to do something like set a default PWM
      * signal (by configuring this 'initial' value to 50%) when your application
      * creates the PWM instance.  This just helps eliminate a second line of code

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmConfigBuilder.java
@@ -50,7 +50,7 @@ public interface PwmConfigBuilder extends GpioConfigBuilder<PwmConfigBuilder, Pw
      *  Set the configured frequency value in Hertz (number of cycles per second)
      *  that the PWM signal generator should attempt to output when the PWM state
      *  is enabled.
-     *
+     * <p>
      *  Please note that certain PWM signal generators may be limited to specific
      *  frequency bands and may not generate all possible explicit frequency values.
      *  After enabling the PWM signal using the 'on(...)' method, you can check the
@@ -68,7 +68,7 @@ public interface PwmConfigBuilder extends GpioConfigBuilder<PwmConfigBuilder, Pw
      *  period.  The duty-cycle range is valid from 0 to 100 including
      *  factional values.  (Values above 50% mean the signal will
      *  remain HIGH more time than LOW.)
-     *
+     * <p>
      *  Example: A value of 50 represents a duty-cycle where half of
      *  the time period the signal is LOW and the other half is HIGH.
      *

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmPreset.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmPreset.java
@@ -67,7 +67,7 @@ public interface PwmPreset {
      *  period.  The duty-cycle range is valid from 0 to 100 including
      *  factional values. (Values above 50% mean the signal will
      *  remain HIGH more time than LOW.)
-     *
+     * <p>
      *  Example: A value of 50 represents a duty-cycle where half of
      *  the time period the signal is LOW and the other half is HIGH.
      *
@@ -81,7 +81,7 @@ public interface PwmPreset {
      *  period.  The duty-cycle range is valid from 0 to 100 including
      *  factional values.  (Values above 50% mean the signal will
      *  remain HIGH more time than LOW.)
-     *
+     * <p>
      *  Example: A value of 50 represents a duty-cycle where half of
      *  the time period the signal is LOW and the other half is HIGH.
      *
@@ -95,7 +95,7 @@ public interface PwmPreset {
      *  Get the configured frequency value in Hertz (number of cycles per second)
      *  that the PWM signal generator should attempt to output when this preset
      *  is applied to a PWM instance.
-     *
+     * <p>
      *  Please note that certain PWM signal generators may be limited to specific
      *  frequency bands and may not generate all possible explicit frequency values.
      *  After enabling the PWM signal using the 'on(...)' method, you can check the
@@ -111,7 +111,7 @@ public interface PwmPreset {
      *  Get the configured frequency value in Hertz (number of cycles per second)
      *  that the PWM signal generator should attempt to output when this preset
      *  is applied to a PWM instance.
-     *
+     * <p>
      *  Please note that certain PWM signal generators may be limited to specific
      *  frequency bands and may not generate all possible explicit frequency values.
      *  After enabling the PWM signal using the 'on(...)' method, you can check the

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmPresetBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmPresetBuilder.java
@@ -51,7 +51,7 @@ public interface PwmPresetBuilder extends Builder<PwmPreset> {
      *  period.  The duty-cycle range is valid from 0 to 100 including
      *  factional values.  (Values above 50% mean the signal will
      *  remain HIGH more time than LOW.)
-     *
+     * <p>
      *  Example: A value of 50 represents a duty-cycle where half of
      *  the time period the signal is LOW and the other half is HIGH.
      *
@@ -64,7 +64,7 @@ public interface PwmPresetBuilder extends Builder<PwmPreset> {
      *  Set the configured frequency value in Hertz (number of cycles per second)
      *  that the PWM signal generator should attempt to output when this preset
      *  is applied to a PWM instance.
-     *
+     * <p>
      *  Please note that certain PWM signal generators may be limited to specific
      *  frequency bands and may not generate all possible explicit frequency values.
      *  After enabling the PWM signal using the 'on(...)' method, you can check the

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/impl/DefaultPwmConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/impl/DefaultPwmConfigBuilder.java
@@ -54,6 +54,7 @@ public class DefaultPwmConfigBuilder
     /**
      * <p>newInstance.</p>
      *
+     * @param context
      * @return a {@link com.pi4j.io.pwm.PwmConfigBuilder} object.
      */
     public static PwmConfigBuilder newInstance(Context context) {

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/impl/DefaultPwmPresetBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/impl/DefaultPwmPresetBuilder.java
@@ -48,7 +48,12 @@ public class DefaultPwmPresetBuilder implements PwmPresetBuilder{
         super(); this.name = name;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * Creates a new instance of {@link DefaultPwmPresetBuilder} with the specified name.
+     *
+     * @param name the name of the PWM preset
+     * @return a new {@link PwmPresetBuilder} instance
+     */
     public static PwmPresetBuilder newInstance(String name) {
         return new DefaultPwmPresetBuilder(name);
     }

--- a/pi4j-core/src/main/java/com/pi4j/io/serial/impl/DefaultSerialConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/serial/impl/DefaultSerialConfigBuilder.java
@@ -49,6 +49,7 @@ public class DefaultSerialConfigBuilder
     /**
      * <p>newInstance.</p>
      *
+     * @param context
      * @return a {@link com.pi4j.io.serial.SerialConfigBuilder} object.
      */
     public static SerialConfigBuilder newInstance(Context context) {

--- a/pi4j-core/src/main/java/com/pi4j/io/spi/Spi.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/Spi.java
@@ -223,7 +223,7 @@ public interface Spi extends IO<Spi, SpiConfig, SpiProvider>, AutoCloseable, IOD
      * using the same length ('numberOfBytes').  Both the 'write' and 'read' byte buffers must
      * at least have the available capacity of the defined 'numberOfBytes' + their corresponding
      * offsets.
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is not
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is
@@ -274,7 +274,7 @@ public interface Spi extends IO<Spi, SpiConfig, SpiProvider>, AutoCloseable, IOD
      * current position using the same length ('numberOfBytes').  Both the 'write' and 'read'
      * byte buffers must at least have the available capacity of the defined 'numberOfBytes' +
      * their corresponding current positions.
-     *
+     * <p>
      * NOTE:  The contents from the 'write' byte buffer is read
      *        from the current position index up to the length
      *        requested or up to the buffer's remaining limit;
@@ -282,7 +282,7 @@ public interface Spi extends IO<Spi, SpiConfig, SpiProvider>, AutoCloseable, IOD
      *        position is already at the buffer's limit, then we
      *        will automatically flip the buffer to begin reading
      *        data from the zero position up to the buffer's limit     *
-     *
+     * <p>
      * NOTE:  The data bytes read from the SPI device are copied/
      *        inserted into the 'read' byte buffer starting at the current
      *        position index up to the length requested or up to the
@@ -321,7 +321,7 @@ public interface Spi extends IO<Spi, SpiConfig, SpiProvider>, AutoCloseable, IOD
      * read from the SPI device is then copied to the byte buffer at the given 'offset'
      * using the same length (number of bytes). The byte buffer must at least have the
      * available capacity of the defined 'length' + 'offset'.
-     *
+     * <p>
      * NOTE:  The buffer's internal position tracking is not
      *        used but rather only the explicit offset and
      *        length provided.  If the requested length is

--- a/pi4j-core/src/main/java/com/pi4j/io/spi/impl/DefaultSpiConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/impl/DefaultSpiConfigBuilder.java
@@ -49,6 +49,7 @@ public class DefaultSpiConfigBuilder
     /**
      * <p>newInstance.</p>
      *
+     * @param context
      * @return a {@link com.pi4j.io.spi.SpiConfigBuilder} object.
      */
     public static SpiConfigBuilder newInstance(Context context) {

--- a/pi4j-core/src/main/java/com/pi4j/platform/PlatformBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/platform/PlatformBase.java
@@ -53,6 +53,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <PLATFORM>
  */
 public abstract class PlatformBase<PLATFORM extends Platform>
         extends ExtensionBase<Platform>

--- a/pi4j-core/src/main/java/com/pi4j/provider/Provider.java
+++ b/pi4j-core/src/main/java/com/pi4j/provider/Provider.java
@@ -42,6 +42,9 @@ import java.util.Map;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
+ * @param <IO_TYPE>
+ * @param <PROVIDER_TYPE>
  */
 public interface Provider<PROVIDER_TYPE extends Provider, IO_TYPE extends IO, CONFIG_TYPE extends Config> extends Extension<PROVIDER_TYPE> {
 

--- a/pi4j-core/src/main/java/com/pi4j/provider/ProviderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/provider/ProviderBase.java
@@ -42,6 +42,9 @@ import java.util.Map;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <CONFIG_TYPE>
+ * @param <IO_TYPE>
+ * @param <PROVIDER_TYPE>
  */
 public abstract class ProviderBase<PROVIDER_TYPE extends Provider, IO_TYPE extends IO, CONFIG_TYPE extends Config>
         extends ExtensionBase<PROVIDER_TYPE>

--- a/pi4j-core/src/main/java/com/pi4j/provider/ProviderGroup.java
+++ b/pi4j-core/src/main/java/com/pi4j/provider/ProviderGroup.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @param <T>
  */
 public class ProviderGroup<T extends Provider> implements Describable {
 

--- a/pi4j-test/src/main/java/com/pi4j/test/platform/TestPlatform.java
+++ b/pi4j-test/src/main/java/com/pi4j/test/platform/TestPlatform.java
@@ -30,7 +30,6 @@ import com.pi4j.platform.Platform;
 import com.pi4j.platform.PlatformBase;
 import com.pi4j.provider.Provider;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/internal/LinuxPwm.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/internal/LinuxPwm.java
@@ -71,6 +71,7 @@ public class LinuxPwm {
      * <p>Constructor for LinuxPwm.</p>
      *
      * @param systemPath a {@link String} object.
+     * @param chip
      * @param address a int.
      */
     public LinuxPwm(String systemPath, int chip, int address){

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalInputProvider.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalInputProvider.java
@@ -45,6 +45,7 @@ public interface LinuxFsDigitalInputProvider extends DigitalInputProvider {
     /**
      * <p>newInstance.</p>
      *
+     * @param gpioFileSystemPath
      * @return a {@link com.pi4j.plugin.linuxfs.provider.gpio.digital.LinuxFsDigitalInputProvider} object.
      */
     static LinuxFsDigitalInputProvider newInstance(String gpioFileSystemPath) {

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalInputProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalInputProviderImpl.java
@@ -46,6 +46,7 @@ public class LinuxFsDigitalInputProviderImpl extends DigitalInputProviderBase im
 
     /**
      * <p>Constructor for LinuxFsDigitalInputProviderImpl.</p>
+     * @param gpioFileSystemPath
      */
     public LinuxFsDigitalInputProviderImpl(String gpioFileSystemPath) {
         this.id = ID;

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalOutputProvider.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalOutputProvider.java
@@ -45,6 +45,7 @@ public interface LinuxFsDigitalOutputProvider extends DigitalOutputProvider {
     /**
      * <p>newInstance.</p>
      *
+     * @param gpioFileSystemPath
      * @return a {@link com.pi4j.plugin.linuxfs.provider.gpio.digital.LinuxFsDigitalOutputProvider} object.
      */
     static LinuxFsDigitalOutputProvider newInstance(String gpioFileSystemPath) {

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalOutputProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalOutputProviderImpl.java
@@ -47,6 +47,7 @@ public class LinuxFsDigitalOutputProviderImpl extends DigitalOutputProviderBase
 
     /**
      * <p>Constructor for LinuxFsDigitalOutputProviderImpl.</p>
+     * @param gpioFileSystemPath
      */
     public LinuxFsDigitalOutputProviderImpl(String gpioFileSystemPath) {
         this.id = ID;

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/i2c/LinuxFsI2C.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/i2c/LinuxFsI2C.java
@@ -47,6 +47,7 @@ public class LinuxFsI2C extends I2CBase<LinuxFsI2CBus> implements I2C {
     /**
      * <p>Constructor for PiGpioI2C.</p>
      *
+     * @param i2CBus
      * @param provider
      *     a {@link I2CProvider} object.
      * @param config

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmProvider.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmProvider.java
@@ -45,6 +45,8 @@ public interface LinuxFsPwmProvider extends PwmProvider {
     /**
      * <p>newInstance.</p>
      *
+     * @param pwmFileSystemPath
+     * @param pwmChip
      * @return a {@link LinuxFsPwmProvider} object.
      */
     static LinuxFsPwmProvider newInstance(String pwmFileSystemPath, int pwmChip) {
@@ -54,6 +56,7 @@ public interface LinuxFsPwmProvider extends PwmProvider {
     /**
      * <p>newInstance.</p>
      *
+     * @param pwmChip
      * @return a {@link LinuxFsPwmProvider} object.
      */
     static LinuxFsPwmProvider newInstance(int pwmChip) {

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmProviderImpl.java
@@ -51,6 +51,8 @@ public class LinuxFsPwmProviderImpl extends PwmProviderBase implements LinuxFsPw
 
     /**
      * <p>Constructor for LinuxFsPwmProviderImpl.</p>
+     * @param pwmFileSystemPath
+     * @param pwmChip
      */
     public LinuxFsPwmProviderImpl(String pwmFileSystemPath, int pwmChip) {
         this.id = ID;
@@ -67,6 +69,7 @@ public class LinuxFsPwmProviderImpl extends PwmProviderBase implements LinuxFsPw
 
     /**
      * <p>Constructor for LinuxFsPwmProviderImpl.</p>
+     * @param pwmFileSystemPath
      */
     public LinuxFsPwmProviderImpl(String pwmFileSystemPath) {
         this.id = ID;

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/gpio/digital/PiGpioDigitalInput.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/gpio/digital/PiGpioDigitalInput.java
@@ -67,7 +67,7 @@ public class PiGpioDigitalInput extends DigitalInputBase implements DigitalInput
 
     /**
      * PIGPIO Pin Change Event Handler
-     *
+     * <p>
      * This listener implementation will forward pin change events received from PIGPIO
      * to registered Pi4J 'DigitalChangeEvent' event listeners on this digital pin.
      */

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/spi/PiGpioSpi.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/spi/PiGpioSpi.java
@@ -53,22 +53,22 @@ public class PiGpioSpi extends SpiBase implements Spi {
      * @param piGpio a {@link com.pi4j.library.pigpio.PiGpio} object.
      * @param provider a {@link com.pi4j.io.spi.SpiProvider} object.
      * @param config a {@link com.pi4j.io.spi.SpiConfig} object.
-     *
+     * <p>
      * ------------------------------------------------------------------
      * spiFlags consists of the least significant 22 bits.
      * ------------------------------------------------------------------
      * 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0
      *  b  b  b  b  b  b  R  T  n  n  n  n  W  A u2 u1 u0 p2 p1 p0  m  m
-     *
+     * <p>
      * [mm]     defines the SPI mode.
      *          Warning: modes 1 and 3 do not appear to work on the auxiliary SPI.
-     *
+     * <p>
      *          Mode POL PHA
      *           0    0   0
      *           1    0   1
      *           2    1   0
      *           3    1   1
-     *
+     * <p>
      * [px]     is 0 if CEx is active low (default) and 1 for active high.
      * [ux]     is 0 if the CEx GPIO is reserved for SPI (default) and 1 otherwise.
      * [A]      is 0 for the main SPI, 1 for the auxiliary SPI.

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,7 @@
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
         <maven-bundle-plugin.version>5.1.2</maven-bundle-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+        <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
         <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
         <maven-gpg-plugin.version>3.2.1</maven-gpg-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
@@ -770,9 +771,29 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven-checkstyle-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>checkstyle-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>validate</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <failsOnError>true</failsOnError>
+                    <configLocation>config/checkstyle/checkstyle.xml</configLocation>
+                    <excludes>**/module-info.java</excludes>
+                    <outputFileFormat>plain</outputFileFormat>
+                    <consoleOutput>true</consoleOutput>
+                </configuration>
+            </plugin>
 		</plugins>
 	</build>
-
     <reporting>
         <plugins>
             <plugin>


### PR DESCRIPTION
This PR addresses various Checkstyle issues by ensuring that all missing Javadoc comments are added and improving the Checkstyle configuration to properly handle documentation-related rules.

### Summary of Changes:

-   **Javadoc Fixes**: Added missing Javadoc comments for methods, fields, and types. Specifically:
    -   Added `@param`, `@return`, and `@throws` tags where applicable.
    -   Corrected incorrect use of `@inheritDoc` tags for static methods.
    -   Updated Javadoc formatting to align with project standards.

### Additional Context:

-   The errors seen in the build were caused by a previous commit (`e530765`), which inadvertently introduced some violations in Javadoc documentation.

### Example Fix for Static Method:
Before:
```java
/** {@inheritDoc} */
public static DigitalOutputBuilder newInstance(Context context) {
    return new DefaultDigitalOutputBuilder(context);
}
```

After:
```java
/**
 * Creates a new instance of {@link DefaultDigitalOutputBuilder} with the specified context.
 *
 * @param context the context used to initialize the digital output
 * @return a new instance of {@link DigitalOutputBuilder}
 */
public static DigitalOutputBuilder newInstance(Context context) {
    return new DefaultDigitalOutputBuilder(context);
}
```

This fixes the invalid `@inheritDoc` tag usage and provides a detailed description of the method's behavior.
