### PR TITLE
Fix Javadoc Plugin Configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -506,11 +506,9 @@
                         <source>${java.version}</source>
                         <detectJavaApiLink>false</detectJavaApiLink>
                         <doclint>none</doclint>
-                        <!-- Add module options -->
-                        <additionalJOption>--add-modules</additionalJOption>
-                        <additionalJOption>ALL-MODULE-PATH</additionalJOption>
                         <!-- Optional: skip errors -->
                         <failOnError>false</failOnError>
+                        <additionalOptions>-Xdoclint:none</additionalOptions>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
This PR updates the Maven Javadoc Plugin configuration in the `pom.xml` to address issues with Javadoc generation and improve build stability.

#### **Key Changes**

1.  **Removed unnecessary module options:**

    -   Removed `--add-modules` and `ALL-MODULE-PATH` from `additionalJOption`, as they were not required and could cause issues in modular projects.
2.  **Added `-Xdoclint:none` option:**

    -   Suppresses all Javadoc lint warnings, such as missing `@param` descriptions, to streamline the build process.

#### **Benefits**

-   Simplifies and fixes the Javadoc Plugin configuration.
-   Avoids unnecessary warnings or errors during Javadoc generation.
-   Makes the configuration compatible with both modular and non-modular projects.