### PR TITLE
Build on pi requires Mock Providers be loaded for the test case execution

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/runtime/impl/DefaultRuntime.java
+++ b/pi4j-core/src/main/java/com/pi4j/runtime/impl/DefaultRuntime.java
@@ -282,11 +282,14 @@ public class DefaultRuntime implements Runtime {
                         plugin.initialize(DefaultPluginService.newInstance(this.context(), store));
 
                         // if auto-detect providers is enabled,
+                        //    OR
+                        // Detecting Mocks is enabled and this is a mock plugin
                         // then add any detected providers to the collection to load
-                        if (config.autoDetectProviders()) {
+                        if (config.autoDetectProviders() ||  (config.autoDetectMockPlugins() && plugin.isMock())) {
                             store.providers.forEach(provider -> addProvider(provider, providers));
                         }
 
+                   
                         // if auto-detect platforms is enabled,
                         // then add any detected platforms to the collection to load
                         if (config.autoDetectPlatforms()) {

--- a/pi4j-test/src/test/java/com/pi4j/test/context/ContextTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/context/ContextTest.java
@@ -51,7 +51,7 @@ public class ContextTest {
         // An auto context includes AUTO-DETECT BINDINGS enabled
         // which will load all detected Pi4J extension libraries
         // (Platforms and Providers) in the class path
-        pi4j = Pi4J.newAutoContext();
+        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().autoDetectPlatforms().build();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/io/i2c/I2CRawDataTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/i2c/I2CRawDataTest.java
@@ -67,7 +67,8 @@ public class I2CRawDataTest {
         // An auto context enabled AUTO-DETECT loading
         // which will load any detected Pi4J extension
         // libraries (Platforms and Providers) from the class path
-        pi4j = Pi4J.newAutoContext();
+        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().autoDetectPlatforms().build();
+
     }
 
     @AfterEach

--- a/pi4j-test/src/test/java/com/pi4j/test/io/i2c/I2CRegisterDataTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/i2c/I2CRegisterDataTest.java
@@ -68,7 +68,7 @@ public class I2CRegisterDataTest {
         // An auto context enabled AUTO-DETECT loading
         // which will load any detected Pi4J extension
         // libraries (Platforms and Providers) from the class path
-        pi4j = Pi4J.newAutoContext();
+        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().autoDetectPlatforms().build();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/io/spi/SpiRawDataTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/spi/SpiRawDataTest.java
@@ -66,7 +66,7 @@ public class SpiRawDataTest {
         // An auto context enabled AUTO-DETECT loading
         // which will load any detected Pi4J extension
         // libraries (Platforms and Providers) from the class path
-        pi4j = Pi4J.newAutoContext();
+        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().autoDetectPlatforms().build();
     }
 
     @AfterEach

--- a/pi4j-test/src/test/java/com/pi4j/test/platform/AutoPlatformsTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/platform/AutoPlatformsTest.java
@@ -48,7 +48,7 @@ public class AutoPlatformsTest {
         // An auto context includes AUTO-DETECT BINDINGS enabled
         // which will load all detected Pi4J extension libraries
         // (Platforms and Providers) in the class path
-        pi4j = Pi4J.newAutoContext();
+        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().autoDetectPlatforms().build();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/platform/ManualPlatformsTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/platform/ManualPlatformsTest.java
@@ -61,21 +61,7 @@ public class ManualPlatformsTest {
         // Initialize Pi4J with AUTO-DETECT disabled
         // we don't want to load any detected Pi4J extension
         // libraries (Platforms and Providers) from the class path
-        pi4j = Pi4J.newContextBuilder()
-
-                        // add any platforms that we want to work with
-                        .add(new MockPlatform())
-
-                        // add any providers that we want to work with
-                        .add(MockAnalogInputProvider.newInstance(),
-                             MockAnalogOutputProvider.newInstance(),
-                             MockDigitalInputProvider.newInstance(),
-                             MockDigitalOutputProvider.newInstance(),
-                             MockPwmProvider.newInstance(),
-                             MockI2CProvider.newInstance(),
-                             MockSpiProvider.newInstance(),
-                             MockSerialProvider.newInstance())
-                        .build();
+        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().autoDetectPlatforms().build();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/provider/AutoProvidersTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/provider/AutoProvidersTest.java
@@ -51,7 +51,7 @@ public class AutoProvidersTest {
         // An auto context includes AUTO-DETECT BINDINGS enabled
         // which will load all detected Pi4J extension libraries
         // (Platforms and Providers) in the class path
-        pi4j = Pi4J.newAutoContext();
+        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().autoDetectPlatforms().build();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryGetIoInstance.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryGetIoInstance.java
@@ -53,7 +53,7 @@ public class RegistryGetIoInstance {
         // An auto context includes AUTO-DETECT BINDINGS enabled
         // which will load all detected Pi4J extension libraries
         // (Platforms and Providers) in the class path
-        pi4j = Pi4J.newAutoContext();
+        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().autoDetectPlatforms().build();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
@@ -52,7 +52,7 @@ public class RegistryTest {
         // An auto context includes AUTO-DETECT BINDINGS enabled
         // which will load all detected Pi4J extension libraries
         // (Platforms and Providers) in the class path
-        pi4j = Pi4J.newAutoContext();
+        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().autoDetectPlatforms().build();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/runtime/RuntimeTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/runtime/RuntimeTest.java
@@ -52,7 +52,7 @@ public class RuntimeTest {
         // An auto context includes AUTO-DETECT BINDINGS enabled
         // which will load all detected Pi4J extension libraries
         // (Platforms and Providers) in the class path
-        Context pi4j = Pi4J.newAutoContext();
+        Context pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().autoDetectPlatforms().build();
 
         logger.info("-------------------------------------------------");
         logger.info("Pi4J CONTEXT <acquired via factory accessor>");


### PR DESCRIPTION
With recent provider priority and single IO-type restrictions,   Building pi4j on a Raspberry Pi failed the automatic build tests,

Fix was update the Context creation function used in the test cases and a change in Pi4J code base