### PR TITLE
Fix typo in JavaDoc: Correct return type reference in SpiConfig.newBuilder

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/spi/SpiConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/SpiConfig.java
@@ -49,7 +49,7 @@ public interface SpiConfig extends AddressConfig<SpiConfig>, IOConfig<SpiConfig>
      * <p>newBuilder.</p>
      *
      * @param context {@link Context}
-     * @return a {@link com.pi4j.io.i2c.I2CConfigBuilder} object.
+     * @return a {@link com.pi4j.io.spi.SpiConfigBuilder} object.
      */
     static SpiConfigBuilder newBuilder(Context context)  {
         return SpiConfigBuilder.newInstance(context);


### PR DESCRIPTION
This patch fixes a minor typo in the JavaDoc of the `SpiConfig.newBuilder` method. The return type was incorrectly documented as `I2CConfigBuilder`, which has now been corrected to `SpiConfigBuilder`.