### PR TITLE
Add Support for Throttled State Parsing and Retrieval

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/boardinfo/model/ThrottledState.java
+++ b/pi4j-core/src/main/java/com/pi4j/boardinfo/model/ThrottledState.java
@@ -28,6 +28,11 @@ package com.pi4j.boardinfo.model;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Enum representing the different throttling and under-voltage states of the Raspberry Pi board.
+ * Each enum value represents a specific condition that might be detected on the board, such as
+ * undervoltage, frequency capping, throttling, or temperature limits.
+ */
 public enum ThrottledState {
     UNDERVOLTAGE_DETECTED(0x1, "Undervoltage detected"),
     ARM_FREQUENCY_CAPPED(0x2, "ARM frequency capped"),
@@ -41,15 +46,31 @@ public enum ThrottledState {
     private final int value;
     private final String description;
 
+    /**
+     * Constructor for the ThrottledState enum.
+     *
+     * @param value The integer value representing the state.
+     * @param description A human-readable description of the state.
+     */
     ThrottledState(int value, String description) {
         this.value = value;
         this.description = description;
     }
 
+    /**
+     * Returns the integer value representing this throttled state.
+     *
+     * @return the integer value associated with the state.
+     */
     public int getValue() {
         return value;
     }
 
+    /**
+     * Returns a human-readable description of this throttled state.
+     *
+     * @return the description of the throttled state.
+     */
     public String getDescription() {
         return description;
     }
@@ -57,7 +78,7 @@ public enum ThrottledState {
     /**
      * Decodes a raw throttled state (as an integer) and returns a list of active {@link ThrottledState} enums.
      *
-     * @param rawState the raw throttled state (as an integer value, e.g., 0x50005).
+     * @param rawState the raw throttled state as an integer (e.g., 0x50005).
      * @return a list of active throttled states.
      */
     public static List<ThrottledState> decode(int rawState) {
@@ -71,9 +92,9 @@ public enum ThrottledState {
     }
 
     /**
-     * Returns a human-readable description of the active throttled states.
+     * Returns a human-readable description of the active throttled states based on the raw throttled state value.
      *
-     * @param rawState the raw throttled state (as an integer value, e.g., 0x50005).
+     * @param rawState the raw throttled state as an integer (e.g., 0x50005).
      * @return a description of the active throttled states.
      */
     public static String getActiveStatesDescription(int rawState) {

--- a/pi4j-core/src/main/java/com/pi4j/boardinfo/model/ThrottledState.java
+++ b/pi4j-core/src/main/java/com/pi4j/boardinfo/model/ThrottledState.java
@@ -1,0 +1,90 @@
+package com.pi4j.boardinfo.model;
+
+/*-
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: LIBRARY  :: Java Library (CORE)
+ * FILENAME      :  ThrottledState.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  https://pi4j.com/
+ * **********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+
+public enum ThrottledState {
+    UNDERVOLTAGE_DETECTED(0x1, "Undervoltage detected"),
+    ARM_FREQUENCY_CAPPED(0x2, "ARM frequency capped"),
+    CURRENTLY_THROTTLED(0x4, "Currently throttled"),
+    SOFT_TEMPERATURE_LIMIT_ACTIVE(0x8, "Soft temperature limit active"),
+    UNDERVOLTAGE_HAS_OCCURED(0x10000, "Undervoltage has occurred"),
+    ARM_FREQUENCY_CAPPING_HAS_OCCURED(0x20000, "ARM frequency capping has occurred"),
+    THROTTLING_HAS_OCCURED(0x40000, "Throttling has occurred"),
+    SOFT_TEMPERATURE_LIMIT_HAS_OCCURED(0x80000, "Soft temperature limit has occurred");
+
+    private final int value;
+    private final String description;
+
+    ThrottledState(int value, String description) {
+        this.value = value;
+        this.description = description;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Decodes a raw throttled state (as an integer) and returns a list of active {@link ThrottledState} enums.
+     *
+     * @param rawState the raw throttled state (as an integer value, e.g., 0x50005).
+     * @return a list of active throttled states.
+     */
+    public static List<ThrottledState> decode(int rawState) {
+        List<ThrottledState> activeStates = new ArrayList<>();
+        for (ThrottledState state : ThrottledState.values()) {
+            if ((rawState & state.getValue()) != 0) {
+                activeStates.add(state);
+            }
+        }
+        return activeStates;
+    }
+
+    /**
+     * Returns a human-readable description of the active throttled states.
+     *
+     * @param rawState the raw throttled state (as an integer value, e.g., 0x50005).
+     * @return a description of the active throttled states.
+     */
+    public static String getActiveStatesDescription(int rawState) {
+        List<ThrottledState> activeStates = decode(rawState);
+        StringBuilder description = new StringBuilder();
+        for (ThrottledState state : activeStates) {
+            if (description.length() > 0) {
+                description.append(", ");
+            }
+            description.append(state.getDescription());
+        }
+        return description.length() > 0 ? description.toString() : "No active throttled states";
+    }
+}

--- a/pi4j-core/src/main/java/com/pi4j/boardinfo/util/BoardInfoHelper.java
+++ b/pi4j-core/src/main/java/com/pi4j/boardinfo/util/BoardInfoHelper.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 
 import static com.pi4j.boardinfo.util.Command.CORE_VOLTAGE_COMMAND;
 import static com.pi4j.boardinfo.util.Command.TEMPERATURE_COMMAND;
+import static com.pi4j.boardinfo.util.Command.THROTTLED_STATE_COMMAND;
 import static com.pi4j.boardinfo.util.Command.UPTIME_COMMAND;
 import static com.pi4j.boardinfo.util.SystemProperties.ARCHITECTURE_DATA_MODEL;
 import static com.pi4j.boardinfo.util.SystemProperties.JAVA_RUNTIME_VERSION;
@@ -242,7 +243,8 @@ public class BoardInfoHelper {
             getTemperature(),
             getUptime(),
             getCoreVoltage(),
-            getMemTotal()
+            getMemTotal(),
+            getThrottledState()
         );
     }
 
@@ -280,6 +282,19 @@ public class BoardInfoHelper {
      */
     private static String getTemperature() {
         return execute(TEMPERATURE_COMMAND).getOutputMessage();
+    }
+
+    /**
+     * Retrieves the throttled state of the system.
+     * <p>
+     * This command uses the `vcgencmd get_throttled` utility to check for under-voltage,
+     * throttling, or frequency capping conditions on the board.
+     * </p>
+     *
+     * @return a string representing the throttled state of the system
+     */
+    public static String getThrottledState() {
+        return execute(THROTTLED_STATE_COMMAND).getOutputMessage();
     }
 }
 

--- a/pi4j-core/src/main/java/com/pi4j/boardinfo/util/Command.java
+++ b/pi4j-core/src/main/java/com/pi4j/boardinfo/util/Command.java
@@ -61,4 +61,19 @@ public interface Command {
      * </p>
      */
     String TEMPERATURE_COMMAND = "vcgencmd measure_temp";
+
+    /**
+     * Command to retrieve throttled state information.
+     * <p>
+     * This command uses the `vcgencmd` tool to query the throttled state of the system. The output provides
+     * details about under-voltage, throttling, and frequency capping conditions. It is useful for diagnosing
+     * power and thermal management issues.
+     * </p>
+     * <p>
+     * For more details on the bit interpretation of the output, see the
+     * <a href="https://www.raspberrypi.com/documentation/computers/os.html#get_throttled">
+     * Raspberry Pi documentation</a>.
+     * </p>
+     */
+    String THROTTLED_STATE_COMMAND = "vcgencmd get_throttled";
 }

--- a/pi4j-core/src/test/java/com/pi4j/boardinfo/model/ModelTest.java
+++ b/pi4j-core/src/test/java/com/pi4j/boardinfo/model/ModelTest.java
@@ -2,6 +2,8 @@ package com.pi4j.boardinfo.model;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -23,19 +25,30 @@ class ModelTest {
     void testBoardReadingParsing() {
         var boardReading = new BoardReading(
             "Raspberry Pi 4 Model B Rev 1.1",
-        "c03111",
+            "c03111",
             "temp=42.8'C",
             "08:06:15 up 85 days, 9:43, 0 users, load average: 0.00, 0.00, 0.00",
-        "volt=0.8563V",
-            "MemTotal: 3885396 kB"
-            );
+            "volt=0.8563V",
+            "MemTotal: 3885396 kB",
+            "throttled=0x3"
+        );
 
         assertAll(
             () -> assertEquals(42.8, boardReading.getTemperatureInCelsius(), "Temperature in Celsius"),
-            () -> assertEquals(109.03999999999999, boardReading.getTemperatureInFahrenheit(), "Temperature in Fahrenheit"),
-            () -> assertEquals(0.8563, boardReading.getVoltValue(), "Volt")
+            () -> assertEquals(109.04, boardReading.getTemperatureInFahrenheit(), 0.01, "Temperature in Fahrenheit"),
+            () -> assertEquals(0.8563, boardReading.getVoltValue(), "Volt"),
+            () -> assertEquals(3, boardReading.getThrottledStateAsInt(), "Throttled state as integer"), // Hex 0x3 to int
+            () -> assertEquals(List.of(ThrottledState.UNDERVOLTAGE_DETECTED, ThrottledState.ARM_FREQUENCY_CAPPED),
+                boardReading.getThrottledStates(),
+                "Throttled states as list of active ThrottledState enums"),
+            () -> assertEquals(
+                "Undervoltage detected, ARM frequency capped",
+                boardReading.getThrottledStatesDescription(),
+                "Throttled states description for active states"
+            )
         );
     }
+
 
     @Test
     void testMemoryParsing() {

--- a/pi4j-core/src/test/java/com/pi4j/boardinfo/model/ThrottledStateTest.java
+++ b/pi4j-core/src/test/java/com/pi4j/boardinfo/model/ThrottledStateTest.java
@@ -1,0 +1,103 @@
+package com.pi4j.boardinfo.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ThrottledStateTest {
+
+    @Test
+    void testDecodeThrottledStateUndervoltageDetected() {
+        int throttledStateInt = 0x1; // 0000000000000001 in binary
+        var activeStates = ThrottledState.decode(throttledStateInt);
+
+        assertAll(
+            () -> assertEquals(1, activeStates.size(), "Should only have 1 active state"),
+            () -> assertEquals(ThrottledState.UNDERVOLTAGE_DETECTED, activeStates.get(0), "Should be Undervoltage detected")
+        );
+    }
+
+    @Test
+    void testDecodeThrottledStateArmFrequencyCapped() {
+        int throttledStateInt = 0x2; // 0000000000000010 in binary
+        var activeStates = ThrottledState.decode(throttledStateInt);
+
+        assertAll(
+            () -> assertEquals(1, activeStates.size(), "Should only have 1 active state"),
+            () -> assertEquals(ThrottledState.ARM_FREQUENCY_CAPPED, activeStates.get(0), "Should be Arm frequency capped")
+        );
+    }
+
+    @Test
+    void testDecodeThrottledStateCurrentlyThrottled() {
+        int throttledStateInt = 0x4; // 0000000000000100 in binary
+        var activeStates = ThrottledState.decode(throttledStateInt);
+
+        assertAll(
+            () -> assertEquals(1, activeStates.size(), "Should only have 1 active state"),
+            () -> assertEquals(ThrottledState.CURRENTLY_THROTTLED, activeStates.get(0), "Should be Currently throttled")
+        );
+    }
+
+    @Test
+    void testDecodeCombinedThrottledStates() {
+        int throttledStateInt = 0x5; // 0000000000000101 in binary (Undervoltage detected + Currently throttled)
+        var activeStates = ThrottledState.decode(throttledStateInt);
+
+        assertAll(
+            () -> assertEquals(2, activeStates.size(), "Should have 2 active states"),
+            () -> assertEquals(ThrottledState.UNDERVOLTAGE_DETECTED, activeStates.get(0), "Should be Undervoltage detected"),
+            () -> assertEquals(ThrottledState.CURRENTLY_THROTTLED, activeStates.get(1), "Should be Currently throttled")
+        );
+    }
+
+    @Test
+    void testDecodeThrottledStateSoftTemperatureLimitActive() {
+        int throttledStateInt = 0x8; // 0000000000001000 in binary
+        var activeStates = ThrottledState.decode(throttledStateInt);
+
+        assertAll(
+            () -> assertEquals(1, activeStates.size(), "Should only have 1 active state"),
+            () -> assertEquals(ThrottledState.SOFT_TEMPERATURE_LIMIT_ACTIVE, activeStates.get(0), "Should be Soft temperature limit active")
+        );
+    }
+
+    @Test
+    void testThrottledStateDescription() {
+        int rawState = 0x50005; // rawState in hexadecimal: 0x50005 or 327685
+
+        // Breakdown of the bits that are set:
+        // 0x1 (bit 0): Undervoltage detected
+        // 0x4 (bit 2): Currently throttled
+        // 0x10000 (bit 16): Undervoltage has occurred
+        // 0x40000 (bit 18): Throttling has occurred
+
+        String description = ThrottledState.getActiveStatesDescription(rawState);
+
+        // Assert that the description contains the correct states based on the bits set
+        assertEquals(
+            "Undervoltage detected, Currently throttled, Undervoltage has occurred, Throttling has occurred",
+            description,
+            "Description should include the correct active states"
+        );
+    }
+
+    @Test
+    void testDecodeNoThrottledState() {
+        int throttledStateInt = 0x0; // 0000000000000000 (no bits set)
+        var activeStates = ThrottledState.decode(throttledStateInt);
+
+        assertAll(
+            () -> assertEquals(0, activeStates.size(), "Should have 0 active states")
+        );
+    }
+
+    @Test
+    void testDecodeAllThrottledStates() {
+        int throttledStateInt = 0xFFFFF; // All possible bits set
+        var activeStates = ThrottledState.decode(throttledStateInt);
+
+        assertEquals(8, activeStates.size(), "Should have 8 active states");
+    }
+}


### PR DESCRIPTION
This pull request introduces enhancements to the Pi4J library to support parsing and retrieving the throttled state of the Raspberry Pi, in line with the feedback provided in [Discussion #410](https://github.com/Pi4J/pi4j-v2/discussions/410). The `vcgencmd get_throttled` command is used to determine if the Raspberry Pi is currently experiencing under-voltage or throttling conditions. The interpretation of the hex result is aligned with the documentation found in [this Gist](https://gist.github.com/Paraphraser/17fb6320d0e896c6446fb886e1207c7e#the-vcgencmd_power_reportsh-script) and [raspberrypi documentation](https://www.raspberrypi.com/documentation/computers/os.html#get_throttled).

### Changes:

1.  **Throttled State Command**: Added a new constant `THROTTLED_STATE_COMMAND` to execute the `vcgencmd get_throttled` command, which retrieves the throttled state of the Raspberry Pi, identifying under-voltage conditions or throttling events.

2.  **Throttled State Parsing**:

    -   Introduced a new method `getThrottledState` in the `BoardInfoHelper` class to retrieve and parse the throttled state from the `vcgencmd` output.
    -   Added a `throttledState` field in the `BoardReading` class to store the raw throttled state as a string.
3.  **Throttled State Handling**:

    -   Implemented methods to decode the throttled state value as an integer (`getThrottledStateAsInt()`).
    -   Added functionality to parse the throttled state and convert it into a list of active `ThrottledState` enums (`getThrottledStates()`).
    -   Created a method to generate a human-readable description of active throttling states (`getThrottledStatesDescription()`).
4.  **New `ThrottledState` Enum**:

    -   Created a `ThrottledState` enum with constants for various throttling conditions (e.g., undervoltage, ARM frequency capping, and soft temperature limits).
    -   Introduced a `decode` method to convert raw integer values into human-readable throttling states.
5.  **Unit Tests**:

    -   Added a `ThrottledStateTest` class to validate the correct parsing and description of throttled states.
    -   Updated existing unit tests to verify the integration of throttled state parsing within the `BoardReading` model.