### PR TITLE
(Currently failing) Test for shutdown and re-creation

### DIFF
--- a/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.pi4j.Pi4J;
 import com.pi4j.context.Context;
 import com.pi4j.exception.Pi4JException;
+import com.pi4j.io.gpio.digital.DigitalInput;
 import com.pi4j.registry.Registry;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -70,5 +71,19 @@ public class RegistryTest {
         logger.info("Pi4J I/O REGISTRY <acquired via factory accessor>");
         logger.info("-------------------------------------------------");
         registry.describe().print(System.out);
+    }
+
+    @Test
+    public void testShutdownAndRecreate() throws Pi4JException {
+        var inputConfig = DigitalInput.newConfigBuilder(pi4j)
+                .id("DIN-3")
+                .name("DIN-3")
+                .address(3);
+
+        var input = pi4j.create(inputConfig);
+
+        input.shutdown(pi4j);
+
+        input = pi4j.create(inputConfig);
     }
 }


### PR DESCRIPTION
Illustrates that #40 isn't actually fixed.

I have tried to work around via manually calling config.shutdown(id). While this makes the registry problem disappear, I get a new error that seems to suggest that iobase.shutdown(config) doesn't actually release the corresponding resources properly. 