### PR TITLE
Fix minor bug with pulseAsync always pulsing high.

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalOutput.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalOutput.java
@@ -304,7 +304,7 @@ public interface DigitalOutput extends Digital<DigitalOutput, DigitalOutputConfi
      * @return a {@link java.util.concurrent.Future} object.
      */
     default Future<?> pulseAsync(int interval, TimeUnit unit, DigitalState state){
-        return pulseAsync(interval, unit, DigitalState.HIGH, null);
+        return pulseAsync(interval, unit, state, null);
     }
 
     /**


### PR DESCRIPTION
Fixes a minor bug in DigitalOutput where pulseAsync ignored the given state and always pulsed high.