### PR TITLE
 PWM linuxfs failed if the first interface call was off().  Fix is te…

### DIFF
--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwm.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwm.java
@@ -161,8 +161,10 @@ public class LinuxFsPwm extends PwmBase implements Pwm {
         try {
             // disable PWM
             logger.trace("disable PWM [{}]; {}", this.config.address(), pwm.getPwmPath());
-            if (pwm.enabled()) pwm.disable();
-
+            if (pwm.enabled()) {
+                pwm.disable();
+            }
+            
             // update tracking state
             this.onState = false;
         } catch (Exception e) {


### PR DESCRIPTION
…st if the accessed PWM address is enabled, is enabled normal code path, is not enabled do not attempt to disable.

The fix is line 164      The other edits are using the IDE to  Cleanup the file.     Looks like at creation my editor did not add a space between a "paren and brace"