### PR TITLE
SpiChipSelect located in the core code base contained code enforcing …

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/spi/SpiChipSelect.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/SpiChipSelect.java
@@ -31,8 +31,9 @@ package com.pi4j.io.spi;
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
  */
+@Deprecated
 public enum SpiChipSelect {
-    CS_0(0), CS_1(1), CS_2(2);
+    CS_0(0), CS_1(1), CS_2(2), CS_3(3), CS_4(4), CS_5(5), CS_6(6), CS_7(7), CS_8(8), CS_9(9), CS_10(10);
 
     private final int address;
 
@@ -84,6 +85,14 @@ public enum SpiChipSelect {
         if(bus.equalsIgnoreCase("0")) return SpiChipSelect.CS_0;
         if(bus.equalsIgnoreCase("1")) return SpiChipSelect.CS_1;
         if(bus.equalsIgnoreCase("2")) return SpiChipSelect.CS_2;
+        if(bus.equalsIgnoreCase("3")) return SpiChipSelect.CS_3;
+        if(bus.equalsIgnoreCase("4")) return SpiChipSelect.CS_4;
+        if(bus.equalsIgnoreCase("5")) return SpiChipSelect.CS_5;
+        if(bus.equalsIgnoreCase("6")) return SpiChipSelect.CS_6;
+        if(bus.equalsIgnoreCase("7")) return SpiChipSelect.CS_7;
+        if(bus.equalsIgnoreCase("8")) return SpiChipSelect.CS_8;
+        if(bus.equalsIgnoreCase("9")) return SpiChipSelect.CS_9;
+        if(bus.equalsIgnoreCase("10")) return SpiChipSelect.CS_10;
         return Spi.DEFAULT_CHIP_SELECT;
     }
 }

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/spi/LinuxFsSpi.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/spi/LinuxFsSpi.java
@@ -154,7 +154,7 @@ public class LinuxFsSpi extends SpiBase implements Spi {
         // /dev/spidevB.C ...
         //    character special device, major number 153 with a dynamically chosen minor device number.
         //    This is the node that userspace programs will open, created by “udev” or “mdev”.
-        String spiDev = SPI_DEVICE_BASE + config().bus().getBus() + "." + config().getChipSelect().getChipSelect();
+        String spiDev = SPI_DEVICE_BASE + config().bus().getBus() + "." + config().address();
         fd = libc.open(spiDev, LinuxLibC.O_RDWR);
         if (fd < 0) {
             throw new RuntimeException("Failed to open SPI device " + spiDev);

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/spi/PiGpioSpi.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/spi/PiGpioSpi.java
@@ -111,9 +111,11 @@ public class PiGpioSpi extends SpiBase implements Spi {
 
         // channel/address (chip-select) #2 is not supported on SPI_BUS_0 by PiGPIO
         if(bus == SpiBus.BUS_0 && config.address() == 2) {
-            throw new IOException("Unsupported SPI channel (chip select) on SPI BUS_0 bus: address=" + config.address() );
+            throw new IOException("Unsupported Pigpio SPI channel (chip select) on SPI BUS_0 bus: address=" + config.address() );
         }
-
+        if(config.address() > 2) {
+            throw new IOException("Unsupported Pigpio SPI channel (chip select) address greater than 2" + config.address() );
+        }
         // Comments on the PiGPIO web https://abyz.me.uk/rpi/pigpio/cif.html#spiOpen as follows:
         // "Warning: modes 1 and 3 do not appear to work on the auxiliary SPI."
         // SPI MODE_1 and MODE_3 are not supported on the AUX SPI BUS_1 by PiGPIO


### PR DESCRIPTION
…a Pigpio limitation of chipselect 0 1 2 only allowe values.  Move this limit check in the Pigpio provider. Update SpiChipSelect to support values 0 thru 10. If a client required more than 11 GPIOs dedicated to chipSelects I think they would instead use a single MCP23017 i2c chip to control the CS, and save all the GPIOs.   

I think the on-going rewrite to abandon JNA and JNI should either create a brand new Spi Config builder or tear the existing one apart.  At present the user can use address, channel or chipSelect to assign the spi channel. If all three attribute are used at once, the last one one the build command is used. This just adds to the confusion of using the GPIO or true channel number introduced in linuxfs-spi. 