### PR TITLE
linuxfs-i2c  registerRead using offset parm to place read data, faile…

### DIFF
--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/i2c/LinuxFsI2C.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/i2c/LinuxFsI2C.java
@@ -311,9 +311,9 @@ public class LinuxFsI2C extends I2CBase<LinuxFsI2CBus> implements I2C {
 
        this.i2CBus.executeIOCTL(this, command, ioctlData, offsets);
 
-        // move results back into user buffer
-        for (int i = 0; i < length; i++) {   // can I assume length is safe and the readBuff data is not shorter ??   I think yes
-            buffer[i] = ioctlData.get(readBuffPosition + i);
+        // move results back into user buffer. Location determined by user supplied offset
+        for (int i = 0; i < length; i++) {
+            buffer[i + offset] = ioctlData.get(readBuffPosition + i);
         }
 
         return readLength;


### PR DESCRIPTION
…d to use the 

My bug to ignore the user supplied offset


Intellij reformat would make many changes to the file.  I wanted to be certain of the correct format before letting the IDE rip.