### PR TITLE
when the RP1 chip is found, PWM provider will use the RP1 architected…

### DIFF
--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/LinuxFsPlugin.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/LinuxFsPlugin.java
@@ -29,24 +29,21 @@ package com.pi4j.plugin.linuxfs;
 
 
 import com.pi4j.boardinfo.util.BoardInfoHelper;
-import com.pi4j.boardinfo.util.command.CommandResult;
 import com.pi4j.extension.Plugin;
 import com.pi4j.extension.PluginService;
 import com.pi4j.plugin.linuxfs.internal.LinuxGpio;
-import com.pi4j.plugin.linuxfs.provider.i2c.LinuxFsI2CProvider;
+import com.pi4j.plugin.linuxfs.internal.LinuxPwm;
 import com.pi4j.plugin.linuxfs.provider.gpio.digital.LinuxFsDigitalInputProvider;
 import com.pi4j.plugin.linuxfs.provider.gpio.digital.LinuxFsDigitalOutputProvider;
+import com.pi4j.plugin.linuxfs.provider.i2c.LinuxFsI2CProvider;
 import com.pi4j.plugin.linuxfs.provider.pwm.LinuxFsPwmProvider;
-import com.pi4j.plugin.linuxfs.internal.LinuxPwm;
 import com.pi4j.plugin.linuxfs.provider.spi.LinuxFsSpiProvider;
 import com.pi4j.provider.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
 
-import static com.pi4j.boardinfo.util.command.CommandExecutor.execute;
-
+import static com.pi4j.plugin.linuxfs.provider.pwm.LinuxFsPwmUtil.getPWMChipForRP1;
 
 
 /**
@@ -66,11 +63,6 @@ public class LinuxFsPlugin implements Plugin {
      */
     public static final String ID = "linuxfs";
 
-//    // Analog Input (GPIO) Provider name and unique ID
-//    public static final String ANALOG_INPUT_PROVIDER_NAME = NAME + " Analog Input (GPIO) Provider";
-//    public static final String ANALOG_INPUT_PROVIDER_ID = ID + "-analog-input";
-
-    // Analog Output (GPIO) Provider name and unique ID
     /**
      * Constant <code>ANALOG_OUTPUT_PROVIDER_NAME="NAME +  Analog Output (GPIO) Provider"</code>
      */
@@ -108,11 +100,6 @@ public class LinuxFsPlugin implements Plugin {
     public static final String I2C_PROVIDER_NAME = NAME + " I2C Provider";
     public static final String I2C_PROVIDER_ID = ID + "-i2c";
 
-
-//    // Serial Provider name and unique ID
-//    public static final String SERIAL_PROVIDER_NAME = NAME + " Serial Provider";
-//    public static final String SERIAL_PROVIDER_ID = ID + "-serial";
-
     // SPI Provider name and unique ID
     public static final String SPI_PROVIDER_NAME = NAME + " SPI Provider";
     public static final String SPI_PROVIDER_ID = ID + "-spi";
@@ -133,57 +120,33 @@ public class LinuxFsPlugin implements Plugin {
         String pwmFileSystemPath = DEFAULT_PWM_FILESYSTEM_PATH;
 
         int pwmChip;
-        if(BoardInfoHelper.usesRP1()) {
-            pwmChip = LinuxPwm.DEFAULT_RP1_PWM_CHIP;
-            // init to original bookworm using pwmChip2, test if different
-            String command =  "ls -l " + pwmFileSystemPath  ;
-            CommandResult rslt = execute( command);
-
-            String[] paths =  rslt.getOutputMessage().split("\n");
-            int counter = 0;
-            for(counter = 0 ; counter < paths.length; counter ++ ) {
-                String chipNum = "";
-                String ChipName = "pwmchip";
-                //Test for the RP1 chip address for the user PWM channels
-                if (paths[counter].contains("1f00098000")) {
-                     int numStart = paths[counter].indexOf(ChipName) + ChipName.length() ;
-                     while( Character.isDigit(paths[counter].substring(numStart, numStart + 1).charAt(0)) ){
-                        chipNum = new StringBuilder().append(chipNum.substring(0, chipNum.length())).append(paths[counter].substring(numStart, numStart + 1)).toString();
-                        numStart ++;
-                    }
-                    pwmChip = Integer.parseInt(chipNum);
-                    break;
-                }
-            }
-
-            logger.debug(String.valueOf(pwmChip));
-            logger.debug(Arrays.toString(paths));
-
-        }else{
+        // if using a RP1,heck the device address to find the correct PWM chip
+        if (BoardInfoHelper.usesRP1()) {
+            pwmChip = getPWMChipForRP1(pwmFileSystemPath);
+        } else {
             pwmChip = LinuxPwm.DEFAULT_LEGACY_PWM_CHIP;
         }
 
         // [GPIO] get overriding custom 'linux.gpio.system.path' setting from Pi4J context
-        if(service.context().properties().has("linux.gpio.system.path")){
+        if (service.context().properties().has("linux.gpio.system.path")) {
             gpioFileSystemPath = service.context().properties().get("linux.gpio.system.path", gpioFileSystemPath);
         }
 
         // [PWM] get overriding custom 'linux.gpio.system.path' setting from Pi4J context
-        if(service.context().properties().has("linux.pwm.system.path")){
+        if (service.context().properties().has("linux.pwm.system.path")) {
             pwmFileSystemPath = service.context().properties().get("linux.pwm.system.path", pwmFileSystemPath);
         }
 
         // [PWM] get overriding custom 'linux.gpio.system.path' setting from Pi4J context
-        if(service.context().properties().has("linux.pwm.chip")){
+        if (service.context().properties().has("linux.pwm.chip")) {
             try {
                 pwmChip = Integer.parseInt(service.context().properties().get("linux.pwm.chip", Integer.toString(pwmChip)));
-            }
-            catch (Exception e){
+            } catch (Exception e) {
                 logger.error(e.getMessage(), e);
             }
         }
 
-        // create & define supported Linux file system I/O providers that will be exposed to Pi4J via this plugin
+        // Create & define supported Linux file system I/O providers that will be exposed to Pi4J via this plugin
         Provider[] providers = {
             LinuxFsDigitalInputProvider.newInstance(gpioFileSystemPath),
             LinuxFsDigitalOutputProvider.newInstance(gpioFileSystemPath),
@@ -195,4 +158,6 @@ public class LinuxFsPlugin implements Plugin {
         // register the LinuxFS I/O Providers with the plugin service
         service.register(providers);
     }
+
+
 }

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmProvider.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmProvider.java
@@ -45,8 +45,8 @@ public interface LinuxFsPwmProvider extends PwmProvider {
     /**
      * <p>newInstance.</p>
      *
-     * @param pwmFileSystemPath
-     * @param pwmChip
+     * @param pwmFileSystemPath     Path to PWM device tree
+     * @param pwmChip               Number of PWM chip in device tree
      * @return a {@link LinuxFsPwmProvider} object.
      */
     static LinuxFsPwmProvider newInstance(String pwmFileSystemPath, int pwmChip) {
@@ -56,7 +56,7 @@ public interface LinuxFsPwmProvider extends PwmProvider {
     /**
      * <p>newInstance.</p>
      *
-     * @param pwmChip
+     * @param pwmChip    Number of PWM chip in device tree
      * @return a {@link LinuxFsPwmProvider} object.
      */
     static LinuxFsPwmProvider newInstance(int pwmChip) {

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmProviderImpl.java
@@ -75,13 +75,21 @@ public class LinuxFsPwmProviderImpl extends PwmProviderBase implements LinuxFsPw
         this.id = ID;
         this.name = NAME;
         this.pwmFileSystemPath = pwmFileSystemPath;
+        // if a RP1, check the device address to find the correct pwmchip?
         if(BoardInfoHelper.usesRP1()) {
             this.pwmChip = LinuxPwm.DEFAULT_RP1_PWM_CHIP;
+
+
+
         }else{
             this.pwmChip = LinuxPwm.DEFAULT_LEGACY_PWM_CHIP;
         }
     }
 
+    private int findRp1Pwm(){
+        int rval =  LinuxPwm.DEFAULT_RP1_PWM_CHIP;
+        return rval;
+    }
     /**
      * {@inheritDoc}
      */

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmProviderImpl.java
@@ -36,6 +36,7 @@ import com.pi4j.io.pwm.PwmProviderBase;
 import com.pi4j.io.pwm.PwmType;
 import com.pi4j.plugin.linuxfs.internal.LinuxPwm;
 
+import static com.pi4j.plugin.linuxfs.provider.pwm.LinuxFsPwmUtil.getPWMChipForRP1;
 import static java.text.MessageFormat.format;
 
 /**
@@ -51,8 +52,9 @@ public class LinuxFsPwmProviderImpl extends PwmProviderBase implements LinuxFsPw
 
     /**
      * <p>Constructor for LinuxFsPwmProviderImpl.</p>
-     * @param pwmFileSystemPath
-     * @param pwmChip
+     *
+     * @param pwmFileSystemPath  Path to PWM device tree
+     * @param pwmChip            Number of PWM chip to use
      */
     public LinuxFsPwmProviderImpl(String pwmFileSystemPath, int pwmChip) {
         this.id = ID;
@@ -69,27 +71,27 @@ public class LinuxFsPwmProviderImpl extends PwmProviderBase implements LinuxFsPw
 
     /**
      * <p>Constructor for LinuxFsPwmProviderImpl.</p>
-     * @param pwmFileSystemPath
+     *
+     * @param pwmFileSystemPath  Path to PWM device tree
      */
     public LinuxFsPwmProviderImpl(String pwmFileSystemPath) {
         this.id = ID;
         this.name = NAME;
         this.pwmFileSystemPath = pwmFileSystemPath;
-        // if a RP1, check the device address to find the correct pwmchip?
-        if(BoardInfoHelper.usesRP1()) {
-            this.pwmChip = LinuxPwm.DEFAULT_RP1_PWM_CHIP;
 
-
-
-        }else{
+        // if a RP1,  check the device address to find the correct PWM chip
+        if (BoardInfoHelper.usesRP1()) {
+            this.pwmChip = getPWMChipForRP1(pwmFileSystemPath);
+        } else {
             this.pwmChip = LinuxPwm.DEFAULT_LEGACY_PWM_CHIP;
         }
     }
 
-    private int findRp1Pwm(){
-        int rval =  LinuxPwm.DEFAULT_RP1_PWM_CHIP;
+    private int findRp1Pwm() {
+        int rval = LinuxPwm.DEFAULT_RP1_PWM_CHIP;
         return rval;
     }
+
     /**
      * {@inheritDoc}
      */

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmProviderImpl.java
@@ -51,6 +51,7 @@ public class LinuxFsPwmProviderImpl extends PwmProviderBase implements LinuxFsPw
 
     /**
      * <p>Constructor for LinuxFsPwmProviderImpl.</p>
+     *
      * @param pwmFileSystemPath
      * @param pwmChip
      */
@@ -69,27 +70,27 @@ public class LinuxFsPwmProviderImpl extends PwmProviderBase implements LinuxFsPw
 
     /**
      * <p>Constructor for LinuxFsPwmProviderImpl.</p>
+     *
      * @param pwmFileSystemPath
      */
     public LinuxFsPwmProviderImpl(String pwmFileSystemPath) {
         this.id = ID;
         this.name = NAME;
         this.pwmFileSystemPath = pwmFileSystemPath;
-        // if a RP1, check the device address to find the correct pwmchip?
-        if(BoardInfoHelper.usesRP1()) {
+
+        // if a RP1, check the device address to find the correct PWM chip
+        if (BoardInfoHelper.usesRP1()) {
             this.pwmChip = LinuxPwm.DEFAULT_RP1_PWM_CHIP;
-
-
-
-        }else{
+        } else {
             this.pwmChip = LinuxPwm.DEFAULT_LEGACY_PWM_CHIP;
         }
     }
 
-    private int findRp1Pwm(){
-        int rval =  LinuxPwm.DEFAULT_RP1_PWM_CHIP;
+    private int findRp1Pwm() {
+        int rval = LinuxPwm.DEFAULT_RP1_PWM_CHIP;
         return rval;
     }
+
     /**
      * {@inheritDoc}
      */

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmUtil.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmUtil.java
@@ -1,0 +1,111 @@
+package com.pi4j.plugin.linuxfs.provider.pwm;
+
+
+/*
+ *
+ * -
+ *  * #%L
+ *  * **********************************************************************
+ *  * ORGANIZATION  :  Pi4J
+ *  * PROJECT       :  Pi4J :: LIBRARY  :: Java Library (CORE)
+ *  * FILENAME      :  LinuxFsPwmUtil.java
+ *  *
+ *  * This file is part of the Pi4J project. More information about
+ *  * this project can be found here:  https://pi4j.com/
+ *  * **********************************************************************
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *  * #L%
+ *
+ *
+ */
+
+
+import com.pi4j.boardinfo.util.command.CommandResult;
+import com.pi4j.plugin.linuxfs.internal.LinuxPwm;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.pi4j.boardinfo.util.command.CommandExecutor.execute;
+
+/**
+ * LinuxFsPwmUtil
+ * PWM Utilities used by a Pi with the RP1 chip.  Will determine if a user
+ * accessible PWM is configured, if so, return an Int identifying which pwmchip
+ * If no user accessible PWM found, will return the original default value of 2.
+ */
+
+
+public class LinuxFsPwmUtil {
+
+    /**
+     * getPWMChipForRP1
+     *
+     * @param pwmFileSystemPath Device tree path to PWM chips
+     *                          typically /sys/class/pwm
+     * @return Int value for the pwmchip if configured,
+     * else default to original expected value of 2.
+     */
+
+
+    public static int getPWMChipForRP1(String pwmFileSystemPath) {
+        Logger logger = LoggerFactory.getLogger(LinuxFsPwmUtil.class);
+        int pwmChip = LinuxPwm.DEFAULT_RP1_PWM_CHIP;
+
+        // init to original bookworm using pwmChip2, test if different
+        String command = "ls -l " + pwmFileSystemPath;
+        CommandResult rslt = execute(command);
+        String[] paths = rslt.getOutputMessage().split("\n");
+        var foundChipNum = parsePWMPaths(paths);
+        if (foundChipNum.isPresent()) {
+            pwmChip = foundChipNum.get();
+            if (logger.isDebugEnabled()) {
+                logger.debug("Detected PWM chip {} ", pwmChip);
+            }
+        } else {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Did NOT detect PWM chip for RP1 on paths {}", Arrays.toString(paths));
+            }
+        }
+
+        return pwmChip;
+    }
+
+    /**
+     * @param paths Array containing all objects found in pwmFileSystemPath
+     * @return Optional containing an Int if successful, else an empty
+     */
+    public static Optional<Integer> parsePWMPaths(String[] paths) {
+        var pwmChipIdentifier = "pwmchip";
+        for (int counter = 0; counter < paths.length; counter++) {
+            String chipNum = "";
+            StringBuilder chipName = new StringBuilder(pwmChipIdentifier);
+
+            // Test for the RP1 chip address for the user PWM channels
+            if (paths[counter].contains("1f00098000")) {
+                int numStart = paths[counter].indexOf(pwmChipIdentifier) + chipName.length();
+                while (Character.isDigit(paths[counter].substring(numStart, numStart + 1).charAt(0))) {
+                    chipName.append(paths[counter].charAt(numStart));
+                    chipNum = new StringBuilder().append(chipNum.substring(0, chipNum.length())).append(paths[counter].substring(numStart, numStart + 1)).toString();
+                    numStart++;
+                }
+                return Optional.of(Integer.parseInt(chipNum));
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/plugins/pi4j-plugin-linuxfs/src/test/java/com/pi4j/plugin/linuxfs/PWMChipTest.java
+++ b/plugins/pi4j-plugin-linuxfs/src/test/java/com/pi4j/plugin/linuxfs/PWMChipTest.java
@@ -1,0 +1,14 @@
+package com.pi4j.plugin.linuxfs;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PWMChipTest {
+
+    @Test
+    void shouldReturnCorrectPWMChipForRP1Paths() {
+        String[] paths = new String[]{"1f00098000"};
+        assertEquals(1, LinuxFsPlugin.parsePWMPaths(paths));
+    }
+}

--- a/plugins/pi4j-plugin-linuxfs/src/test/java/com/pi4j/plugin/linuxfs/PWMChipTest.java
+++ b/plugins/pi4j-plugin-linuxfs/src/test/java/com/pi4j/plugin/linuxfs/PWMChipTest.java
@@ -1,0 +1,22 @@
+package com.pi4j.plugin.linuxfs;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static com.pi4j.plugin.linuxfs.provider.pwm.LinuxFsPwmUtil.parsePWMPaths;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PWMChipTest {
+
+    @Test
+    void shouldReturnCorrectPWMChipForRP1Paths() {
+        String[] paths = new String[]{"total 0  ",
+            "lrwxrwxrwx 1root root 0Aug 20 07:51 pwmchip42 ->../../devices / platform / axi / 1000120000. pcie / 1f00098000. pwm / pwm / pwmchip0",
+        "lrwxrwxrwx 1 root root 0 Aug 20 07:51 pwmchip1 ->../../devices / platform / axi / 1000120000. pcie / 1f 0009c000.pwm / pwm / pwmchip1"};
+
+        Optional<Optional<Integer>> optionalInt = Optional.of( parsePWMPaths(paths));
+        assertEquals(42, optionalInt.get().get());
+
+    }
+}


### PR DESCRIPTION
… address of PWM0 to determine the correct pwmChipx to use.   This change will effect Pi5 and CM5 using updated kernel

Implemented code to allow multi digit pwmChip? values.  Not likely but reading the post from Pi engineers if pwmPIOs are created they may be numbered before the user PWM.   