### PR TITLE
Make GpioLine closeable

### DIFF
--- a/libraries/pi4j-library-gpiod/src/main/java/com/pi4j/library/gpiod/internal/GpioLine.java
+++ b/libraries/pi4j-library-gpiod/src/main/java/com/pi4j/library/gpiod/internal/GpioLine.java
@@ -3,13 +3,15 @@ package com.pi4j.library.gpiod.internal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
+
 /**
  * <p>GpioLine</p>
  *
  * @author Alexander Liggesmeyer (<a href="https://alexander.liggesmeyer.net/">https://alexander.liggesmeyer.net/</a>)
  * @version $Id: $Id
  */
-public class GpioLine extends CWrapper {
+public class GpioLine extends CWrapper implements Closeable {
     private static final Logger logger = LoggerFactory.getLogger(GpioLine.class);
     private final int offset;
 
@@ -141,5 +143,10 @@ public class GpioLine extends CWrapper {
     public GpioLineEvent eventRead(GpioLineEvent lineEvent) {
         GpioD.lineEventRead(getCPointer(), lineEvent.getCPointer());
         return lineEvent;
+    }
+
+    @Override
+    public void close() {
+        GpioD.lineRelease(getCPointer());
     }
 }

--- a/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalInput.java
+++ b/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalInput.java
@@ -78,6 +78,7 @@ public class GpioDDigitalInput extends DigitalInputBase implements DigitalInput 
         super.shutdown(context);
         if (this.inputListener != null)
             shutdownInputListener();
+        this.line.close();
         return this;
     }
 

--- a/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalOutput.java
+++ b/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalOutput.java
@@ -82,6 +82,7 @@ public class GpioDDigitalOutput extends DigitalOutputBase implements DigitalOutp
     @Override
     public DigitalOutput shutdown(Context context) throws ShutdownException {
         super.shutdown(context);
+        this.line.close();
         return this;
     }
 


### PR DESCRIPTION
This PR would address a possible issue described in #485 

`GpioLine` is made `Closeable` and on close the GpioD library to release the line.

GpioD input and output are updated to close the line during `shutdown`