### PR TITLE
Release GpioLine on IO device shutdown

### DIFF
--- a/libraries/pi4j-library-gpiod/src/main/java/com/pi4j/library/gpiod/internal/GpioDContext.java
+++ b/libraries/pi4j-library-gpiod/src/main/java/com/pi4j/library/gpiod/internal/GpioDContext.java
@@ -155,6 +155,7 @@ public class GpioDContext implements Closeable {
     public synchronized void closeLine(GpioLine gpioLine) {
         long linePtr = gpioLine.getCPointer();
         GpioD.lineRelease(linePtr);
+        this.openLines.remove(gpioLine.getOffset());
     }
 
     public synchronized GpioLineEvent openLineEvent() {

--- a/libraries/pi4j-library-gpiod/src/main/java/com/pi4j/library/gpiod/internal/GpioLine.java
+++ b/libraries/pi4j-library-gpiod/src/main/java/com/pi4j/library/gpiod/internal/GpioLine.java
@@ -3,15 +3,13 @@ package com.pi4j.library.gpiod.internal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.Closeable;
-
 /**
  * <p>GpioLine</p>
  *
  * @author Alexander Liggesmeyer (<a href="https://alexander.liggesmeyer.net/">https://alexander.liggesmeyer.net/</a>)
  * @version $Id: $Id
  */
-public class GpioLine extends CWrapper implements Closeable {
+public class GpioLine extends CWrapper {
     private static final Logger logger = LoggerFactory.getLogger(GpioLine.class);
     private final int offset;
 
@@ -143,10 +141,5 @@ public class GpioLine extends CWrapper implements Closeable {
     public GpioLineEvent eventRead(GpioLineEvent lineEvent) {
         GpioD.lineEventRead(getCPointer(), lineEvent.getCPointer());
         return lineEvent;
-    }
-
-    @Override
-    public void close() {
-        GpioD.lineRelease(getCPointer());
     }
 }

--- a/libraries/pi4j-library-gpiod/src/main/java/com/pi4j/library/gpiod/internal/GpioLine.java
+++ b/libraries/pi4j-library-gpiod/src/main/java/com/pi4j/library/gpiod/internal/GpioLine.java
@@ -3,13 +3,15 @@ package com.pi4j.library.gpiod.internal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
+
 /**
  * <p>GpioLine</p>
  *
  * @author Alexander Liggesmeyer (<a href="https://alexander.liggesmeyer.net/">https://alexander.liggesmeyer.net/</a>)
  * @version $Id: $Id
  */
-public class GpioLine extends CWrapper {
+public class GpioLine extends CWrapper implements Closeable {
     private static final Logger logger = LoggerFactory.getLogger(GpioLine.class);
     private final int offset;
 
@@ -141,5 +143,10 @@ public class GpioLine extends CWrapper {
     public GpioLineEvent eventRead(GpioLineEvent lineEvent) {
         GpioD.lineEventRead(getCPointer(), lineEvent.getCPointer());
         return lineEvent;
+    }
+
+    @Override
+    public void close() {
+        GpioD.lineRelease(getCPointer());
     }
 }

--- a/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalInput.java
+++ b/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalInput.java
@@ -78,6 +78,7 @@ public class GpioDDigitalInput extends DigitalInputBase implements DigitalInput 
         super.shutdown(context);
         if (this.inputListener != null)
             shutdownInputListener();
+        this.line.close();
         return this;
     }
 

--- a/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalInput.java
+++ b/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalInput.java
@@ -78,7 +78,7 @@ public class GpioDDigitalInput extends DigitalInputBase implements DigitalInput 
         super.shutdown(context);
         if (this.inputListener != null)
             shutdownInputListener();
-        this.line.close();
+        GpioDContext.getInstance().closeLine(this.line);
         return this;
     }
 

--- a/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalOutput.java
+++ b/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalOutput.java
@@ -82,6 +82,7 @@ public class GpioDDigitalOutput extends DigitalOutputBase implements DigitalOutp
     @Override
     public DigitalOutput shutdown(Context context) throws ShutdownException {
         super.shutdown(context);
+        this.line.close();
         return this;
     }
 

--- a/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalOutput.java
+++ b/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalOutput.java
@@ -82,7 +82,7 @@ public class GpioDDigitalOutput extends DigitalOutputBase implements DigitalOutp
     @Override
     public DigitalOutput shutdown(Context context) throws ShutdownException {
         super.shutdown(context);
-        this.line.close();
+        GpioDContext.getInstance().closeLine(this.line);
         return this;
     }
 


### PR DESCRIPTION
This PR could address a possible issue described in https://github.com/Pi4J/pi4j/issues/485

GpioLine is made Closeable and on close the GpioD library to release the line.

GpioD input and output are updated to close the line during shutdown