### PR TITLE
Move PWM chip detection to BoardInfo

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/boardinfo/util/BoardInfoHelper.java
+++ b/pi4j-core/src/main/java/com/pi4j/boardinfo/util/BoardInfoHelper.java
@@ -29,27 +29,15 @@ import com.pi4j.boardinfo.datareader.BoardCodeReader;
 import com.pi4j.boardinfo.datareader.CpuInfoReader;
 import com.pi4j.boardinfo.datareader.MemInfoReader;
 import com.pi4j.boardinfo.definition.BoardModel;
-import com.pi4j.boardinfo.model.BoardInfo;
-import com.pi4j.boardinfo.model.BoardReading;
-import com.pi4j.boardinfo.model.JavaInfo;
-import com.pi4j.boardinfo.model.JvmMemory;
-import com.pi4j.boardinfo.model.OperatingSystem;
+import com.pi4j.boardinfo.model.*;
 import com.pi4j.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.pi4j.boardinfo.util.Command.CORE_VOLTAGE_COMMAND;
-import static com.pi4j.boardinfo.util.Command.TEMPERATURE_COMMAND;
-import static com.pi4j.boardinfo.util.Command.THROTTLED_STATE_COMMAND;
-import static com.pi4j.boardinfo.util.Command.UPTIME_COMMAND;
-import static com.pi4j.boardinfo.util.SystemProperties.ARCHITECTURE_DATA_MODEL;
-import static com.pi4j.boardinfo.util.SystemProperties.JAVA_RUNTIME_VERSION;
-import static com.pi4j.boardinfo.util.SystemProperties.JAVA_VENDOR;
-import static com.pi4j.boardinfo.util.SystemProperties.JAVA_VENDOR_VERSION;
-import static com.pi4j.boardinfo.util.SystemProperties.JAVA_VERSION;
-import static com.pi4j.boardinfo.util.SystemProperties.OS_ARCH;
-import static com.pi4j.boardinfo.util.SystemProperties.OS_NAME;
-import static com.pi4j.boardinfo.util.SystemProperties.OS_VERSION;
+import static com.pi4j.boardinfo.util.Command.*;
+import static com.pi4j.boardinfo.util.PwmChipUtil.DEFAULT_LEGACY_PWM_CHIP;
+import static com.pi4j.boardinfo.util.PwmChipUtil.DEFAULT_PWM_SYSTEM_PATH;
+import static com.pi4j.boardinfo.util.SystemProperties.*;
 import static com.pi4j.boardinfo.util.command.CommandExecutor.execute;
 
 /**
@@ -174,6 +162,13 @@ public class BoardInfoHelper {
      */
     public static boolean usesRP1() {
         return current().getBoardModel().usesRP1();
+    }
+
+    public static int getPwmChipAddress() {
+        if (BoardInfoHelper.usesRP1()) {
+            return PwmChipUtil.getPWMChipForRP1(DEFAULT_PWM_SYSTEM_PATH);
+        }
+        return DEFAULT_LEGACY_PWM_CHIP;
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/boardinfo/util/PwmChipUtil.java
+++ b/pi4j-core/src/main/java/com/pi4j/boardinfo/util/PwmChipUtil.java
@@ -1,5 +1,4 @@
-package com.pi4j.plugin.linuxfs.provider.pwm;
-
+package com.pi4j.boardinfo.util;
 
 /*
  *
@@ -30,9 +29,7 @@ package com.pi4j.plugin.linuxfs.provider.pwm;
  *
  */
 
-
 import com.pi4j.boardinfo.util.command.CommandResult;
-import com.pi4j.plugin.linuxfs.internal.LinuxPwm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,14 +39,34 @@ import java.util.Optional;
 import static com.pi4j.boardinfo.util.command.CommandExecutor.execute;
 
 /**
- * LinuxFsPwmUtil
- * PWM Utilities used by a Pi with the RP1 chip.  Will determine if a user
- * accessible PWM is configured, if so, return an Int identifying which pwmchip
+ * PWM Util used to determine the PWM address on a Raspberry Pi.
+ * This will determine if a user accessible PWM is configured, if so, returns an Int identifying which pwmchip
  * If no user accessible PWM found, will return the original default value of 2.
  */
+public class PwmChipUtil {
 
+    /**
+     * Constant <code>DEFAULT_SYSTEM_PATH="/sys/class/pwm"</code>
+     */
+    public static String DEFAULT_PWM_SYSTEM_PATH = "/sys/class/pwm";
 
-public class LinuxFsPwmUtil {
+    /** Constant <code>DEFAULT_LEGACY_PWM_CHIP=0</code> */
+    /**
+     * In Pi Models Previous to RP1 the chip is number 0
+     */
+    public static int DEFAULT_LEGACY_PWM_CHIP = 0;
+
+    /** Constant <code>DEFAULT_RP1_PWM_CHIP=2</code> */
+    /**
+     * In RP1 the chip is number 2
+     */
+    public static int DEFAULT_RP1_PWM_CHIP = 2;
+
+    /** Constant <code>DEFAULT_PWM_CHIP=2</code> */
+    /**
+     * In RP1 the chip is number 2
+     */
+    public static int DEFAULT_PWM_CHIP = DEFAULT_RP1_PWM_CHIP;
 
     /**
      * getPWMChipForRP1
@@ -59,11 +76,9 @@ public class LinuxFsPwmUtil {
      * @return Int value for the pwmchip if configured,
      * else default to original expected value of 2.
      */
-
-
     public static int getPWMChipForRP1(String pwmFileSystemPath) {
-        Logger logger = LoggerFactory.getLogger(LinuxFsPwmUtil.class);
-        int pwmChip = LinuxPwm.DEFAULT_RP1_PWM_CHIP;
+        Logger logger = LoggerFactory.getLogger(PwmChipUtil.class);
+        int pwmChip = DEFAULT_RP1_PWM_CHIP;
 
         // init to original bookworm using pwmChip2, test if different
         String command = "ls -l " + pwmFileSystemPath;

--- a/pi4j-core/src/main/java/module-info.java
+++ b/pi4j-core/src/main/java/module-info.java
@@ -31,6 +31,7 @@ module com.pi4j {
 
     // depends on SLF4J
     requires org.slf4j;
+    requires com.pi4j;
 
     // exposed interfaces/classes
     exports com.pi4j;

--- a/pi4j-core/src/main/java/module-info.java
+++ b/pi4j-core/src/main/java/module-info.java
@@ -31,7 +31,6 @@ module com.pi4j {
 
     // depends on SLF4J
     requires org.slf4j;
-    requires com.pi4j;
 
     // exposed interfaces/classes
     exports com.pi4j;

--- a/pi4j-core/src/test/java/com/pi4j/boardinfo/util/PWMChipUtilTest.java
+++ b/pi4j-core/src/test/java/com/pi4j/boardinfo/util/PWMChipUtilTest.java
@@ -2,6 +2,7 @@ package com.pi4j.boardinfo.util;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.pi4j.boardinfo.util.PwmChipUtil.parsePWMPaths;
@@ -11,9 +12,10 @@ class PWMChipUtilTest {
 
     @Test
     void shouldReturnCorrectPWMChipForRP1Paths() {
-        String[] paths = new String[]{"total 0  ",
+        var paths = List.of("total 0  ",
             "lrwxrwxrwx 1root root 0Aug 20 07:51 pwmchip42 ->../../devices / platform / axi / 1000120000. pcie / 1f00098000. pwm / pwm / pwmchip0",
-            "lrwxrwxrwx 1 root root 0 Aug 20 07:51 pwmchip1 ->../../devices / platform / axi / 1000120000. pcie / 1f 0009c000.pwm / pwm / pwmchip1"};
+            "lrwxrwxrwx 1 root root 0 Aug 20 07:51 pwmchip1 ->../../devices / platform / axi / 1000120000. pcie / 1f 0009c000.pwm / pwm / pwmchip1"
+        );
 
         Optional<Optional<Integer>> optionalInt = Optional.of(parsePWMPaths(paths));
         assertEquals(42, optionalInt.get().get());

--- a/pi4j-core/src/test/java/com/pi4j/boardinfo/util/PWMChipUtilTest.java
+++ b/pi4j-core/src/test/java/com/pi4j/boardinfo/util/PWMChipUtilTest.java
@@ -1,20 +1,21 @@
-package com.pi4j.plugin.linuxfs;
+package com.pi4j.boardinfo.util;
 
 import org.junit.jupiter.api.Test;
+
 import java.util.Optional;
-import static com.pi4j.plugin.linuxfs.provider.pwm.LinuxFsPwmUtil.parsePWMPaths;
+
+import static com.pi4j.boardinfo.util.PwmChipUtil.parsePWMPaths;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class PWMChipTest {
+class PWMChipUtilTest {
 
     @Test
     void shouldReturnCorrectPWMChipForRP1Paths() {
         String[] paths = new String[]{"total 0  ",
             "lrwxrwxrwx 1root root 0Aug 20 07:51 pwmchip42 ->../../devices / platform / axi / 1000120000. pcie / 1f00098000. pwm / pwm / pwmchip0",
-        "lrwxrwxrwx 1 root root 0 Aug 20 07:51 pwmchip1 ->../../devices / platform / axi / 1000120000. pcie / 1f 0009c000.pwm / pwm / pwmchip1"};
+            "lrwxrwxrwx 1 root root 0 Aug 20 07:51 pwmchip1 ->../../devices / platform / axi / 1000120000. pcie / 1f 0009c000.pwm / pwm / pwmchip1"};
 
-        Optional<Optional<Integer>> optionalInt = Optional.of( parsePWMPaths(paths));
+        Optional<Optional<Integer>> optionalInt = Optional.of(parsePWMPaths(paths));
         assertEquals(42, optionalInt.get().get());
-
     }
 }

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/LinuxFsPlugin.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/LinuxFsPlugin.java
@@ -42,8 +42,7 @@ import com.pi4j.provider.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
-import static com.pi4j.plugin.linuxfs.provider.pwm.LinuxFsPwmUtil.getPWMChipForRP1;
+import static com.pi4j.boardinfo.util.PwmChipUtil.getPWMChipForRP1;
 
 /**
  * <p>LinuxFsPlugin class.</p>

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/LinuxFsPlugin.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/LinuxFsPlugin.java
@@ -27,12 +27,10 @@ package com.pi4j.plugin.linuxfs;
  * #L%
  */
 
-
 import com.pi4j.boardinfo.util.BoardInfoHelper;
 import com.pi4j.extension.Plugin;
 import com.pi4j.extension.PluginService;
 import com.pi4j.plugin.linuxfs.internal.LinuxGpio;
-import com.pi4j.plugin.linuxfs.internal.LinuxPwm;
 import com.pi4j.plugin.linuxfs.provider.gpio.digital.LinuxFsDigitalInputProvider;
 import com.pi4j.plugin.linuxfs.provider.gpio.digital.LinuxFsDigitalOutputProvider;
 import com.pi4j.plugin.linuxfs.provider.i2c.LinuxFsI2CProvider;
@@ -42,7 +40,7 @@ import com.pi4j.provider.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.pi4j.boardinfo.util.PwmChipUtil.getPWMChipForRP1;
+import static com.pi4j.boardinfo.util.PwmChipUtil.*;
 
 /**
  * <p>LinuxFsPlugin class.</p>
@@ -103,7 +101,7 @@ public class LinuxFsPlugin implements Plugin {
     public static final String SPI_PROVIDER_ID = ID + "-spi";
 
     public static String DEFAULT_GPIO_FILESYSTEM_PATH = LinuxGpio.DEFAULT_SYSTEM_PATH;
-    public static String DEFAULT_PWM_FILESYSTEM_PATH = LinuxPwm.DEFAULT_SYSTEM_PATH;
+    public static String DEFAULT_PWM_FILESYSTEM_PATH = DEFAULT_PWM_SYSTEM_PATH;
 
     private Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -123,7 +121,7 @@ public class LinuxFsPlugin implements Plugin {
         if (BoardInfoHelper.usesRP1()) {
             pwmChip = getPWMChipForRP1(pwmFileSystemPath);
         } else {
-            pwmChip = LinuxPwm.DEFAULT_LEGACY_PWM_CHIP;
+            pwmChip = DEFAULT_LEGACY_PWM_CHIP;
         }
 
         // [GPIO] get overriding custom 'linux.gpio.system.path' setting from Pi4J context

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/internal/LinuxPwm.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/internal/LinuxPwm.java
@@ -31,37 +31,24 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import static com.pi4j.boardinfo.util.PwmChipUtil.DEFAULT_PWM_CHIP;
+import static com.pi4j.boardinfo.util.PwmChipUtil.DEFAULT_PWM_SYSTEM_PATH;
+
 /**
  * <p>LinuxPwm class.</p>
  *
- * @see "https://www.kernel.org/doc/html/latest/driver-api/pwm.html"
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
+ * @see "https://www.kernel.org/doc/html/latest/driver-api/pwm.html"
  */
 public class LinuxPwm {
-
-    /** Constant <code>DEFAULT_SYSTEM_PATH="/sys/class/pwm"</code> */
-    public static String DEFAULT_SYSTEM_PATH = "/sys/class/pwm";
-
-    /** Constant <code>DEFAULT_LEGACY_PWM_CHIP=0</code> */
-    /** In Pi Models Previous to RP1 the chip is number 0 */
-    public static int DEFAULT_LEGACY_PWM_CHIP = 0;
-
-    /** Constant <code>DEFAULT_RP1_PWM_CHIP=2</code> */
-    /** In RP1 the chip is number 2 */
-    public static int DEFAULT_RP1_PWM_CHIP = 2;
-
-    /** Constant <code>DEFAULT_PWM_CHIP=2</code> */
-    /** In RP1 the chip is number 2 */
-    public static int DEFAULT_PWM_CHIP = DEFAULT_RP1_PWM_CHIP;
-
 
     protected final String systemPath;
     protected final int chip;
     protected final int address;
     protected final String pwmPath;
 
-    public enum Polarity{
+    public enum Polarity {
         NORMAL,
         INVERSED,
         UNKNOWN
@@ -72,9 +59,9 @@ public class LinuxPwm {
      *
      * @param systemPath a {@link String} object.
      * @param chip
-     * @param address a int.
+     * @param address    a int.
      */
-    public LinuxPwm(String systemPath, int chip, int address){
+    public LinuxPwm(String systemPath, int chip, int address) {
         this.chip = chip;
         this.address = address;
         this.systemPath = Paths.get(systemPath, String.format("pwmchip%d", chip)).toString();
@@ -85,11 +72,11 @@ public class LinuxPwm {
      * <p>Constructor for LinuxPwm.</p>
      *
      * @param systemPath a {@link String} object.
-     * @param address a int.
+     * @param address    a int.
      */
 
     public LinuxPwm(String systemPath, int address) {
-        this(DEFAULT_SYSTEM_PATH, DEFAULT_PWM_CHIP, address);
+        this(DEFAULT_PWM_SYSTEM_PATH, DEFAULT_PWM_CHIP, address);
     }
 
     /**
@@ -97,10 +84,9 @@ public class LinuxPwm {
      *
      * @param address a int.
      */
-    public LinuxPwm(int address){
-        this(DEFAULT_SYSTEM_PATH, address);
+    public LinuxPwm(int address) {
+        this(DEFAULT_PWM_SYSTEM_PATH, address);
     }
-
 
 
     /**
@@ -122,7 +108,7 @@ public class LinuxPwm {
      * @throws IOException if any.
      */
     public int getChannels() throws IOException {
-        var path = Paths.get(systemPath,"npwm");
+        var path = Paths.get(systemPath, "npwm");
         return Integer.parseInt(Files.readString(path).trim());
     }
 
@@ -166,6 +152,7 @@ public class LinuxPwm {
     public void polarity(Polarity polarity) throws IOException {
         setPolarity(polarity);
     }
+
     /**
      * <p>setPolarity.</p>
      *
@@ -186,6 +173,7 @@ public class LinuxPwm {
     public Polarity polarity() throws IOException {
         return getPolarity();
     }
+
     /**
      * <p>getPolarity.</p>
      *
@@ -194,10 +182,13 @@ public class LinuxPwm {
      */
     public Polarity getPolarity() throws IOException {
         var path = Paths.get(pwmPath, "polarity");
-        switch(Files.readString(path).trim().toLowerCase()){
-            case "inversed": return Polarity.INVERSED;
-            case "normal": return Polarity.NORMAL;
-            default: return Polarity.UNKNOWN;
+        switch (Files.readString(path).trim().toLowerCase()) {
+            case "inversed":
+                return Polarity.INVERSED;
+            case "normal":
+                return Polarity.NORMAL;
+            default:
+                return Polarity.UNKNOWN;
         }
     }
 
@@ -240,7 +231,7 @@ public class LinuxPwm {
      * @throws IOException if any.
      */
     public void setEnabled(boolean enabled) throws IOException {
-        var path = Paths.get(pwmPath,"enable");
+        var path = Paths.get(pwmPath, "enable");
         Files.writeString(path, (enabled ? "1" : "0"));
     }
 
@@ -261,7 +252,7 @@ public class LinuxPwm {
      * @throws IOException if any.
      */
     public boolean isEnabled() throws IOException {
-        var path = Paths.get(pwmPath,"enable");
+        var path = Paths.get(pwmPath, "enable");
         return Files.readString(path).trim().equalsIgnoreCase("1");
     }
 
@@ -275,6 +266,7 @@ public class LinuxPwm {
     public void period(long period) throws IOException {
         setPeriod(period);
     }
+
     public void period(Number period) throws IOException {
         setPeriod(period);
     }
@@ -286,12 +278,12 @@ public class LinuxPwm {
      * @throws IOException if any.
      */
     public void setPeriod(long period) throws IOException {
-        var path = Paths.get(pwmPath,"period");
+        var path = Paths.get(pwmPath, "period");
         Files.writeString(path, Long.toUnsignedString(period));
     }
 
     public void setPeriod(Number period) throws IOException {
-        var path = Paths.get(pwmPath,"period");
+        var path = Paths.get(pwmPath, "period");
         Files.writeString(path, period.toString());
     }
 
@@ -314,7 +306,7 @@ public class LinuxPwm {
      * @throws IOException if any.
      */
     public long getPeriod() throws IOException {
-        var path = Paths.get(pwmPath,"period");
+        var path = Paths.get(pwmPath, "period");
         return Long.parseLong(Files.readString(path).trim());
     }
 
@@ -337,7 +329,7 @@ public class LinuxPwm {
      * @throws IOException if any.
      */
     public void setDutyCycle(long dutyCycle) throws IOException {
-        var path = Paths.get(pwmPath,"duty_cycle");
+        var path = Paths.get(pwmPath, "duty_cycle");
         Files.writeString(path, Long.toString(dutyCycle));
     }
 
@@ -360,39 +352,43 @@ public class LinuxPwm {
      * @throws IOException if any.
      */
     public long getDutyCycle() throws IOException {
-        var path = Paths.get(pwmPath,"duty_cycle");
+        var path = Paths.get(pwmPath, "duty_cycle");
         return Long.parseLong(Files.readString(path).trim());
     }
 
     /**
      * Get Linux File System path for PWM
+     *
      * @return Linux File System path for PWM
      */
-    public String systemPath(){
+    public String systemPath() {
         return getSystemPath();
     }
 
     /**
      * Get Linux File System path for PWM
+     *
      * @return Linux File System path for PWM
      */
-    public String getSystemPath(){
+    public String getSystemPath() {
         return this.systemPath;
     }
 
     /**
      * Get Linux File System path for this PWM pin instance
+     *
      * @return Linux File System path for this PWM pin instance
      */
-    public String pwmPath(){
+    public String pwmPath() {
         return getPwmPath();
     }
 
     /**
      * Get Linux File System path for this PWM pin instance
+     *
      * @return Linux File System path for this PWM pin instance
      */
-    public String getPwmPath(){
+    public String getPwmPath() {
         return this.pwmPath;
     }
 }

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/internal/LinuxPwm.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/internal/LinuxPwm.java
@@ -58,8 +58,8 @@ public class LinuxPwm {
      * <p>Constructor for LinuxPwm.</p>
      *
      * @param systemPath a {@link String} object.
-     * @param chip
-     * @param address    a int.
+     * @param chip       the chip number
+     * @param address    the chip address
      */
     public LinuxPwm(String systemPath, int chip, int address) {
         this.chip = chip;
@@ -182,14 +182,11 @@ public class LinuxPwm {
      */
     public Polarity getPolarity() throws IOException {
         var path = Paths.get(pwmPath, "polarity");
-        switch (Files.readString(path).trim().toLowerCase()) {
-            case "inversed":
-                return Polarity.INVERSED;
-            case "normal":
-                return Polarity.NORMAL;
-            default:
-                return Polarity.UNKNOWN;
-        }
+        return switch (Files.readString(path).trim().toLowerCase()) {
+            case "inversed" -> Polarity.INVERSED;
+            case "normal" -> Polarity.NORMAL;
+            default -> Polarity.UNKNOWN;
+        };
     }
 
     /**

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmProviderImpl.java
@@ -27,7 +27,6 @@ package com.pi4j.plugin.linuxfs.provider.pwm;
  * #L%
  */
 
-
 import com.pi4j.boardinfo.util.BoardInfoHelper;
 import com.pi4j.io.exception.IOException;
 import com.pi4j.io.pwm.Pwm;
@@ -36,7 +35,7 @@ import com.pi4j.io.pwm.PwmProviderBase;
 import com.pi4j.io.pwm.PwmType;
 import com.pi4j.plugin.linuxfs.internal.LinuxPwm;
 
-import static com.pi4j.plugin.linuxfs.provider.pwm.LinuxFsPwmUtil.getPWMChipForRP1;
+import static com.pi4j.boardinfo.util.PwmChipUtil.DEFAULT_LEGACY_PWM_CHIP;
 import static java.text.MessageFormat.format;
 
 /**
@@ -53,8 +52,8 @@ public class LinuxFsPwmProviderImpl extends PwmProviderBase implements LinuxFsPw
     /**
      * <p>Constructor for LinuxFsPwmProviderImpl.</p>
      *
-     * @param pwmFileSystemPath  Path to PWM device tree
-     * @param pwmChip            Number of PWM chip to use
+     * @param pwmFileSystemPath Path to PWM device tree
+     * @param pwmChip           Number of PWM chip to use
      */
     public LinuxFsPwmProviderImpl(String pwmFileSystemPath, int pwmChip) {
         this.id = ID;
@@ -72,25 +71,19 @@ public class LinuxFsPwmProviderImpl extends PwmProviderBase implements LinuxFsPw
     /**
      * <p>Constructor for LinuxFsPwmProviderImpl.</p>
      *
-     * @param pwmFileSystemPath  Path to PWM device tree
+     * @param pwmFileSystemPath Path to PWM device tree
      */
     public LinuxFsPwmProviderImpl(String pwmFileSystemPath) {
         this.id = ID;
         this.name = NAME;
         this.pwmFileSystemPath = pwmFileSystemPath;
 
-
-        // if a RP1,  check the device address to find the correct PWM chip
+        // if a RP1, check the device address to find the correct PWM chip
         if (BoardInfoHelper.usesRP1()) {
-            this.pwmChip = getPWMChipForRP1(pwmFileSystemPath);
+            this.pwmChip = BoardInfoHelper.getPwmChipAddress();
         } else {
-            this.pwmChip = LinuxPwm.DEFAULT_LEGACY_PWM_CHIP;
+            this.pwmChip = DEFAULT_LEGACY_PWM_CHIP;
         }
-    }
-
-    private int findRp1Pwm() {
-        int rval = LinuxPwm.DEFAULT_RP1_PWM_CHIP;
-        return rval;
     }
 
     /**


### PR DESCRIPTION
Related to Slack discussion:

```
Is it something we need to solve in FFM API? It sounds like we need to provide better API and suggestions with e.g. BoardInfoHelper but not in provider's code?
```

What do you think of this proposal to move PWM Chip detection to BoardInfo?
So if needed, can also be used for FFM API initialization.

