### PR TITLE
Add a listenable OnOffRead

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/ListenableOnOffRead.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/ListenableOnOffRead.java
@@ -40,7 +40,10 @@ import java.util.function.Consumer;
  */
 public interface ListenableOnOffRead<T> extends OnOffRead<T> {
 
-    /** Adds a consumer as a listener to this object. */
+    /**
+     * Adds a boolan consumer as a listener to this object. This method name was chosen to avoid any ambiguity with
+     * addListener in Digital.
+     */
     T addConsumer(Consumer<Boolean> listener);
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/io/ListenableOnOffRead.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/ListenableOnOffRead.java
@@ -41,7 +41,7 @@ import java.util.function.Consumer;
 public interface ListenableOnOffRead<T> extends OnOffRead<T> {
 
     /**
-     * Adds a boolan consumer as a listener to this object. This method name was chosen to avoid any ambiguity with
+     * Adds a boolean consumer as a listener to this object. This method name was chosen to avoid any ambiguity with
      * addListener in Digital.
      */
     T addConsumer(Consumer<Boolean> listener);

--- a/pi4j-core/src/main/java/com/pi4j/io/ListenableOnOffRead.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/ListenableOnOffRead.java
@@ -25,9 +25,6 @@ package com.pi4j.io;
  */
 
 import com.pi4j.io.exception.IOException;
-import com.pi4j.io.gpio.digital.DigitalInput;
-import com.pi4j.io.gpio.digital.DigitalStateChangeEvent;
-import com.pi4j.io.gpio.digital.DigitalStateChangeListener;
 
 import java.util.*;
 import java.util.function.Consumer;

--- a/pi4j-core/src/main/java/com/pi4j/io/ListenableOnOffRead.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/ListenableOnOffRead.java
@@ -1,0 +1,129 @@
+package com.pi4j.io;
+/*-
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: LIBRARY  :: Java Library (CORE)
+ * FILENAME      :  OnOff.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  https://pi4j.com/
+ * **********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.pi4j.io.exception.IOException;
+import com.pi4j.io.gpio.digital.DigitalInput;
+import com.pi4j.io.gpio.digital.DigitalStateChangeEvent;
+import com.pi4j.io.gpio.digital.DigitalStateChangeListener;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+/**
+ * OnOffRead with simple functional interface listener support.
+ * <p>
+ * The purpose of this interface is to provide a simple DigitalInput abstraction that can be used to stand
+ * in for a "real" digital input, e.g. when providing IO pins managed by IO expanders to drivers.
+ * </p>
+ */
+public interface ListenableOnOffRead<T> extends OnOffRead<T> {
+
+    void addListener(Consumer<Boolean> listener);
+    void removeListener(Consumer<Boolean> listener);
+
+    static ListenableOnOffRead<DigitalInput> wrap(DigitalInput digitalInput) {
+        return new ListenableOnOffRead<>() {
+            Map<Consumer<Boolean>, DigitalStateChangeListener> listeners = new HashMap<>();
+            @Override
+            public void addListener(Consumer<Boolean> listener) {
+                DigitalStateChangeListener wrapper = new DigitalStateChangeListener() {
+                    @Override
+                    public void onDigitalStateChange(DigitalStateChangeEvent event) {
+                        listener.accept(event.state().equals(true));
+                    }
+                };
+                digitalInput.addListener(wrapper);
+                listeners.put(listener, wrapper);
+            }
+
+            @Override
+            public void removeListener(Consumer<Boolean> listener) {
+                DigitalStateChangeListener wrapper = listeners.remove(listener);
+                if (wrapper != null) {
+                    digitalInput.removeListener(wrapper);
+                }
+            }
+
+            @Override
+            public boolean isOn() {
+                return digitalInput.isOn();
+            }
+        };
+    }
+
+    /**
+     * A simple implementation that will notify listeners for state-changing on()/off() (or setState()) calls.
+     */
+    class Impl<T> implements ListenableOnOffRead<T>, OnOff<T> {
+        private List<Consumer<Boolean>> listeners = new ArrayList<>();
+        private boolean state;
+
+        public Impl() {
+            this(false);
+        }
+
+        public Impl(boolean initialState) {
+            this.state = initialState;
+        }
+
+        @Override
+        public T on() throws IOException {
+            if (!state) {
+                state = true;
+                for (Consumer<Boolean> listener: listeners) {
+                    listener.accept(true);
+                }
+            }
+            return (T) this;
+        }
+
+        @Override
+        public T off() throws IOException {
+            if (!state) {
+                state = false;
+                for (Consumer<Boolean> listener: listeners) {
+                    listener.accept(false);
+                }
+            }
+            return (T) this;
+        }
+
+        @Override
+        public boolean isOn() {
+            return state;
+        }
+
+        @Override
+        public void addListener(Consumer<Boolean> listener) {
+            listeners.add(listener);
+        }
+
+        @Override
+        public void removeListener(Consumer<Boolean> listener) {
+            listeners.remove(listener);
+        }
+    }
+}

--- a/pi4j-core/src/main/java/com/pi4j/io/ListenableOnOffRead.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/ListenableOnOffRead.java
@@ -38,6 +38,8 @@ import java.util.function.Consumer;
  * The purpose of this interface is to provide a simple DigitalInput abstraction that can be used to stand
  * in for a "real" digital input, e.g. when providing IO pins managed by IO expanders to drivers.
  * </p>
+ *
+ * @param <T> See OnOffRead.
  */
 public interface ListenableOnOffRead<T> extends OnOffRead<T> {
 
@@ -76,6 +78,8 @@ public interface ListenableOnOffRead<T> extends OnOffRead<T> {
 
     /**
      * A simple implementation that will notify listeners for state-changing on()/off() (or setState()) calls.
+     *
+     * @param <T> See OnOffRead.
      */
     class Impl<T> implements ListenableOnOffRead<T>, OnOff<T> {
         private List<Consumer<Boolean>> listeners = new ArrayList<>();

--- a/pi4j-core/src/main/java/com/pi4j/io/ListenableOnOffRead.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/ListenableOnOffRead.java
@@ -40,7 +40,8 @@ import java.util.function.Consumer;
  */
 public interface ListenableOnOffRead<T> extends OnOffRead<T> {
 
-    T addListener(Consumer<Boolean> listener);
+    /** Adds a consumer as a listener to this object. */
+    T addConsumer(Consumer<Boolean> listener);
 
     /**
      * A simple implementation that will notify listeners for state-changing on()/off() (or setState()) calls.
@@ -86,7 +87,7 @@ public interface ListenableOnOffRead<T> extends OnOffRead<T> {
         }
 
         @Override
-        public T addListener(Consumer<Boolean> listener) {
+        public T addConsumer(Consumer<Boolean> listener) {
             listeners.add(listener);
             return (T) this;
         }

--- a/pi4j-core/src/main/java/com/pi4j/io/OnOffWrite.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/OnOffWrite.java
@@ -30,4 +30,13 @@ import com.pi4j.io.exception.IOException;
 public interface OnOffWrite<T> {
     T on() throws IOException;
     T off() throws IOException;
+    @SuppressWarnings("unchecked")
+    default T setState(boolean state) throws IOException {
+        if (state) {
+            on();
+        } else {
+            off();
+        }
+        return (T) this;
+    }
 }

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/Digital.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/Digital.java
@@ -26,12 +26,9 @@ package com.pi4j.io.gpio.digital;
  */
 
 import com.pi4j.io.ListenableOnOffRead;
-import com.pi4j.io.OnOffRead;
 import com.pi4j.io.binding.Bindable;
 import com.pi4j.io.binding.DigitalBinding;
 import com.pi4j.io.gpio.Gpio;
-
-import java.util.function.Consumer;
 
 /**
  * <p>Digital interface.</p>

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/Digital.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/Digital.java
@@ -25,10 +25,13 @@ package com.pi4j.io.gpio.digital;
  * #L%
  */
 
+import com.pi4j.io.ListenableOnOffRead;
 import com.pi4j.io.OnOffRead;
 import com.pi4j.io.binding.Bindable;
 import com.pi4j.io.binding.DigitalBinding;
 import com.pi4j.io.gpio.Gpio;
+
+import java.util.function.Consumer;
 
 /**
  * <p>Digital interface.</p>
@@ -43,7 +46,7 @@ public interface Digital<DIGITAL_TYPE extends Digital<DIGITAL_TYPE, CONFIG_TYPE,
         CONFIG_TYPE extends DigitalConfig<CONFIG_TYPE>,
         PROVIDER_TYPE extends DigitalProvider>
         extends Gpio<DIGITAL_TYPE, CONFIG_TYPE, PROVIDER_TYPE>,
-        OnOffRead<DIGITAL_TYPE>,
+        ListenableOnOffRead<DIGITAL_TYPE>,
         Bindable<DIGITAL_TYPE, DigitalBinding>
 {
 
@@ -61,6 +64,7 @@ public interface Digital<DIGITAL_TYPE extends Digital<DIGITAL_TYPE, CONFIG_TYPE,
      * @return a DIGITAL_TYPE object.
      */
     DIGITAL_TYPE addListener(DigitalStateChangeListener... listener);
+
     /**
      * <p>removeListener.</p>
      *

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalBase.java
@@ -79,7 +79,7 @@ public abstract class DigitalBase<DIGITAL_TYPE extends Digital<DIGITAL_TYPE, CON
     }
 
     @Override
-    public DIGITAL_TYPE addListener(Consumer<Boolean> listener) {
+    public DIGITAL_TYPE addConsumer(Consumer<Boolean> listener) {
         addListener((DigitalStateChangeListener) event -> listener.accept(event.state().equals(true)));
         return (DIGITAL_TYPE)this;
     }

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalBase.java
@@ -35,6 +35,8 @@ import com.pi4j.io.binding.BindingManager;
 import com.pi4j.io.binding.DigitalBinding;
 import com.pi4j.io.gpio.GpioBase;
 
+import java.util.function.Consumer;
+
 /**
  * <p>Abstract DigitalBase class.</p>
  *
@@ -74,6 +76,12 @@ public abstract class DigitalBase<DIGITAL_TYPE extends Digital<DIGITAL_TYPE, CON
         // create a binding manager for digital state change events
         bindings = new BindingManager(this, (BindingDelegate<DigitalBinding, DigitalStateChangeEvent>)
                 (binding, event) -> binding.process(event));
+    }
+
+    @Override
+    public DIGITAL_TYPE addListener(Consumer<Boolean> listener) {
+        addListener((DigitalStateChangeListener) event -> listener.accept(event.state().equals(true)));
+        return (DIGITAL_TYPE)this;
     }
 
     /** {@inheritDoc} */

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalOutput.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalOutput.java
@@ -118,16 +118,6 @@ public interface DigitalOutput extends Digital<DigitalOutput, DigitalOutputConfi
     /**
      * <p>setState.</p>
      *
-     * @param state a boolean.
-     * @return a {@link com.pi4j.io.gpio.digital.DigitalOutput} object.
-     * @throws IOException if any.
-     */
-    default DigitalOutput setState(boolean state) throws IOException {
-        return this.state(DigitalState.getState(state));
-    }
-    /**
-     * <p>setState.</p>
-     *
      * @param state a byte.
      * @return a {@link com.pi4j.io.gpio.digital.DigitalOutput} object.
      * @throws IOException if any.


### PR DESCRIPTION
When combining digital driver inputs with IO expanders, we need a way to hand over a representation of the expander pins to the driver.

Also move setState(boolean) up to OnOffWrite for convenience (ideally this would be the one non-default method, so only one override is needed in implementations, but I guess this ship has sailed now....)