### PR TITLE
Call `super.initialize` after initialisation

### DIFF
--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalOutputFFM.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalOutputFFM.java
@@ -40,7 +40,6 @@ public class DigitalOutputFFM extends DigitalOutputBase implements DigitalOutput
 
     @Override
     public DigitalOutput initialize(Context context) throws InitializeException {
-        super.initialize(context);
         try {
             if (!canAccessDevice()) {
                 var posix = Files.readAttributes(Path.of(deviceName), PosixFileAttributes.class);
@@ -71,7 +70,7 @@ public class DigitalOutputFFM extends DigitalOutputBase implements DigitalOutput
             logger.error("{}-{} - DigitalOutput Pin Initialization error: {}", deviceName, pin, e.getMessage());
             throw new InitializeException(e);
         }
-        return this;
+        return super.initialize(context);
     }
 
     @Override

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/integration/GPIOTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/integration/GPIOTest.java
@@ -4,6 +4,7 @@ import com.pi4j.Pi4J;
 import com.pi4j.context.Context;
 import com.pi4j.exception.Pi4JException;
 import com.pi4j.io.gpio.digital.DigitalInputConfigBuilder;
+import com.pi4j.io.gpio.digital.DigitalOutputConfigBuilder;
 import com.pi4j.io.gpio.digital.DigitalState;
 import com.pi4j.io.gpio.digital.PullResistance;
 import com.pi4j.plugin.ffm.providers.gpio.DigitalInputFFMProviderImpl;
@@ -130,5 +131,16 @@ public class GPIOTest {
         assertEquals(DigitalState.HIGH, pin.state());
         pin.state(DigitalState.LOW);
         assertEquals(DigitalState.LOW, pin.state());
+    }
+
+    @Test
+    public void testOutputCustomConfig() {
+        var config = DigitalOutputConfigBuilder.newInstance(pi4j0)
+            .address(4)
+            .initial(DigitalState.HIGH)
+            .build();
+        var pin = pi4j0.digitalOutput().create(config);
+        assertEquals(DigitalState.HIGH, pin.config().initialState());
+        assertEquals(4, pin.address());
     }
 }


### PR DESCRIPTION
This PR provides a fix for #504 to allow initial state of the output to be set during initialisation