### PR TITLE
Add default accessor for pwm bus number

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmConfig.java
@@ -29,6 +29,7 @@ import com.pi4j.config.AddressConfig;
 import com.pi4j.io.gpio.GpioConfig;
 
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * <p>PwmConfig interface.</p>
@@ -54,6 +55,10 @@ public interface PwmConfig extends GpioConfig<PwmConfig>, AddressConfig<PwmConfi
     String INITIAL_VALUE_KEY = "initial";
 
     Integer busNumber();
+
+    default Integer getBusNumber() {
+        return this.busNumber();
+    }
 
     /**
      *  Get the configured duty-cycle value as a decimal value that represents

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmConfig.java
@@ -29,7 +29,6 @@ import com.pi4j.config.AddressConfig;
 import com.pi4j.io.gpio.GpioConfig;
 
 import java.util.Collection;
-import java.util.Optional;
 
 /**
  * <p>PwmConfig interface.</p>


### PR DESCRIPTION
This PR address an issue described in #506, adding a default accessor method for `PwmConfig.busNumber`.
