### PR TITLE
Make IO closeable and add a base implementation to BaseIO

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/common/Lifecycle.java
+++ b/pi4j-core/src/main/java/com/pi4j/common/Lifecycle.java
@@ -51,10 +51,9 @@ public interface Lifecycle<T> {
     T initialize(Context context) throws InitializeException;
 
     /**
-     * <p>shutdown.</p>
-     *
-     * <p>This method is called by the registry when the registry shutting down. To shut down an IO instance, call
-     * io.close().</p>
+     * This method is called by the registry when the registry shutting down and should not be called by
+     * users directly. To shut down an IO instance, call close() instead. This will make sure that the
+     * instance is not just shut down and closed but also properly unregistered.</p>
      *
      * @param context a {@link com.pi4j.context.Context} object.
      *

--- a/pi4j-core/src/main/java/com/pi4j/common/Lifecycle.java
+++ b/pi4j-core/src/main/java/com/pi4j/common/Lifecycle.java
@@ -53,8 +53,8 @@ public interface Lifecycle<T> {
     /**
      * <p>shutdown.</p>
      *
-     * <p>This method is called by the registry when the registry shutting down. To shutdown an element, call
-     * {@link Context#shutdown(String)} passing the ID of the relevant element.</p>
+     * <p>This method is called by the registry when the registry shutting down. To shut down an IO instance, call
+     * io.close().</p>
      *
      * @param context a {@link com.pi4j.context.Context} object.
      *

--- a/pi4j-core/src/main/java/com/pi4j/io/IO.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IO.java
@@ -44,7 +44,13 @@ import java.io.Closeable;
 public interface IO<IO_TYPE extends IO, CONFIG_TYPE extends IOConfig, PROVIDER_TYPE extends Provider>
         extends Describable, Lifecycle, Identity, Closeable {
 
-    /** Pi4J generally throws unchecked exceptions, so we restrict Closeable.close() here accordingly. */
+    /**
+     * Closes this IO instance.
+     * <p>
+     * Pi4J generally throws unchecked exceptions, so we restrict Closeable.close() here accordingly.
+     * For the interaction with shutdown and general overriding and usage recommendations, please
+     * refer to the documentation of IOBase.close().
+     */
     @Override
     void close();
 

--- a/pi4j-core/src/main/java/com/pi4j/io/IO.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IO.java
@@ -30,6 +30,8 @@ import com.pi4j.common.Identity;
 import com.pi4j.common.Lifecycle;
 import com.pi4j.provider.Provider;
 
+import java.io.Closeable;
+
 /**
  * <p>IO interface.</p>
  *
@@ -40,7 +42,11 @@ import com.pi4j.provider.Provider;
  * @param <PROVIDER_TYPE>
  */
 public interface IO<IO_TYPE extends IO, CONFIG_TYPE extends IOConfig, PROVIDER_TYPE extends Provider>
-        extends Describable, Lifecycle, Identity {
+        extends Describable, Lifecycle, Identity, Closeable {
+
+    /** Pi4J generally throws unchecked exceptions, so we restrict Closeable.close() here accordingly. */
+    @Override
+    void close();
 
     /**
      * <p>config.</p>

--- a/pi4j-core/src/main/java/com/pi4j/io/IOBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IOBase.java
@@ -91,12 +91,16 @@ public abstract class IOBase<IO_TYPE extends IO, CONFIG_TYPE extends IOConfig, P
      * Closes the driver by calling this.context().shutdown(this.getId()), which in turn calls
      * the local shutdown() method here via DefaultRuntimeRegistry.remove().
      * <p>
-     * IO implementations need to override the local shutdown method with implementation-
-     * specific shutdown behaviour as needed.
+     * Basically, for Pi4J, this constitutes an idempotent user convenience method for
+     * this.context().shutdown(this.getId())
+     * <p>
+     * Subclasses should typically override the local shutdown method with implementation-specific shutdown
+     * behaviour. Behaviour added here will not be triggered by context.shutdown()
      */
     @Override
-    public final void close() {
-        // Account for contextless tests or somehow just closing without initializing
+    public void close() {
+        // The null check accounts for contextless tests or somehow just closing without initializing
+        // The closed check ensures idempotency, as required by the close method contract.
         if (this.context != null && !closed) {
             this.closed = true;
             this.context.shutdown(getId());

--- a/pi4j-core/src/main/java/com/pi4j/io/IOBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IOBase.java
@@ -32,6 +32,7 @@ import com.pi4j.exception.InitializeException;
 import com.pi4j.exception.ShutdownException;
 import com.pi4j.provider.Provider;
 
+import java.io.Closeable;
 
 /**
  * <p>Abstract IOBase class.</p>

--- a/pi4j-core/src/main/java/com/pi4j/io/IOBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IOBase.java
@@ -87,7 +87,10 @@ public abstract class IOBase<IO_TYPE extends IO, CONFIG_TYPE extends IOConfig, P
 
     @Override
     public void close() {
-        context().shutdown(getId());
+        // Account for
+        if (context() != null) {
+            context().shutdown(getId());
+        }
     }
 
     /** {@inheritDoc} */

--- a/pi4j-core/src/main/java/com/pi4j/io/IOBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IOBase.java
@@ -87,9 +87,9 @@ public abstract class IOBase<IO_TYPE extends IO, CONFIG_TYPE extends IOConfig, P
 
     @Override
     public void close() {
-        // Account for
-        if (context() != null) {
-            context().shutdown(getId());
+        // Account for contextless tests or somehow just closing without initializing
+        if (this.context != null) {
+            this.context.shutdown(getId());
         }
     }
 

--- a/pi4j-core/src/main/java/com/pi4j/io/IOBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IOBase.java
@@ -43,7 +43,7 @@ import com.pi4j.provider.Provider;
  * @param <PROVIDER_TYPE>
  */
 public abstract class IOBase<IO_TYPE extends IO, CONFIG_TYPE extends IOConfig, PROVIDER_TYPE extends Provider>
-        extends IdentityBase implements IO<IO_TYPE,CONFIG_TYPE, PROVIDER_TYPE> {
+        extends IdentityBase implements IO<IO_TYPE,CONFIG_TYPE, PROVIDER_TYPE>, Closeable {
 
     protected CONFIG_TYPE config;
     protected PROVIDER_TYPE provider;
@@ -82,6 +82,11 @@ public abstract class IOBase<IO_TYPE extends IO, CONFIG_TYPE extends IOConfig, P
     public IO_TYPE description(String description){
         this.description = description;
         return (IO_TYPE)this;
+    }
+
+    @Override
+    public void close() {
+        context().shutdown(getId());
     }
 
     /** {@inheritDoc} */

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalBase.java
@@ -35,6 +35,7 @@ import com.pi4j.io.binding.BindingManager;
 import com.pi4j.io.binding.DigitalBinding;
 import com.pi4j.io.gpio.GpioBase;
 
+import java.io.Closeable;
 import java.util.function.Consumer;
 
 /**
@@ -51,7 +52,8 @@ public abstract class DigitalBase<DIGITAL_TYPE extends Digital<DIGITAL_TYPE, CON
         PROVIDER_TYPE extends DigitalProvider>
         extends GpioBase<DIGITAL_TYPE, CONFIG_TYPE, PROVIDER_TYPE>
         implements Digital<DIGITAL_TYPE, CONFIG_TYPE, PROVIDER_TYPE>,
-        Bindable<DIGITAL_TYPE, DigitalBinding>
+        Bindable<DIGITAL_TYPE, DigitalBinding>, Closeable
+
 {
     // internal listeners collection
     protected final EventManager<DIGITAL_TYPE, DigitalStateChangeListener, DigitalStateChangeEvent> stateChangeEventManager;
@@ -89,6 +91,11 @@ public abstract class DigitalBase<DIGITAL_TYPE extends Digital<DIGITAL_TYPE, CON
     public DIGITAL_TYPE addListener(DigitalStateChangeListener... listener) {
         stateChangeEventManager.add(listener);
         return (DIGITAL_TYPE)this;
+    }
+
+    @Override
+    public void close() {
+        context().shutdown(getId());
     }
 
     /** {@inheritDoc} */

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalBase.java
@@ -35,7 +35,6 @@ import com.pi4j.io.binding.BindingManager;
 import com.pi4j.io.binding.DigitalBinding;
 import com.pi4j.io.gpio.GpioBase;
 
-import java.io.Closeable;
 import java.util.function.Consumer;
 
 /**
@@ -53,7 +52,6 @@ public abstract class DigitalBase<DIGITAL_TYPE extends Digital<DIGITAL_TYPE, CON
         extends GpioBase<DIGITAL_TYPE, CONFIG_TYPE, PROVIDER_TYPE>
         implements Digital<DIGITAL_TYPE, CONFIG_TYPE, PROVIDER_TYPE>,
         Bindable<DIGITAL_TYPE, DigitalBinding>
-
 {
     // internal listeners collection
     protected final EventManager<DIGITAL_TYPE, DigitalStateChangeListener, DigitalStateChangeEvent> stateChangeEventManager;

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalBase.java
@@ -52,7 +52,7 @@ public abstract class DigitalBase<DIGITAL_TYPE extends Digital<DIGITAL_TYPE, CON
         PROVIDER_TYPE extends DigitalProvider>
         extends GpioBase<DIGITAL_TYPE, CONFIG_TYPE, PROVIDER_TYPE>
         implements Digital<DIGITAL_TYPE, CONFIG_TYPE, PROVIDER_TYPE>,
-        Bindable<DIGITAL_TYPE, DigitalBinding>, Closeable
+        Bindable<DIGITAL_TYPE, DigitalBinding>
 
 {
     // internal listeners collection
@@ -91,11 +91,6 @@ public abstract class DigitalBase<DIGITAL_TYPE extends Digital<DIGITAL_TYPE, CON
     public DIGITAL_TYPE addListener(DigitalStateChangeListener... listener) {
         stateChangeEventManager.add(listener);
         return (DIGITAL_TYPE)this;
-    }
-
-    @Override
-    public void close() {
-        context().shutdown(getId());
     }
 
     /** {@inheritDoc} */

--- a/pi4j-test/src/main/java/com/pi4j/test/provider/TestAnalogOutput.java
+++ b/pi4j-test/src/main/java/com/pi4j/test/provider/TestAnalogOutput.java
@@ -158,4 +158,9 @@ public class TestAnalogOutput implements AnalogOutput {
     public Object shutdown(Context context) throws ShutdownException {
         return null;
     }
+
+    /** {@inheritDoc} */
+    @Override
+    public void close() {
+    }
 }

--- a/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
@@ -118,7 +118,11 @@ public class RegistryTest {
         // now shutdown all I/O instances by closing them.
         input.close();
         output.close();
-        pi4j.shutdown(pwm);  // PWM has no context here for some reason.
+
+        // The test PWM has no context here; assuming mock/fake incompleteness.
+        // First guess was that this is because TestPwmProvider returns null from the create method, but this would
+        // mean that pwm.id() above would fail already.
+        pi4j.shutdown(pwm);
 
         // and now we shouldn't find them by address or ID
         assertFalse(registry.exists(IOType.PWM, 3));
@@ -128,5 +132,10 @@ public class RegistryTest {
         assertFalse(registry.exists(pwm.id()));
         assertFalse(registry.exists(input.id()));
         assertFalse(registry.exists(output.id()));
+
+        // Check close idempotency.
+        input.close();
+        output.close();
+        pwm.close();
     }
 }

--- a/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
@@ -115,7 +115,7 @@ public class RegistryTest {
         assertFalse(registry.exists(IOType.ANALOG_INPUT, output.address()));
         assertFalse(registry.exists(IOType.ANALOG_OUTPUT, output.address()));
 
-        // now shutdown all I/O instances
+        // now shutdown all I/O instances by closing them.
         input.close();
         output.close();
         pwm.close();

--- a/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
@@ -118,7 +118,7 @@ public class RegistryTest {
         // now shutdown all I/O instances by closing them.
         input.close();
         output.close();
-        pwm.close();
+        pi4j.shutdown(pwm);  // PWM has no context here for some reason.
 
         // and now we shouldn't find them by address or ID
         assertFalse(registry.exists(IOType.PWM, 3));

--- a/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
@@ -80,13 +80,13 @@ public class RegistryTest {
         // create a new input, then shutdown
         var input = pi4j.create(inputConfig);
 
-        pi4j.shutdown(input.id());
+        input.close();
 
         // shouldn't fail when recreating
         input = pi4j.create(inputConfig);
 
         // or shutting down
-        pi4j.shutdown(input.id());
+        input.close();
     }
 
     @Test
@@ -116,9 +116,9 @@ public class RegistryTest {
         assertFalse(registry.exists(IOType.ANALOG_OUTPUT, output.address()));
 
         // now shutdown all I/O instances
-        pi4j.shutdown(input);
-        pi4j.shutdown(output);
-        pi4j.shutdown(pwm);
+        input.close();
+        output.close();
+        pwm.close();
 
         // and now we shouldn't find them by address or ID
         assertFalse(registry.exists(IOType.PWM, 3));


### PR DESCRIPTION
Not exactly sure what the best place would be to avoid cycles with stuff that already implements close (maybe that's not a problem because then that will override anyway and we could push this up all the way to IOBase)?