### PR TITLE
Rename the internal shutdown method in Lifecycle to shutdownInternal

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/common/Lifecycle.java
+++ b/pi4j-core/src/main/java/com/pi4j/common/Lifecycle.java
@@ -51,7 +51,7 @@ public interface Lifecycle<T> {
     T initialize(Context context) throws InitializeException;
 
     /**
-     * This method is called by the registry when the registry shutting down and should not be called by
+     * This method is called by the registry internally when the registry shutting down and should not be called by
      * users directly. To shut down an IO instance, call close() instead. This will make sure that the
      * instance is not just shut down and closed but also properly unregistered.</p>
      *
@@ -61,5 +61,5 @@ public interface Lifecycle<T> {
      *
      * @throws com.pi4j.exception.ShutdownException if an error occurs during shutdown.
      */
-    T shutdown(Context context) throws ShutdownException;
+    T shutdownInternal(Context context) throws ShutdownException;
 }

--- a/pi4j-core/src/main/java/com/pi4j/io/IOBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IOBase.java
@@ -126,7 +126,7 @@ public abstract class IOBase<IO_TYPE extends IO, CONFIG_TYPE extends IOConfig, P
 
     /** {@inheritDoc} */
     @Override
-    public IO_TYPE shutdown(Context context) throws ShutdownException {
+    public IO_TYPE shutdownInternal(Context context) throws ShutdownException {
         // Close is supposed to be idempotent. We interpret this here to include effective shutdowns by
         // other means, i.e. the infrastructure calling this method.
         this.closed = true;

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogBase.java
@@ -117,7 +117,7 @@ public abstract class AnalogBase<ANALOG_TYPE
 
     /** {@inheritDoc} */
     @Override
-    public ANALOG_TYPE shutdown(Context context){
+    public ANALOG_TYPE shutdownInternal(Context context){
         // remove all listeners
         valueChangeEventManager.clear();
 

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogOutputBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogOutputBase.java
@@ -136,7 +136,7 @@ public abstract class AnalogOutputBase extends AnalogBase<AnalogOutput, AnalogOu
 
     /** {@inheritDoc} */
     @Override
-    public AnalogOutput shutdown(Context context){
+    public AnalogOutput shutdownInternal(Context context){
         // update the analog value to the shutdown value if a shutdown value is configured
         if(config().shutdownValue() != null){
             try {

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalBase.java
@@ -132,7 +132,7 @@ public abstract class DigitalBase<DIGITAL_TYPE extends Digital<DIGITAL_TYPE, CON
 
     /** {@inheritDoc} */
     @Override
-    public DIGITAL_TYPE shutdown(Context context) throws ShutdownException {
+    public DIGITAL_TYPE shutdownInternal(Context context) throws ShutdownException {
         // remove all listeners
         stateChangeEventManager.clear();
 

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalOutputBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalOutputBase.java
@@ -233,7 +233,7 @@ public abstract class DigitalOutputBase extends DigitalBase<DigitalOutput, Digit
 
     /** {@inheritDoc} */
     @Override
-    public DigitalOutput shutdown(Context context) throws ShutdownException {
+    public DigitalOutput shutdownInternal(Context context) throws ShutdownException {
         // set pin state to the shutdown state if a shutdown state is configured
         if(config().shutdownState() != null && config().shutdownState() != DigitalState.UNKNOWN){
             try {
@@ -242,7 +242,7 @@ public abstract class DigitalOutputBase extends DigitalBase<DigitalOutput, Digit
                 throw new ShutdownException(e);
             }
         }
-        return super.shutdown(context);
+        return super.shutdownInternal(context);
     }
 
     /** {@inheritDoc} */

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBase.java
@@ -93,7 +93,7 @@ public abstract class I2CBase<T extends I2CBus> extends IOBase<I2C, I2CConfig, I
      * {@inheritDoc}
      */
     @Override
-    public I2C shutdown(Context context) throws ShutdownException {
+    public I2C shutdownInternal(Context context) throws ShutdownException {
         // if this I2C device is still open, then we need to close it since we are shutting down
         if (this.isOpen()) {
             try {

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmBase.java
@@ -166,7 +166,7 @@ public abstract class PwmBase extends IOBase<Pwm, PwmConfig, PwmProvider> implem
      * {@inheritDoc}
      */
     @Override
-    public Pwm shutdown(Context context) throws ShutdownException {
+    public Pwm shutdownInternal(Context context) throws ShutdownException {
         // apply a shutdown value if configured
         if (this.config.shutdownValue() != null) {
             try {

--- a/pi4j-core/src/main/java/com/pi4j/platform/PlatformBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/platform/PlatformBase.java
@@ -261,7 +261,7 @@ public abstract class PlatformBase<PLATFORM extends Platform>
 
     /** {@inheritDoc} */
     @Override
-    public PLATFORM shutdown(Context context) throws ShutdownException {
+    public PLATFORM shutdownInternal(Context context) throws ShutdownException {
         return (PLATFORM)this;
     }
 

--- a/pi4j-core/src/main/java/com/pi4j/platform/impl/DefaultRuntimePlatforms.java
+++ b/pi4j-core/src/main/java/com/pi4j/platform/impl/DefaultRuntimePlatforms.java
@@ -306,7 +306,7 @@ public class DefaultRuntimePlatforms implements RuntimePlatforms {
         try {
             logger.trace("calling 'shutdown' platform [id={}; name={}; class={}]",
                     platform.id(), platform.name(), platform.getClass().getName());
-            platform.shutdown(runtime.context());
+            platform.shutdownInternal(runtime.context());
         } catch (Exception e) {
             logger.error("unable to 'shutdown()' platform: [id={}; name={}]; {}",
                     platform.id(), platform.name(), e.getMessage());

--- a/pi4j-core/src/main/java/com/pi4j/provider/ProviderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/provider/ProviderBase.java
@@ -88,7 +88,7 @@ public abstract class ProviderBase<PROVIDER_TYPE extends Provider, IO_TYPE exten
 
     /** {@inheritDoc} */
     @Override
-    public PROVIDER_TYPE shutdown(Context context) throws ShutdownException {
+    public PROVIDER_TYPE shutdownInternal(Context context) throws ShutdownException {
 
         // TODO :: ABSTRACT PROVIDER IO INSTANCE SHUTDOWN VIA PROXY IMPL
 
@@ -96,7 +96,7 @@ public abstract class ProviderBase<PROVIDER_TYPE extends Provider, IO_TYPE exten
         Map<String, IO> instances = context.registry().allByProvider(this.id(), IO.class);
         instances.forEach((address, instance)->{
             try {
-                instance.shutdown(context);
+                instance.shutdownInternal(context);
             } catch (LifecycleException e) {
                 logger.error(e.getMessage(), e);
             }

--- a/pi4j-core/src/main/java/com/pi4j/provider/impl/DefaultRuntimeProviders.java
+++ b/pi4j-core/src/main/java/com/pi4j/provider/impl/DefaultRuntimeProviders.java
@@ -288,7 +288,7 @@ public class DefaultRuntimeProviders implements RuntimeProviders {
         try {
             logger.trace("calling 'shutdown()' provider [id={}; name={}; class={}]",
                     provider.id(), provider.name(), provider.getClass().getName());
-            provider.shutdown(runtime.context());
+            provider.shutdownInternal(runtime.context());
         } catch (ShutdownException e) {
             logger.error("unable to 'shutdown()' provider: [id={}; name={}]; {}",
                     provider.id(), provider.name(), e.getMessage());

--- a/pi4j-core/src/main/java/com/pi4j/registry/impl/DefaultRuntimeRegistry.java
+++ b/pi4j-core/src/main/java/com/pi4j/registry/impl/DefaultRuntimeRegistry.java
@@ -161,7 +161,7 @@ public class DefaultRuntimeRegistry implements RuntimeRegistry {
         try {
             long start = System.currentTimeMillis();
 
-            instance.shutdown(runtime.context());
+            instance.shutdownInternal(runtime.context());
             long took = System.currentTimeMillis() - start;
             if (took > 10)
                 logger.info("Shutting down of IO {} took {}ms", instance.getId(), took);

--- a/pi4j-test/src/main/java/com/pi4j/test/provider/TestAnalogOutput.java
+++ b/pi4j-test/src/main/java/com/pi4j/test/provider/TestAnalogOutput.java
@@ -155,7 +155,7 @@ public class TestAnalogOutput implements AnalogOutput {
 
     /** {@inheritDoc} */
     @Override
-    public Object shutdown(Context context) throws ShutdownException {
+    public Object shutdownInternal(Context context) throws ShutdownException {
         return null;
     }
 

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/FFMPlugin.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/FFMPlugin.java
@@ -32,6 +32,6 @@ public class FFMPlugin implements Plugin {
 
     @Override
     public void shutdown(Context context) throws ShutdownException {
-        Arrays.stream(this.providers).forEach(provider -> provider.shutdown(context));
+        Arrays.stream(this.providers).forEach(provider -> provider.shutdownInternal(context));
     }
 }

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalInputFFM.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalInputFFM.java
@@ -13,6 +13,7 @@ import com.pi4j.plugin.ffm.common.gpio.PinEvent;
 import com.pi4j.plugin.ffm.common.gpio.PinEventProcessing;
 import com.pi4j.plugin.ffm.common.gpio.PinFlag;
 import com.pi4j.plugin.ffm.common.gpio.enums.LineAttributeId;
+import com.pi4j.plugin.ffm.common.gpio.structs.*;
 import com.pi4j.plugin.ffm.common.ioctl.Command;
 import com.pi4j.plugin.ffm.common.ioctl.IoctlNative;
 import com.pi4j.plugin.ffm.common.poll.PollFlag;

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalInputFFM.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalInputFFM.java
@@ -13,7 +13,6 @@ import com.pi4j.plugin.ffm.common.gpio.PinEvent;
 import com.pi4j.plugin.ffm.common.gpio.PinEventProcessing;
 import com.pi4j.plugin.ffm.common.gpio.PinFlag;
 import com.pi4j.plugin.ffm.common.gpio.enums.LineAttributeId;
-import com.pi4j.plugin.ffm.common.gpio.structs.*;
 import com.pi4j.plugin.ffm.common.ioctl.Command;
 import com.pi4j.plugin.ffm.common.ioctl.IoctlNative;
 import com.pi4j.plugin.ffm.common.poll.PollFlag;
@@ -85,7 +84,7 @@ public class DigitalInputFFM extends DigitalInputBase implements DigitalInput {
             logger.trace("{}-{} - getting line info.", deviceName, pin);
             lineInfo = ioctl.call(fd, Command.getGpioV2GetLineInfoIoctl(), lineInfo);
             if ((lineInfo.flags() & PinFlag.USED.getValue()) > 0) {
-                shutdown(context());
+                this.shutdownInternal(context());
                 throw new InitializeException("Pin " + pin + " is in use");
             }
             logger.trace("{}-{} - DigitalInput Pin line info: {}", deviceName, pin, lineInfo);
@@ -130,8 +129,8 @@ public class DigitalInputFFM extends DigitalInputBase implements DigitalInput {
     }
 
     @Override
-    public DigitalInput shutdown(Context context) throws ShutdownException {
-        super.shutdown(context);
+    public DigitalInput shutdownInternal(Context context) throws ShutdownException {
+        super.shutdownInternal(context);
         logger.info("{}-{} - closing GPIO Pin.", deviceName, pin);
         try {
             if (chipFileDescriptor > 0) {

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalInputFFMProviderImpl.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalInputFFMProviderImpl.java
@@ -36,7 +36,7 @@ public class DigitalInputFFMProviderImpl extends DigitalInputProviderBase implem
     }
 
     @Override
-    public DigitalInputProvider shutdown(Context context) throws ShutdownException {
-        return super.shutdown(context);
+    public DigitalInputProvider shutdownInternal(Context context) throws ShutdownException {
+        return super.shutdownInternal(context);
     }
 }

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalOutputFFM.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalOutputFFM.java
@@ -10,7 +10,6 @@ import com.pi4j.plugin.ffm.common.PermissionHelper;
 import com.pi4j.plugin.ffm.common.file.FileDescriptorNative;
 import com.pi4j.plugin.ffm.common.file.FileFlag;
 import com.pi4j.plugin.ffm.common.gpio.PinFlag;
-import com.pi4j.plugin.ffm.common.gpio.structs.*;
 import com.pi4j.plugin.ffm.common.ioctl.Command;
 import com.pi4j.plugin.ffm.common.ioctl.IoctlNative;
 import org.slf4j.Logger;
@@ -54,7 +53,7 @@ public class DigitalOutputFFM extends DigitalOutputBase implements DigitalOutput
             logger.trace("{}-{} - getting line info.", deviceName, pin);
             lineInfo = ioctl.call(fd, Command.getGpioV2GetLineInfoIoctl(), lineInfo);
             if ((lineInfo.flags() & PinFlag.USED.getValue()) > 0) {
-                shutdown(context());
+                this.shutdownInternal(context());
                 throw new InitializeException("Pin " + pin + " is in use");
             }
             logger.trace("{}-{} - DigitalOutput Pin line info: {}", deviceName, pin, lineInfo);
@@ -74,8 +73,8 @@ public class DigitalOutputFFM extends DigitalOutputBase implements DigitalOutput
     }
 
     @Override
-    public DigitalOutput shutdown(Context context) throws ShutdownException {
-        super.shutdown(context);
+    public DigitalOutput shutdownInternal(Context context) throws ShutdownException {
+        super.shutdownInternal(context);
         logger.info("{}-{} - closing GPIO Pin.", deviceName, pin);
         try {
             if (chipFileDescriptor > 0) {

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalOutputFFM.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalOutputFFM.java
@@ -10,6 +10,7 @@ import com.pi4j.plugin.ffm.common.PermissionHelper;
 import com.pi4j.plugin.ffm.common.file.FileDescriptorNative;
 import com.pi4j.plugin.ffm.common.file.FileFlag;
 import com.pi4j.plugin.ffm.common.gpio.PinFlag;
+import com.pi4j.plugin.ffm.common.gpio.structs.*;
 import com.pi4j.plugin.ffm.common.ioctl.Command;
 import com.pi4j.plugin.ffm.common.ioctl.IoctlNative;
 import org.slf4j.Logger;

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalOutputFFMProviderImpl.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalOutputFFMProviderImpl.java
@@ -37,7 +37,7 @@ public class DigitalOutputFFMProviderImpl extends DigitalOutputProviderBase impl
     }
 
     @Override
-    public DigitalOutputProvider shutdown(Context context) throws ShutdownException {
-        return super.shutdown(context);
+    public DigitalOutputProvider shutdownInternal(Context context) throws ShutdownException {
+        return super.shutdownInternal(context);
     }
 }

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/pwm/PwmFFMHardware.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/pwm/PwmFFMHardware.java
@@ -155,9 +155,9 @@ public class PwmFFMHardware extends PwmBase implements Pwm {
     }
 
     @Override
-    public Pwm shutdown(Context context) throws ShutdownException {
+    public Pwm shutdownInternal(Context context) throws ShutdownException {
         if (config.getShutdownValue() != null) {
-            return super.shutdown(context);
+            return super.shutdownInternal(context);
         }
 
         var exportFd = file.open(CHIP_PATH + pwmChipNumber + CHIP_UNEXPORT_PATH, FileFlag.O_WRONLY);

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/spi/SpiFFM.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/spi/SpiFFM.java
@@ -69,9 +69,9 @@ public class SpiFFM extends SpiBase implements Spi {
     }
 
     @Override
-    public Spi shutdown(Context context) throws ShutdownException {
+    public Spi shutdownInternal(Context context) throws ShutdownException {
         FILE.close(spiFileDescriptor);
-        return super.shutdown(context);
+        return super.shutdownInternal(context);
     }
 
     @Override

--- a/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/GpioDPlugin.java
+++ b/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/GpioDPlugin.java
@@ -60,7 +60,7 @@ public class GpioDPlugin implements Plugin {
     public void shutdown(Context context) throws ShutdownException {
         if (this.providers != null) {
             for (Provider<?, ?, ?> provider : providers) {
-                provider.shutdown(context);
+                provider.shutdownInternal(context);
             }
         }
     }

--- a/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalInput.java
+++ b/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalInput.java
@@ -74,8 +74,8 @@ public class GpioDDigitalInput extends DigitalInputBase implements DigitalInput 
     }
 
     @Override
-    public DigitalInput shutdown(Context context) throws ShutdownException {
-        super.shutdown(context);
+    public DigitalInput shutdownInternal(Context context) throws ShutdownException {
+        super.shutdownInternal(context);
         if (this.inputListener != null)
             shutdownInputListener();
         GpioDContext.getInstance().closeLine(this.line);

--- a/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalInputProviderImpl.java
+++ b/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalInputProviderImpl.java
@@ -50,8 +50,8 @@ public class GpioDDigitalInputProviderImpl extends DigitalInputProviderBase impl
     }
 
     @Override
-    public DigitalInputProvider shutdown(Context context) throws ShutdownException {
+    public DigitalInputProvider shutdownInternal(Context context) throws ShutdownException {
         GpioDContext.getInstance().close();
-        return super.shutdown(context);
+        return super.shutdownInternal(context);
     }
 }

--- a/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalOutput.java
+++ b/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalOutput.java
@@ -80,8 +80,8 @@ public class GpioDDigitalOutput extends DigitalOutputBase implements DigitalOutp
     }
 
     @Override
-    public DigitalOutput shutdown(Context context) throws ShutdownException {
-        super.shutdown(context);
+    public DigitalOutput shutdownInternal(Context context) throws ShutdownException {
+        super.shutdownInternal(context);
         GpioDContext.getInstance().closeLine(this.line);
         return this;
     }

--- a/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalOutputProviderImpl.java
+++ b/plugins/pi4j-plugin-gpiod/src/main/java/com/pi4j/plugin/gpiod/provider/gpio/digital/GpioDDigitalOutputProviderImpl.java
@@ -79,8 +79,8 @@ public class GpioDDigitalOutputProviderImpl extends DigitalOutputProviderBase im
     }
 
     @Override
-    public DigitalOutputProvider shutdown(Context context) throws ShutdownException {
+    public DigitalOutputProvider shutdownInternal(Context context) throws ShutdownException {
         GpioDContext.getInstance().close();
-        return super.shutdown(context);
+        return super.shutdownInternal(context);
     }
 }

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalInput.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalInput.java
@@ -168,7 +168,7 @@ public class LinuxFsDigitalInput extends DigitalInputBase implements DigitalInpu
 
     /** {@inheritDoc} */
     @Override
-    public DigitalInput shutdown(Context context) throws ShutdownException {
+    public DigitalInput shutdownInternal(Context context) throws ShutdownException {
         logger.trace("shutdown GPIO [{}]; {}", this.config.address(), gpio.getPinPath());
 
         // this line will execute immediately, not waiting for your task to complete
@@ -179,7 +179,7 @@ public class LinuxFsDigitalInput extends DigitalInputBase implements DigitalInpu
         }
 
         // perform any shutdown cleanup via superclass
-        super.shutdown(context);
+        super.shutdownInternal(context);
 
         // un-export the GPIO pin from the Linux file system impl
         try {

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalOutput.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalOutput.java
@@ -103,7 +103,7 @@ public class LinuxFsDigitalOutput extends DigitalOutputBase implements DigitalOu
 
     /** {@inheritDoc} */
     @Override
-    public DigitalOutput shutdown(Context context) throws ShutdownException {
+    public DigitalOutput shutdownInternal(Context context) throws ShutdownException {
         logger.trace("shutdown GPIO [{}]; {}", this.config.address(), gpio.getPinPath());
 
         // --------------------------------------------------------------------------
@@ -124,7 +124,7 @@ public class LinuxFsDigitalOutput extends DigitalOutputBase implements DigitalOu
 
         // set pin state to shutdown state if a shutdown state is configured
         if(config().shutdownState() != null && config().shutdownState() != DigitalState.UNKNOWN){
-            return super.shutdown(context);
+            return super.shutdownInternal(context);
         }
 
         // otherwise ... un-export the GPIO pin from the Linux file system impl

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/i2c/LinuxFsI2CProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/i2c/LinuxFsI2CProviderImpl.java
@@ -64,9 +64,9 @@ public class LinuxFsI2CProviderImpl extends I2CProviderBase implements LinuxFsI2
     }
 
     @Override
-    public I2CProvider shutdown(Context context) throws ShutdownException {
+    public I2CProvider shutdownInternal(Context context) throws ShutdownException {
         this.i2CBusMap.forEach(((busNr, bus) -> bus.close()));
         this.i2CBusMap.clear();
-        return super.shutdown(context);
+        return super.shutdownInternal(context);
     }
 }

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwm.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwm.java
@@ -209,7 +209,7 @@ public class LinuxFsPwm extends PwmBase implements Pwm {
      * {@inheritDoc}
      */
     @Override
-    public Pwm shutdown(Context context) throws ShutdownException {
+    public Pwm shutdownInternal(Context context) throws ShutdownException {
         logger.trace("shutdown PWM [{}]; {}", this.config.address(), pwm.getPwmPath());
 
         // --------------------------------------------------------------------------
@@ -228,7 +228,7 @@ public class LinuxFsPwm extends PwmBase implements Pwm {
 
         // set pin state to shutdown state if a shutdown state is configured
         if (config().shutdownValue() != null) {
-            return super.shutdown(context);
+            return super.shutdownInternal(context);
         }
 
         // otherwise ... un-export the GPIO pin from the Linux file system impl

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/spi/LinuxFsSpiProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/spi/LinuxFsSpiProviderImpl.java
@@ -70,13 +70,13 @@ public class LinuxFsSpiProviderImpl extends SpiProviderBase
     }
 
     @Override
-    public SpiProvider shutdown(Context context) throws ShutdownException {
+    public SpiProvider shutdownInternal(Context context) throws ShutdownException {
 
         // Is this the right place to call close?
         this.context.registry().allByType(LinuxFsSpi.class).values()
             .forEach(LinuxFsSpi::close);
 
-        return super.shutdown(context);
+        return super.shutdownInternal(context);
     }
 
 

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/gpio/digital/PiGpioDigitalInput.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/gpio/digital/PiGpioDigitalInput.java
@@ -138,9 +138,9 @@ public class PiGpioDigitalInput extends DigitalInputBase implements DigitalInput
 
     /** {@inheritDoc} */
     @Override
-    public DigitalInput shutdown(Context context) throws ShutdownException {
+    public DigitalInput shutdownInternal(Context context) throws ShutdownException {
         // remove this pin listener
         this.piGpio.removePinListener(pin, piGpioPinListener);
-        return super.shutdown(context);
+        return super.shutdownInternal(context);
     }
 }


### PR DESCRIPTION
The intention is to avoid user confusion: there were several shutdown-related bugs where users were calling io.shutdown(ctx) directly -- instead of correctly calling ctx.shutdown(io) 

CI doesn't seem to like it currently but let's have a discussion if we want this before I sink more time into this O:) 
