### PR TITLE
Implement non-default I2CRegisterDataReader / Writer method in I2CBase

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBase.java
@@ -30,6 +30,7 @@ import com.pi4j.exception.ShutdownException;
 import com.pi4j.io.IOBase;
 import com.pi4j.io.i2c.impl.DefaultI2CRegister;
 
+import java.util.Objects;
 import java.util.concurrent.Callable;
 
 /**
@@ -80,6 +81,48 @@ public abstract class I2CBase<T extends I2CBus> extends IOBase<I2C, I2CConfig, I
      */
     public I2CRegister getRegister(int address) {
         return new DefaultI2CRegister(this, address);
+    }
+
+    @Override
+    public int readRegister(int register) {
+        write(register);
+        return read();
+    }
+
+    @Override
+    public int readRegister(byte[] register, byte[] buffer, int offset, int length) {
+        write(register);
+        return read(buffer, offset, length);
+    }
+
+    @Override
+    public int readRegister(int register, byte[] buffer, int offset, int length) {
+        write(register);
+        return read(buffer, offset, length);
+    }
+
+    @Override
+    public int writeRegister(int register, byte b) {
+        return write((byte) register, b);
+    }
+
+    @Override
+    public int writeRegister(int register, byte[] data, int offset, int length) {
+        Objects.checkFromIndexSize(offset, length, data.length);
+        byte[] tmp = new byte[length + 1];
+        tmp[0] = (byte) register;
+        System.arraycopy(data, offset, tmp, 1, length);
+        return write(tmp);
+    }
+
+    @Override
+    public int writeRegister(byte[] register, byte[] data, int offset, int length) {
+        Objects.checkFromIndexSize(offset, length, data.length);
+        byte[] tmp = new byte[length + register.length];
+        System.arraycopy(register,0, tmp, 0, register.length);
+        System.arraycopy(data, offset, tmp, register.length, length);
+        int rc = write(tmp);
+        return (rc - register.length);  // do not include the register bytes as what was written...
     }
 
     @Override

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBase.java
@@ -85,20 +85,23 @@ public abstract class I2CBase<T extends I2CBus> extends IOBase<I2C, I2CConfig, I
 
     @Override
     public int readRegister(int register) {
-        write(register);
-        return read();
+        return execute(() -> {
+            write(register);
+            return read();
+        });
     }
 
     @Override
     public int readRegister(byte[] register, byte[] buffer, int offset, int length) {
-        write(register);
-        return read(buffer, offset, length);
+        return writeRead(register, register.length, 0, buffer, length, offset);
     }
 
     @Override
     public int readRegister(int register, byte[] buffer, int offset, int length) {
-        write(register);
-        return read(buffer, offset, length);
+        return execute(() ->{
+            write(register);
+            return read(buffer, offset, length);
+        });
     }
 
     @Override


### PR DESCRIPTION
To my understanding, reading from a register / writing to a register is just writing the register address before the "actual" i2c read/write operation.

So we should be able to provide default implementations in IOBase, avoiding that all provider implementations need to implement the same utilities above the "raw" IO level. 

This was triggered by seeing the register based methods in the i2c gprc protobuf spec of @IAmNickNack's implemetation. 

I have taken the write operations from the linuxfs implementation, including the pre-existing return value inconsitency.

Reading the documentation of the I2CRagisterDataReader methods, I am not 100% sure there isn't something more to it -- people more familiar with I2C will probably know better. If so, I think we still should still try to model this as close to an "atomic" level as possible, reducing the methods to be implemented by providers (providing opportunities for differences in behaviour) as much as possible for v4. 

