### PR TITLE
Putting FFM providers on priority 200

### DIFF
--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalInputFFMProviderImpl.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalInputFFMProviderImpl.java
@@ -27,7 +27,7 @@ public class DigitalInputFFMProviderImpl extends DigitalInputProviderBase implem
 
     @Override
     public int getPriority() {
-        return 1;
+        return 200;
     }
 
     @Override

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalOutputFFMProviderImpl.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalOutputFFMProviderImpl.java
@@ -28,7 +28,7 @@ public class DigitalOutputFFMProviderImpl extends DigitalOutputProviderBase impl
 
     @Override
     public int getPriority() {
-        return 1;
+        return 200;
     }
 
     @Override

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/I2CFFMProviderImpl.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/I2CFFMProviderImpl.java
@@ -16,7 +16,7 @@ public class I2CFFMProviderImpl extends I2CProviderBase implements I2CProvider {
 
     @Override
     public int getPriority() {
-        return 1;
+        return 200;
     }
 
     /**

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/pwm/PwmFFMProviderImpl.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/pwm/PwmFFMProviderImpl.java
@@ -16,7 +16,7 @@ public class PwmFFMProviderImpl extends PwmProviderBase implements PwmProvider {
 
     @Override
     public int getPriority() {
-        return 1;
+        return 200;
     }
 
     /**

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/serial/SerialFFMProviderImpl.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/serial/SerialFFMProviderImpl.java
@@ -16,7 +16,7 @@ public class SerialFFMProviderImpl extends SerialProviderBase {
 
     @Override
     public int getPriority() {
-        return 1;
+        return 200;
     }
 
     /**

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/spi/SpiFFMProviderImpl.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/spi/SpiFFMProviderImpl.java
@@ -16,7 +16,7 @@ public class SpiFFMProviderImpl extends SpiProviderBase implements SpiProvider {
 
     @Override
     public int getPriority() {
-        return 1;
+        return 200;
     }
 
     @Override


### PR DESCRIPTION
Because the drivers library loads all plugins, in JBang the FFM plugin gets replaced by others when using the drivers library.

So putting FFM to highest level.
Only Mock is higher, but should only be included when needed for local testing.