### PR TITLE
PWM now uses chip and channel.  Made code change so the path is  /sys…

### DIFF
--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/pwm/PwmFFMHardware.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/pwm/PwmFFMHardware.java
@@ -46,7 +46,7 @@ public class PwmFFMHardware extends PwmBase implements Pwm {
         super(provider, config);
         this.chip = config.chip();
         this.channel = config.channel();
-        PermissionHelper.checkDevicePermissions(CHIP_PATH + channel, config);
+        PermissionHelper.checkDevicePermissions(CHIP_PATH + chip, config);
     }
 
     /**
@@ -54,9 +54,9 @@ public class PwmFFMHardware extends PwmBase implements Pwm {
      */
     @Override
     public Pwm initialize(Context context) throws InitializeException {
-        var pwmChipFile = CHIP_PATH + channel;
+        var pwmChipFile = CHIP_PATH + chip;
 
-        var pwmFile = pwmChipFile + PWM_PATH + chip;
+        var pwmFile = pwmChipFile + PWM_PATH + channel;
         if (deviceNotExists(pwmFile)) {
             logger.trace("{} - no PWM Bus found... will try to export PWM Bus first.", pwmFile);
             var npwmFd = file.open(pwmChipFile + CHIP_NPWM_PATH, FileFlag.O_RDONLY);

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/pwm/PwmFFMHardware.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/pwm/PwmFFMHardware.java
@@ -176,6 +176,9 @@ public class PwmFFMHardware extends PwmBase implements Pwm {
      * @return integer representation of text byte array
      */
     private static int getIntegerContent(byte[] bytes) {
+        if (bytes == null) {
+            throw new IllegalArgumentException("bytes cannot be null");
+        }
         return Integer.parseInt(new String(bytes).trim());
     }
 

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/unit/PWMTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/unit/PWMTest.java
@@ -52,37 +52,45 @@ public class PWMTest {
 
     @Test
     public void testOnOff() {
-        var pwmEnable = new FileDescriptorNativeMock.FileDescriptorTestData("/sys/class/pwm/pwmchip1/pwm0/enable", 1, "Test".getBytes(), (_) -> "0".getBytes());
-        var pwmDutyCycle = new FileDescriptorNativeMock.FileDescriptorTestData("/sys/class/pwm/pwmchip1/pwm0/duty_cycle", 2, "1".getBytes());
-        var pwmPolarity = new FileDescriptorNativeMock.FileDescriptorTestData("/sys/class/pwm/pwmchip1/pwm0/polarity", 3, "normal".getBytes());
-        var pwmPeriod = new FileDescriptorNativeMock.FileDescriptorTestData("/sys/class/pwm/pwmchip1/pwm0/period", 4, "1".getBytes());
+        var chip = 0;
+        var channel = 2;
+        var path = "/sys/class/pwm/pwmchip" + chip + "/pwm" + channel;
+        var pwmEnable = new FileDescriptorNativeMock.FileDescriptorTestData(path + "/enable", 1, "Test".getBytes(), (_) -> "0".getBytes());
+        var pwmDutyCycle = new FileDescriptorNativeMock.FileDescriptorTestData(path + "/duty_cycle", 2, "1".getBytes());
+        var pwmPolarity = new FileDescriptorNativeMock.FileDescriptorTestData(path + "/polarity", 3, "normal".getBytes());
+        var pwmPeriod = new FileDescriptorNativeMock.FileDescriptorTestData(path + "/period", 4, "1".getBytes());
         try (var _ = FileDescriptorNativeMock.echo(pwmEnable, pwmDutyCycle, pwmPolarity, pwmPeriod)) {
-
             var pwm = pi4j.pwm().create(PwmConfigBuilder.newInstance(pi4j)
                 .pwmType(PwmType.HARDWARE)
-                .chip(0)
-                .channel(1)
+                .chip(chip)
+                .channel(channel)
                 .build());
             pwm.on();
             assertTrue(pwm.isOn());
             pwm.off();
             assertTrue(pwm.isOff());
+
+            pi4j.registry().remove(pwm.id());
         }
     }
 
     @Test
     public void testChangeFrequency() {
-        var pwmEnable = new FileDescriptorNativeMock.FileDescriptorTestData("/sys/class/pwm/pwmchip2/pwm0/enable", 1, "Test".getBytes(), (_) -> "0".getBytes());
-        var pwmDutyCycle = new FileDescriptorNativeMock.FileDescriptorTestData("/sys/class/pwm/pwmchip2/pwm0/duty_cycle", 2, "1".getBytes());
-        var pwmPolarity = new FileDescriptorNativeMock.FileDescriptorTestData("/sys/class/pwm/pwmchip2/pwm0/polarity", 3, "normal".getBytes());
-        var pwmPeriod = new FileDescriptorNativeMock.FileDescriptorTestData("/sys/class/pwm/pwmchip2/pwm0/period", 4, "1".getBytes());
+        var chip = 0;
+        var channel = 2;
+        var path = "/sys/class/pwm/pwmchip" + chip + "/pwm" + channel;
+        var pwmEnable = new FileDescriptorNativeMock.FileDescriptorTestData(path + "/enable", 1, "Test".getBytes(), (_) -> "0".getBytes());
+        var pwmDutyCycle = new FileDescriptorNativeMock.FileDescriptorTestData(path + "/duty_cycle", 2, "1".getBytes());
+        var pwmPolarity = new FileDescriptorNativeMock.FileDescriptorTestData(path + "/polarity", 3, "normal".getBytes());
+        var pwmPeriod = new FileDescriptorNativeMock.FileDescriptorTestData(path + "/period", 4, "1".getBytes());
 
         try (var _ = FileDescriptorNativeMock.echo(pwmEnable, pwmDutyCycle, pwmPolarity, pwmPeriod)) {
             var pwm = pi4j.pwm().create(PwmConfigBuilder.newInstance(pi4j)
                 .pwmType(PwmType.HARDWARE)
-                .chip(0)
-                .channel(2)
+                .chip(chip)
+                .channel(channel)
                 .build());
+
             pwm.on();
             assertTrue(pwm.isOn());
 
@@ -93,6 +101,8 @@ public class PWMTest {
 
             pwm.on();
             assertTrue(pwm.isOn());
+
+            pi4j.registry().remove(pwm.id());
         }
     }
 }


### PR DESCRIPTION
…/class/pwm/pwmchipCHIP/CHANNEL   At present the provider ffm integration test for PWM fails.  Attempting to run the test exits with no detail and ignoring the debugger.  Will dig more and then ask Nick.  I think the test path it uses needs update.

With this change the example now works
  ```java     
  private static Pwm createPWM(int channel) {
        var chip = PwmChipUtil.getPWMChip();
        var configPwm = Pwm.newConfigBuilder(pi4j)
            .channel(channel)
            .pwmType(PwmType.HARDWARE)
            .provider(PWM_PROVIDER)     // ffm-pwm
            .initial(50)
            .frequency(1)
            .chip(chip)   
            .shutdown(0) 
            .build();
        pwm = pi4j.create(configPwm);
        return pwm;
    }
```