### PR TITLE
Fix #594

### DIFF
--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/impl/I2CDirect.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/impl/I2CDirect.java
@@ -101,7 +101,7 @@ public class I2CDirect extends I2CBase<FFMI2CBus> {
 
     @Override
     public int readRegister(int register) {
-        return internalRead(new byte[]{(byte) register}, 1, new byte[0])[0];
+        return Byte.toUnsignedInt(internalRead(new byte[]{(byte) register}, 1, new byte[0])[0]);
     }
 
     @Override


### PR DESCRIPTION
Manually checked that the other implementations don't have this issue.

Tested manually via device demos. With some more effort, it should be possible to add a proper check in smoke tests by setting a bmp register to a value > 127 and reading it out.