### PR TITLE
#620 Fix shutdown sequence to close file descriptor as last step.

### DIFF
--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMDigitalInput.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMDigitalInput.java
@@ -150,9 +150,6 @@ public class FFMDigitalInput extends DigitalInputBase implements DigitalInput {
         super.shutdownInternal(context);
         logger.info("{}-{} - closing GPIO BCM.", deviceName, bcm);
         try {
-            if (chipFileDescriptor > 0) {
-                file.close(chipFileDescriptor);
-            }
             logger.trace("{}-{} - Stopping event watchers", deviceName, bcm);
             for (EventWatcher watcher : watchers) {
                 watcher.stopWatching();
@@ -168,9 +165,14 @@ public class FFMDigitalInput extends DigitalInputBase implements DigitalInput {
         } catch (Exception e) {
             this.closed = true;
             throw new ShutdownException(e);
+        } finally {
+            if (chipFileDescriptor > 0) {
+                logger.trace("{}-{} - closing GPIO file descriptor '{}'.", deviceName, bcm, chipFileDescriptor);
+                file.close(chipFileDescriptor);
+            }
         }
         this.closed = true;
-        logger.info("{}-{} - GPIO BCM is closed. Recreate the pin object to reuse.", deviceName, bcm);
+        logger.info("{}-{} - GPIO BCM is closed.", deviceName, bcm);
         return this;
     }
 


### PR DESCRIPTION
Small fix in shutdown sequence, we have to close file descriptor as a last step after executor service with task is guaranteed shutdown.