### PR TITLE
Change the PWM duty cycle type from Integer to double

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/Pwm.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/Pwm.java
@@ -168,7 +168,7 @@ public interface Pwm extends IO<Pwm, PwmConfig, PwmProvider>, OnOff<Pwm> {
      * @return returns this PWM instance
      * @throws IOException if fails to communicate with the PWM pin
      */
-    default Pwm on(Integer dutyCycle) throws IOException {
+    default Pwm on(double dutyCycle) throws IOException {
         if (dutyCycle > 0) {
             setDutyCycle(dutyCycle);
             return on();
@@ -222,7 +222,7 @@ public interface Pwm extends IO<Pwm, PwmConfig, PwmProvider>, OnOff<Pwm> {
      * @return duty-cycle value expressed as a percentage (rage: 0-100)
      * @throws IOException if fails to communicate with the PWM pin
      */
-    Integer getDutyCycle() throws IOException;
+    double getDutyCycle() throws IOException;
 
     /**
      * Get the duty-cycle value as an Integer value that represents the
@@ -257,7 +257,7 @@ public interface Pwm extends IO<Pwm, PwmConfig, PwmProvider>, OnOff<Pwm> {
      * @param dutyCycle duty-cycle value expressed as a percentage (rage: 0-100)
      * @throws IOException if fails to communicate with the PWM pin
      */
-    void setDutyCycle(Integer dutyCycle) throws IOException;
+    void setDutyCycle(double dutyCycle) throws IOException;
 
     /**
      * Set the duty-cycle value as an Integer value that represents the
@@ -276,7 +276,7 @@ public interface Pwm extends IO<Pwm, PwmConfig, PwmProvider>, OnOff<Pwm> {
      * @return returns this PWM instance
      * @throws IOException if fails to communicate with the PWM pin
      */
-    default Pwm dutyCycle(Integer dutyCycle) throws IOException {
+    default Pwm dutyCycle(double dutyCycle) throws IOException {
         setDutyCycle(dutyCycle);
         return this;
     }

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/Pwm.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/Pwm.java
@@ -237,7 +237,7 @@ public interface Pwm extends IO<Pwm, PwmConfig, PwmProvider>, OnOff<Pwm> {
      * @return duty-cycle value expressed as a percentage (rage: 0-100)
      * @throws IOException if fails to communicate with the PWM pin
      */
-    default Integer dutyCycle() throws IOException {
+    default double dutyCycle() throws IOException {
         return getDutyCycle();
     }
 

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmBase.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 public abstract class PwmBase extends IOBase<Pwm, PwmConfig, PwmProvider> implements Pwm {
 
     protected int frequency = 100;
-    protected Integer dutyCycle = 50;
+    protected double dutyCycle = 50;
     protected long period = TimeUnit.NANOSECONDS.convert(1, TimeUnit.SECONDS) / frequency;
     protected boolean onState = false;
     protected PwmPolarity polarity = PwmPolarity.NORMAL;
@@ -68,7 +68,7 @@ public abstract class PwmBase extends IOBase<Pwm, PwmConfig, PwmProvider> implem
      * {@inheritDoc}
      */
     @Override
-    public Integer getDutyCycle() throws IOException {
+    public double getDutyCycle() throws IOException {
         return this.dutyCycle;
     }
 
@@ -92,8 +92,8 @@ public abstract class PwmBase extends IOBase<Pwm, PwmConfig, PwmProvider> implem
      * {@inheritDoc}
      */
     @Override
-    public void setDutyCycle(Integer dutyCycle) throws IOException {
-        Integer dc = dutyCycle;
+    public void setDutyCycle(double dutyCycle) throws IOException {
+        double dc = dutyCycle;
 
         // bounds check the duty-cycle value
         if (dc < 0) dc = 0;

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmConfig.java
@@ -114,7 +114,7 @@ public interface PwmConfig extends ChipConfig<PwmConfig>, ChannelConfig<PwmConfi
      *
      * @return duty-cycle value expressed as a percentage (rage: 0-100)
      */
-    Integer dutyCycle();
+    Double dutyCycle();
 
     /**
      * Get the configured duty-cycle value as a decimal value that represents
@@ -127,7 +127,7 @@ public interface PwmConfig extends ChipConfig<PwmConfig>, ChannelConfig<PwmConfi
      *
      * @return duty-cycle value expressed as a percentage (rage: 0-100)
      */
-    default Integer getDutyCycle() {
+    default Double getDutyCycle() {
         return dutyCycle();
     }
 

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmConfigBuilder.java
@@ -105,7 +105,11 @@ public interface PwmConfigBuilder extends
      * @param dutyCycle duty-cycle value expressed as a percentage (rage: 0-100)
      * @return this builder instance
      */
-    PwmConfigBuilder dutyCycle(Integer dutyCycle);
+    PwmConfigBuilder dutyCycle(Double dutyCycle);
+
+    default PwmConfigBuilder dutyCycle(Integer dutyCycle) {
+        return dutyCycle(dutyCycle == null ? null : (double) dutyCycle);
+    }
 
     /**
      * Set the PwmType of this PWM instance. (Hardware/Software)
@@ -139,8 +143,11 @@ public interface PwmConfigBuilder extends
      * @param dutyCycle duty-cycle value expressed as a percentage (rage: 0-100)
      * @return this builder instance
      */
-    PwmConfigBuilder shutdown(Integer dutyCycle);
+    PwmConfigBuilder shutdown(Double dutyCycle);
 
+    default PwmConfigBuilder shutdown(Integer dutyCycle) {
+        return shutdown(dutyCycle == null ? null : (double) dutyCycle);
+    };
     /**
      * Optionally configure a PWM duty-cycle value that should automatically
      * be applied to the PWM instance when this PWM instance is created and initialized.
@@ -152,8 +159,11 @@ public interface PwmConfigBuilder extends
      * @param dutyCycle duty-cycle value expressed as a percentage (rage: 0-100)
      * @return this builder instance
      */
-    PwmConfigBuilder initial(Integer dutyCycle);
+    PwmConfigBuilder initial(Double dutyCycle);
 
+    default PwmConfigBuilder initial(Integer dutyCycle) {
+        return initial(dutyCycle == null ? null : (double) dutyCycle);
+    }
     /**
      * Add one or more PwmPresets to this PWM instance. You can create new PWM
      * preset instance using the 'PwmPreset::newBuilder(name)' static

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/impl/DefaultPwmConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/impl/DefaultPwmConfig.java
@@ -53,7 +53,7 @@ public class DefaultPwmConfig
     protected Integer bcm = null;
 
     // private configuration properties
-    protected Integer dutyCycle = null;
+    protected Double dutyCycle = null;
     protected Integer frequency = null;
     protected PwmType pwmType = PwmType.SOFTWARE;
     protected PwmPolarity polarity = PwmPolarity.NORMAL;
@@ -104,7 +104,7 @@ public class DefaultPwmConfig
 
         // load optional pwm duty-cycle from properties
         if (properties.containsKey(DUTY_CYCLE_KEY)) {
-            this.dutyCycle = Integer.parseInt(properties.get(DUTY_CYCLE_KEY));
+            this.dutyCycle = Double.parseDouble(properties.get(DUTY_CYCLE_KEY));
         }
 
         // load optional pwm frequency from properties
@@ -134,12 +134,12 @@ public class DefaultPwmConfig
 
         // bounds checking
         if (this.dutyCycle != null && this.dutyCycle > 100) {
-            this.dutyCycle = 100;
+            this.dutyCycle = 100.0;
         }
 
         // bounds checking
         if (this.dutyCycle != null && this.dutyCycle < 0) {
-            this.dutyCycle = (int) 0;
+            this.dutyCycle = 0.0;
         }
 
         // define default property values if any are missing (based on the required address value)
@@ -186,7 +186,7 @@ public class DefaultPwmConfig
      * {@inheritDoc}
      */
     @Override
-    public Integer dutyCycle() {
+    public Double dutyCycle() {
         return this.dutyCycle;
     }
 

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/impl/DefaultPwmConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/impl/DefaultPwmConfigBuilder.java
@@ -123,13 +123,13 @@ public class DefaultPwmConfigBuilder
      * {@inheritDoc}
      */
     @Override
-    public PwmConfigBuilder dutyCycle(Integer dutyCycle) {
+    public PwmConfigBuilder dutyCycle(Double dutyCycle) {
         // bounds check the duty-cycle value
-        Integer dc = dutyCycle;
+        double dc = dutyCycle;
         if (dc < 0) dc = 0;
         if (dc > 100) dc = 100;
 
-        this.properties.put(PwmConfig.DUTY_CYCLE_KEY, Integer.toString(dc));
+        this.properties.put(PwmConfig.DUTY_CYCLE_KEY, Double.toString(dc));
         return this;
     }
 
@@ -155,13 +155,13 @@ public class DefaultPwmConfigBuilder
      * {@inheritDoc}
      */
     @Override
-    public PwmConfigBuilder shutdown(Integer dutyCycle) {
+    public PwmConfigBuilder shutdown(Double dutyCycle) {
         // bounds check the duty-cycle value
-        Integer dc = dutyCycle;
-        if (dc < 0) dc = 0;
-        if (dc > 100) dc = 100;
+        Double dc = dutyCycle;
+        if (dc < 0) dc = 0.0;
+        if (dc > 100) dc = 100.0;
 
-        this.properties.put(PwmConfig.SHUTDOWN_VALUE_KEY, Integer.toString(dc));
+        this.properties.put(PwmConfig.SHUTDOWN_VALUE_KEY, Double.toString(dc));
         return this;
     }
 
@@ -169,13 +169,13 @@ public class DefaultPwmConfigBuilder
      * {@inheritDoc}
      */
     @Override
-    public PwmConfigBuilder initial(Integer dutyCycle) {
+    public PwmConfigBuilder initial(Double dutyCycle) {
         // bounds check the duty-cycle value
-        Integer dc = dutyCycle;
-        if (dc < 0) dc = 0;
-        if (dc > 100) dc = 100;
+        Double dc = dutyCycle;
+        if (dc < 0) dc = 0.0;
+        if (dc > 100) dc = 100.0;
 
-        this.properties.put(PwmConfig.INITIAL_VALUE_KEY, Integer.toString(dc));
+        this.properties.put(PwmConfig.INITIAL_VALUE_KEY, Double.toString(dc));
         return this;
     }
 

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/api/RaspberryPi.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/api/RaspberryPi.java
@@ -89,7 +89,7 @@ public interface RaspberryPi extends Pi4JApi.API {
             return context.create(config);
         }
 
-        public Pwm pwm0(PwmPolarity pwmPolarity, int frequency, int dutyCycle) {
+        public Pwm pwm0(PwmPolarity pwmPolarity, int frequency, double dutyCycle) {
             var config = PwmConfigBuilder.newInstance(context)
                 .chip(0)
                 .channel(0)
@@ -104,7 +104,7 @@ public interface RaspberryPi extends Pi4JApi.API {
             return pwm0(PwmPolarity.NORMAL, 10_000, 5_000);
         }
 
-        public Pwm pwm1(PwmPolarity pwmPolarity, int frequency, int dutyCycle) {
+        public Pwm pwm1(PwmPolarity pwmPolarity, int frequency, double dutyCycle) {
             var config = PwmConfigBuilder.newInstance(context)
                 .chip(0)
                 .channel(1)


### PR DESCRIPTION
- Allows higher precision motor control
- Config Builder setters with Integer values are preserved for backwards compatibility, as integer constants can't be assigned to Double (assigning to double seems fine)
- Code reading the current duty cycle might break, but we expect the impact to be minimal (these getters are mostly provided for completeness -- it seem uncommon to read back the value one has just set)