### PR TITLE
#642 Add hardware detection with FFM plugin

### DIFF
--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/FFMPlugin.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/FFMPlugin.java
@@ -4,20 +4,26 @@ import com.pi4j.context.Context;
 import com.pi4j.exception.ShutdownException;
 import com.pi4j.extension.Plugin;
 import com.pi4j.extension.PluginService;
+import com.pi4j.plugin.ffm.detect.HardwareDetector;
 import com.pi4j.plugin.ffm.providers.gpio.FFMDigitalInputProviderImpl;
 import com.pi4j.plugin.ffm.providers.gpio.FFMDigitalOutputProviderImpl;
 import com.pi4j.plugin.ffm.providers.i2c.FFMI2CProviderImpl;
 import com.pi4j.plugin.ffm.providers.pwm.FFMPwmProviderImpl;
 import com.pi4j.plugin.ffm.providers.spi.FFMSpiProviderImpl;
 import com.pi4j.provider.Provider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 
 public class FFMPlugin implements Plugin {
+    private static final Logger logger = LoggerFactory.getLogger(FFMPlugin.class);
+
     private Provider<?, ?, ?>[] providers = new Provider[]{};
 
     @Override
     public void initialize(PluginService service) {
+        logDetectedHardware();
         this.providers = new Provider[]{
             new FFMDigitalInputProviderImpl(),
             new FFMDigitalOutputProviderImpl(),
@@ -26,6 +32,20 @@ public class FFMPlugin implements Plugin {
             new FFMPwmProviderImpl()
         };
         service.register(providers);
+    }
+
+    /**
+     * Runs hardware I/O detection and logs the report. Best-effort only: detection must never prevent the
+     * plugin from registering its providers, so any failure is logged and swallowed.
+     */
+    private void logDetectedHardware() {
+        try {
+            var report = new HardwareDetector().detect();
+            logger.debug("FFM plugin hardware detection:\n{}", report.renderSummery());
+            logger.trace("GPIO details:\n{}", report.renderGpioDetails());
+        } catch (Exception e) {
+            logger.warn("FFM plugin hardware detection failed: {}", e.getMessage(), e);
+        }
     }
 
     @Override

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/common/FFMPermissionHelper.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/common/FFMPermissionHelper.java
@@ -1,13 +1,8 @@
 package com.pi4j.plugin.ffm.common;
 
 import com.pi4j.exception.Pi4JException;
-import com.pi4j.io.IOConfig;
-import com.pi4j.io.gpio.digital.DigitalInputConfig;
-import com.pi4j.io.gpio.digital.DigitalOutputConfig;
-import com.pi4j.io.i2c.I2CConfig;
-import com.pi4j.io.pwm.PwmConfig;
-import com.pi4j.io.spi.SpiConfig;
 import com.pi4j.plugin.ffm.common.permission.PermissionNative;
+import com.pi4j.plugin.ffm.detect.model.HWInterfaces;
 import com.pi4j.plugin.ffm.providers.gpio.FFMDigitalInputProviderImpl;
 import com.pi4j.plugin.ffm.providers.gpio.FFMDigitalOutputProviderImpl;
 import com.pi4j.plugin.ffm.providers.i2c.FFMI2CProviderImpl;
@@ -26,6 +21,8 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import static com.pi4j.plugin.ffm.detect.model.HWInterfaces.PWM;
 
 /**
  * Helper class to check permissions needed to run with FFM API
@@ -139,7 +136,7 @@ public class FFMPermissionHelper {
      *
      * @param devicePath path to be checked
      */
-    public static void checkDevicePermissions(String devicePath, IOConfig<?> config) {
+    public static void checkDevicePermissions(String devicePath, HWInterfaces subsystem, boolean printError) {
         var path = Paths.get(devicePath);
         // checking that device is physically exists
         if (!path.toFile().exists()) {
@@ -175,26 +172,32 @@ public class FFMPermissionHelper {
         }
 
         // we need to check permissions of a device depending on hardware interface
-        switch (config) {
-            case DigitalInputConfig _, DigitalOutputConfig _, PwmConfig _ -> {
+        switch (subsystem) {
+            case GPIO, PWM -> {
                 if (!group.getName().equals("gpio") && !group.getName().equals("dialout")) {
-                    printError(config instanceof PwmConfig ? "pwm" : "gpio");
+                    if (printError) {
+                        printError(subsystem.equals(PWM) ? "pwm" : "gpio");
+                    }
                     throw new Pi4JException("Device '" + devicePath + "' (" + owner + ":" + group + ") does not belong to group 'gpio' or 'dialout'.");
                 }
             }
-            case I2CConfig _ -> {
+            case I2C -> {
                 if (!group.getName().equals("i2c")) {
-                    printError("i2c");
+                    if (printError) {
+                        printError("i2c");
+                    }
                     throw new Pi4JException("Device '" + devicePath + "' (" + owner + ":" + group + ") does not belong to group 'i2c'.");
                 }
             }
-            case SpiConfig _ -> {
+            case SPI -> {
                 if (!group.getName().equals("spi")) {
-                    printError("spi");
+                    if (printError) {
+                        printError("spi");
+                    }
                     throw new Pi4JException("Device '" + devicePath + "' (" + owner + ":" + group + ") does not belong to group 'spi'.");
                 }
             }
-            default -> throw new Pi4JException("Unknown config: " + config);
+            default -> throw new Pi4JException("Unknown subsystem: " + subsystem);
         }
 
         // finally, check if device has group write/read permissions

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/common/Pi4JNativeContext.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/common/Pi4JNativeContext.java
@@ -50,7 +50,7 @@ public class Pi4JNativeContext implements SegmentAllocator {
      * @param method        string representation of called method
      * @param args          arguments called to function
      */
-    public static void processError(int callResult, MemorySegment capturedState, String method, Object... args) throws Throwable {
+    public static void processError(long callResult, MemorySegment capturedState, String method, Object... args) throws Throwable {
         if (callResult < 0) {
             int errno = (int) ERRNO_HANDLE.get(capturedState, 0L);
             var errnoStr = (MemorySegment) STR_ERROR.invokeExact(errno);

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/common/ioctl/IoctlNative.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/common/ioctl/IoctlNative.java
@@ -55,7 +55,7 @@ public class IoctlNative {
             var dataMemorySegment = arena.allocate(ValueLayout.JAVA_LONG);
             dataMemorySegment.set(ValueLayout.JAVA_LONG, 0, data);
             var capturedState = arena.allocate(CAPTURED_STATE_LAYOUT);
-            var callResult = (int) IoctlContext.IOCTL_0.invoke(capturedState, fd, command, dataMemorySegment);
+            var callResult = (long) IoctlContext.IOCTL_0.invoke(capturedState, fd, command, dataMemorySegment);
             processError(callResult, capturedState, "call", fd, command, data);
             return dataMemorySegment.get(ValueLayout.JAVA_LONG, 0);
         } catch (Throwable e) {

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/HardwareDetector.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/HardwareDetector.java
@@ -1,0 +1,122 @@
+package com.pi4j.plugin.ffm.detect;
+
+import com.pi4j.plugin.ffm.detect.model.BoardOverview;
+import com.pi4j.plugin.ffm.detect.model.DetectedHardware;
+import com.pi4j.plugin.ffm.detect.model.DetectionReport;
+import com.pi4j.plugin.ffm.detect.model.GpioLine;
+import com.pi4j.plugin.ffm.detect.model.HWInterfaces;
+import com.pi4j.plugin.ffm.detect.probe.dev.DeviceNodeProbe;
+import com.pi4j.plugin.ffm.detect.probe.dt.DeviceTreeScanner;
+import com.pi4j.plugin.ffm.detect.probe.sysfs.SysfsBusScanner;
+import com.pi4j.plugin.ffm.detect.probe.sysfs.SysfsReader;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Discovers the hardware I/O a Linux machine exposes — GPIO, I2C, SPI and PWM — without {@code gpiod},
+ * without {@code libgpiod} and without shelling out to any terminal command.
+ * <p>
+ * Detection proceeds in three layers, from most to least authoritative:
+ * <ol>
+ *     <li><b>Live device nodes</b> ({@link DeviceNodeProbe}) — {@code /dev} character devices opened and
+ *         probed directly via {@code ioctl}. These are the controllers usable right now.</li>
+ *     <li><b>Device tree</b> ({@link DeviceTreeScanner}) — for subsystems with no live node, the SoC's
+ *         disabled controllers, with board-appropriate enable hints from {@link BoardOverview}.</li>
+ *     <li><b>Sysfs buses</b> ({@link SysfsBusScanner}) — on platforms with no device tree (x86/ACPI/closed
+ *         firmware), the PCI/ACPI/i2c/spi bus hierarchy instead.</li>
+ * </ol>
+ *
+ * @see DetectionReport
+ */
+public final class HardwareDetector {
+
+    private static final Path DEV = Path.of("/dev");
+    private static final Path SYS_CLASS_PWM = Path.of("/sys/class/pwm");
+
+    private final DeviceNodeProbe devProbe = new DeviceNodeProbe();
+
+    /**
+     * Runs a full detection sweep.
+     *
+     * @return a structured {@link DetectionReport} listing every controller found and, for those not
+     * already active, how to enable them
+     */
+    public DetectionReport detect() {
+        var profile = BoardOverview.detect();
+        var controllers = new ArrayList<DetectedHardware>();
+        var live = EnumSet.noneOf(HWInterfaces.class);
+
+        // Layer 1 — live character devices, plus PWM which lives only in sysfs.
+        probeDeviceNodes(controllers, live, profile);
+        if (probePwm(controllers)) {
+            live.add(HWInterfaces.PWM);
+        }
+
+        // Layers 2 & 3 — fall back only for subsystems that produced no live node.
+        var missing = EnumSet.allOf(HWInterfaces.class);
+        missing.removeAll(live);
+        var deviceTreePresent = DeviceTreeScanner.isAvailable();
+        if (!missing.isEmpty()) {
+            controllers.addAll(deviceTreePresent
+                ? new DeviceTreeScanner(profile).scan(missing)
+                : new SysfsBusScanner().scan(missing));
+        }
+
+        return new DetectionReport(profile.name(), profile.kernelVersion(), List.copyOf(controllers), deviceTreePresent);
+    }
+
+    private void probeDeviceNodes(List<DetectedHardware> out, Set<HWInterfaces> live, BoardOverview profile) {
+        for (var node : SysfsReader.listChildren(DEV, "")) {
+            var name = node.getFileName().toString();
+            for (var subsystem : HWInterfaces.values()) {
+                if (subsystem.matchesDevNode(name)) {
+                    var probe = devProbe.describe(subsystem, node.toString());
+                    out.add(DetectedHardware.active(subsystem, node.toString(), probe.driver(),
+                        probe.description(), withPhysicalPins(probe.lines(), profile)));
+                    live.add(subsystem);
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * Fills in each GPIO line's physical header pin from the detected board profile (the prober reports the
+     * kernel facts only — offset, name, in-use — and leaves the board-specific pin mapping to us).
+     */
+    private static List<GpioLine> withPhysicalPins(List<GpioLine> lines, BoardOverview profile) {
+        if (lines.isEmpty()) {
+            return lines;
+        }
+        return lines.stream()
+            .map(l -> new GpioLine(l.offset(), profile.physicalPin(l.offset()), l.name(), l.used()))
+            .toList();
+    }
+
+    private boolean probePwm(List<DetectedHardware> out) {
+        var chips = SysfsReader.listChildren(SYS_CLASS_PWM, "pwmchip");
+        for (var chip : chips) {
+            var npwm = SysfsReader.firstLine(chip.resolve("npwm"));
+            out.add(DetectedHardware.active(HWInterfaces.PWM, chip.toString(), pwmDriver(chip),
+                npwm == null ? "PWM chip" : npwm + " channels", List.of()));
+        }
+        return !chips.isEmpty();
+    }
+
+    /**
+     * The PWM chip's backing device name (e.g. {@code 1f00098000.pwm}), read from the {@code device} symlink.
+     */
+    private static String pwmDriver(Path chip) {
+        try {
+            return Files.readSymbolicLink(chip.resolve("device")).getFileName().toString();
+        } catch (IOException e) {
+            return null;
+        }
+    }
+}

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/model/BoardOverview.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/model/BoardOverview.java
@@ -1,0 +1,264 @@
+package com.pi4j.plugin.ffm.detect.model;
+
+import com.pi4j.plugin.ffm.detect.probe.dt.DeviceTree;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Supplies platform-appropriate "how to enable this controller" hints.
+ * <p>
+ * Detecting a controller is identical across single-board computers, but the way you <em>turn an interface
+ * on</em> is vendor- and distro-specific. All of that knowledge lives in one data-driven {@link #REGISTRY}:
+ * each {@link BoardDefinition} pairs the signals that identify a board (distro boot-config files, device-tree
+ * {@code compatible} vendor prefixes, {@code model} substrings — read through {@link DeviceTree}) with the
+ * per-subsystem hint strings for that board. {@link #detect()} returns the first matching entry.
+ * <p>
+ * The enable mechanism follows the running <em>image</em> more than the silicon, so distro signatures
+ * (Armbian, Raspberry Pi OS, JetPack, ...) are ordered ahead of the bare silicon vendors (Radxa, Pine64, ...).
+ */
+public final class BoardOverview {
+
+    private static final String GPIO_HINT =
+        "built into the SoC; load the pinctrl/GPIO kernel module if no chip appears";
+    private static final String GENERIC_FALLBACK =
+        "enable the corresponding device-tree overlay for your board and reboot";
+    private static final String GENERIC_LOCATION =
+        "  -> enable the matching device-tree overlay for your board/distro and reboot";
+
+    // Raspberry Pi 40-pin header: BCM GPIO number (== main-bank line offset) -> physical header pin.
+    private static final Map<Integer, Integer> RPI_40PIN_HEADER = Map.ofEntries(
+        Map.entry(2, 3), Map.entry(3, 5), Map.entry(4, 7), Map.entry(14, 8),
+        Map.entry(15, 10), Map.entry(17, 11), Map.entry(18, 12), Map.entry(27, 13),
+        Map.entry(22, 15), Map.entry(23, 16), Map.entry(24, 18), Map.entry(10, 19),
+        Map.entry(9, 21), Map.entry(25, 22), Map.entry(11, 23), Map.entry(8, 24),
+        Map.entry(7, 26), Map.entry(0, 27), Map.entry(1, 28), Map.entry(5, 29),
+        Map.entry(6, 31), Map.entry(12, 32), Map.entry(13, 33), Map.entry(19, 35),
+        Map.entry(16, 36), Map.entry(26, 37), Map.entry(20, 38), Map.entry(21, 40));
+
+    // Ordered most- to least-specific: distro images first (the enable mechanism follows the distro),
+    // then silicon vendors, then the catch-all generic entry (no criteria => always matches).
+    private static final List<BoardDefinition> REGISTRY = List.of(
+        new BoardDefinition("Armbian",
+            List.of("/boot/armbianEnv.txt", "/etc/armbian-release"), Set.of(), List.of(),
+            overlayHints("  -> add to the 'overlays=' line in /boot/armbianEnv.txt "
+                + "(or run armbian-config -> System -> Hardware) and reboot")),
+        new BoardDefinition("Raspberry Pi",
+            List.of("/boot/firmware/config.txt", "/boot/config.txt"), Set.of("raspberrypi"), List.of("Raspberry Pi"),
+            raspberryPiHints()),
+        new BoardDefinition("NVIDIA Jetson",
+            List.of("/etc/nv_tegra_release", "/opt/nvidia/jetson-io"), Set.of("nvidia"), List.of("Jetson"),
+            jetsonHints()),
+        new BoardDefinition("Hardkernel ODROID",
+            List.of("/boot/config.ini", "/media/boot/boot.ini"), Set.of("hardkernel"), List.of("ODROID"),
+            overlayHints("  -> add the overlay to the 'overlays=' line in /boot/config.ini "
+                + "(or /media/boot/boot.ini) and reboot")),
+        new BoardDefinition("Radxa",
+            List.of("/usr/local/sbin/rsetup", "/usr/bin/rsetup"), Set.of("radxa"), List.of("Radxa"),
+            overlayHints("  -> run 'rsetup' -> Overlays (Radxa OS), or add to the 'overlays=' line "
+                + "in /boot/uEnv.txt, then reboot")),
+        new BoardDefinition("Libre Computer",
+            List.of("/usr/bin/ldto"), Set.of("libretech"), List.of("Libre Computer"),
+            overlayHints("  -> run 'sudo ldto enable <overlay>' (e.g. ldto enable spicc-spidev), then reboot")),
+        new BoardDefinition("Orange Pi",
+            List.of("/boot/orangepiEnv.txt"), Set.of(), List.of("Orange Pi"),
+            overlayHints("  -> add to the 'overlays=' line in /boot/orangepiEnv.txt and reboot")),
+        new BoardDefinition("Khadas",
+            List.of(), Set.of("khadas"), List.of("Khadas"),
+            overlayHints("  -> add the overlay to the 'overlays=' line in /boot/env.txt (Khadas/Fenix) and reboot")),
+        new BoardDefinition("Pine64",
+            List.of(), Set.of("pine64"), List.of("Pine64"), overlayHints(GENERIC_LOCATION)),
+        new BoardDefinition("FriendlyELEC",
+            List.of(), Set.of("friendlyarm", "friendlyelec"), List.of("NanoPi"), overlayHints(GENERIC_LOCATION)),
+        new BoardDefinition("Banana Pi",
+            List.of(), Set.of("sinovoip", "bananapi", "lemaker"), List.of("Banana Pi"), overlayHints(GENERIC_LOCATION)),
+        new BoardDefinition("Generic Linux",
+            List.of(), Set.of(), List.of(),
+            overlayHints("  -> enable it in your board's device tree/overlay and reboot")));
+
+    private final String name;
+    private final String kernelVersion;
+    private final Map<HWInterfaces, String> enableHints;
+
+    private BoardOverview(String name, String kernelVersion, Map<HWInterfaces, String> enableHints) {
+        this.name = name;
+        this.kernelVersion = kernelVersion;
+        this.enableHints = enableHints;
+    }
+
+    /**
+     * @return human readable board family name, e.g. {@code "Raspberry Pi"} or {@code "Radxa (ROCK 5B)"}
+     */
+    public String name() {
+        return name;
+    }
+
+    /**
+     * @return the running Linux kernel release (e.g. {@code "6.8.0-52-generic"}), or {@code "unknown"}
+     */
+    public String kernelVersion() {
+        return kernelVersion;
+    }
+
+    /**
+     * @param subsystem the subsystem the caller wants to enable
+     * @return a board-appropriate instruction describing how to enable it
+     */
+    public String enableHint(HWInterfaces subsystem) {
+        return enableHints.getOrDefault(subsystem, GENERIC_FALLBACK);
+    }
+
+    /**
+     * Maps a GPIO line offset to the physical board header pin it is exposed on. Only known for the
+     * Raspberry Pi 40-pin header today; other boards return {@code null}.
+     *
+     * @param gpioOffset the line offset on the chip (the BCM GPIO number on a Raspberry Pi main bank)
+     * @return the physical header pin (1-40), or {@code null} if unknown for this board/offset
+     */
+    public Integer physicalPin(int gpioOffset) {
+        if (name.startsWith("Raspberry Pi")) {
+            return RPI_40PIN_HEADER.get(gpioOffset);
+        }
+        return null;
+    }
+
+    /**
+     * Picks the most specific profile for the running machine.
+     *
+     * @return the detected board profile (never {@code null}; falls back to a generic Linux profile)
+     */
+    public static BoardOverview detect() {
+        return detect(DeviceTree.readModel(), DeviceTree.readCompatible());
+    }
+
+    /**
+     * Resolves a profile from an explicit device-tree model/compatible (package-private for testing).
+     *
+     * @param model      the device-tree {@code model} string ({@code ""} if unknown)
+     * @param compatible the device-tree {@code compatible} list (board entry first)
+     * @return the first matching profile from the registry
+     */
+    static BoardOverview detect(String model, List<String> compatible) {
+        for (var board : REGISTRY) {
+            if (board.matches(model, compatible)) {
+                return new BoardOverview(board.label(model), readKernelVersion(), board.hints());
+            }
+        }
+        throw new IllegalStateException("REGISTRY must contain a catch-all entry");
+    }
+
+    /**
+     * Returns the profile for a registry entry by its base family name (package-private for testing).
+     *
+     * @param baseName the {@link BoardDefinition#name()} to look up
+     * @return the matching profile
+     */
+    static BoardOverview forName(String baseName) {
+        for (var board : REGISTRY) {
+            if (board.name().equals(baseName)) {
+                return new BoardOverview(baseName, readKernelVersion(), board.hints());
+            }
+        }
+        throw new IllegalArgumentException("Unknown board: " + baseName);
+    }
+
+    /**
+     * Reads the running kernel release, preferring {@code /proc/sys/kernel/osrelease} (the same string as
+     * {@code uname -r}) and falling back to the {@code os.version} system property.
+     *
+     * @return the kernel release string, or {@code "unknown"}
+     */
+    private static String readKernelVersion() {
+        var release = Path.of("/proc/sys/kernel/osrelease");
+        if (Files.exists(release)) {
+            try {
+                return Files.readString(release).strip();
+            } catch (IOException e) {
+                // fall through to the system property
+            }
+        }
+        return System.getProperty("os.version", "unknown");
+    }
+
+    /**
+     * One board family: the signals that identify it plus the per-subsystem enable hints.
+     *
+     * @param name              base display name
+     * @param distroFiles       boot-config/tool paths whose presence identifies the distro (any-exists matches)
+     * @param compatibleVendors device-tree {@code compatible} vendor prefixes (any match)
+     * @param modelSubstrings   device-tree {@code model} substrings (case-insensitive, any match)
+     * @param hints             per-subsystem enable hints
+     */
+    private record BoardDefinition(String name, List<String> distroFiles, Set<String> compatibleVendors,
+                                   List<String> modelSubstrings,
+                                   Map<HWInterfaces, String> hints) {
+
+        boolean matches(String model, List<String> compatible) {
+            // A definition with no criteria is the catch-all (generic) entry.
+            if (distroFiles.isEmpty() && compatibleVendors.isEmpty() && modelSubstrings.isEmpty()) {
+                return true;
+            }
+            for (var file : distroFiles) {
+                if (Files.exists(Path.of(file))) {
+                    return true;
+                }
+            }
+            for (var vendor : compatibleVendors) {
+                var prefix = vendor + ",";
+                if (compatible.stream().anyMatch(c -> c.startsWith(prefix))) {
+                    return true;
+                }
+            }
+            var lower = model.toLowerCase();
+            for (var substring : modelSubstrings) {
+                if (lower.contains(substring.toLowerCase())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        String label(String model) {
+            if (model == null || model.isBlank() || model.contains(name)) {
+                return name;
+            }
+            return name + " (" + model + ")";
+        }
+    }
+
+    /**
+     * Builds the hint map for boards whose interfaces are toggled by a device-tree overlay; only the
+     * {@code location} (where/how the overlay is applied) differs between such boards.
+     */
+    private static Map<HWInterfaces, String> overlayHints(String location) {
+        return Map.of(
+            HWInterfaces.I2C, "enable the I2C controller via a device-tree overlay" + location,
+            HWInterfaces.SPI, "enable the SPI controller via a device-tree overlay" + location,
+            HWInterfaces.PWM, "enable the PWM controller via a device-tree overlay" + location,
+            HWInterfaces.GPIO, GPIO_HINT);
+    }
+
+    private static Map<HWInterfaces, String> raspberryPiHints() {
+        var loc = "  -> add to /boot/firmware/config.txt (or /boot/config.txt) and reboot (or use raspi-config)";
+        return Map.of(
+            HWInterfaces.I2C, "dtparam=i2c_arm=on" + loc,
+            HWInterfaces.SPI, "dtparam=spi=on" + loc,
+            HWInterfaces.PWM, "dtoverlay=pwm (or dtoverlay=pwm-2chan)" + loc,
+            HWInterfaces.GPIO, GPIO_HINT);
+    }
+
+    private static Map<HWInterfaces, String> jetsonHints() {
+        var loc = "  -> run 'sudo /opt/nvidia/jetson-io/jetson-io.py' to configure the 40-pin header, then reboot";
+        return Map.of(
+            HWInterfaces.I2C, "most I2C buses are enabled by default; otherwise reconfigure the header" + loc,
+            HWInterfaces.SPI, "enable SPI on the 40-pin header" + loc,
+            HWInterfaces.PWM, "enable PWM on the 40-pin header" + loc,
+            HWInterfaces.GPIO, GPIO_HINT);
+    }
+
+
+}

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/model/DetectedHardware.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/model/DetectedHardware.java
@@ -1,0 +1,76 @@
+package com.pi4j.plugin.ffm.detect.model;
+
+import java.util.List;
+
+/**
+ * A single hardware I/O controller discovered during detection.
+ *
+ * @param subsystem   which kind of I/O this controller provides
+ * @param source      where the evidence came from (a live device node, the device tree, or sysfs buses)
+ * @param state       whether the controller is usable right now, or merely present-but-not-enabled
+ * @param identifier  a stable handle for the controller, e.g. {@code /dev/i2c-1}, {@code spi@7e204000}
+ *                    or a PCI address {@code 0000:00:1f.4}
+ * @param driver      the driver/controller/adapter name (chip label, I2C adapter name, DT {@code compatible}
+ *                    binding, ...); may be {@code null} when unknown
+ * @param description free-form details (line count, decoded I2C functionality, SPI mode/speed, status, ...)
+ * @param enableHint  if {@code state} is not {@link State#ACTIVE}, how to turn the controller on; otherwise {@code null}
+ * @param lines       for a live GPIO chip, the per-line offset → physical-pin → name mapping; empty otherwise
+ */
+public record DetectedHardware(HWInterfaces subsystem, Source source, State state, String identifier,
+                               String driver,
+                               String description,
+                               String enableHint,
+                               List<GpioLine> lines) {
+
+    /**
+     * Where the knowledge about a controller originated.
+     */
+    public enum Source {
+        /**
+         * A live {@code /dev} character device, probed directly via {@code ioctl}.
+         */
+        DEVICE_NODE,
+        /**
+         * The flattened device tree at {@code /proc/device-tree} (ARM/SoC platforms).
+         */
+        DEVICE_TREE,
+        /**
+         * The sysfs bus/class hierarchy ({@code /sys/bus}, {@code /sys/class}) — works on x86/ACPI/PCI too.
+         */
+        SYSFS_BUS
+    }
+
+    /**
+     * The usability of a discovered controller.
+     */
+    public enum State {
+        /**
+         * Driver bound, device node present — ready to use now.
+         */
+        ACTIVE,
+        /**
+         * Hardware exists but is switched off (device tree {@code status = "disabled"}, or driver not loaded).
+         */
+        DISABLED,
+        /**
+         * Hardware/driver present in sysfs but no userspace device node was exported (e.g. {@code i2c-dev} not loaded).
+         */
+        NOT_BOUND
+    }
+
+    /**
+     * Convenience factory for a live, ready-to-use controller.
+     */
+    public static DetectedHardware active(HWInterfaces subsystem, String identifier, String driver,
+                                          String description, List<GpioLine> lines) {
+        return new DetectedHardware(subsystem, Source.DEVICE_NODE, State.ACTIVE, identifier, driver, description,
+            null, lines);
+    }
+
+    /**
+     * @return {@code true} when the controller can be used without any configuration change
+     */
+    public boolean isActive() {
+        return state == State.ACTIVE;
+    }
+}

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/model/DetectionReport.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/model/DetectionReport.java
@@ -1,0 +1,203 @@
+package com.pi4j.plugin.ffm.detect.model;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
+/**
+ * Structured result of a hardware detection run.
+ *
+ * @param boardName         the detected board family (e.g. {@code "Raspberry Pi"}, {@code "Radxa (ROCK 5B)"})
+ * @param kernelVersion     the running Linux kernel release (e.g. {@code "6.8.0-52-generic"})
+ * @param controllers       every controller discovered, in detection order
+ * @param deviceTreePresent whether the platform exposes a device tree (false on most x86/closed firmware machines)
+ */
+public record DetectionReport(String boardName, String kernelVersion, List<DetectedHardware> controllers,
+                              boolean deviceTreePresent) {
+
+    /**
+     * @param subsystem the subsystem to filter by
+     * @return all controllers of the given subsystem
+     */
+    public List<DetectedHardware> of(HWInterfaces subsystem) {
+        return controllers.stream().filter(c -> c.subsystem() == subsystem).toList();
+    }
+
+    /**
+     * @return the set of subsystems for which at least one live, ready-to-use controller exists
+     */
+    public EnumSet<HWInterfaces> activeSubsystems() {
+        var set = EnumSet.noneOf(HWInterfaces.class);
+        for (var c : controllers) {
+            if (c.isActive()) {
+                set.add(c.subsystem());
+            }
+        }
+        return set;
+    }
+
+    /**
+     * Renders the report as a tidy, multi-line block intended to be emitted through a logging framework
+     * (e.g. logback). It leads with a newline so the first line is not appended to the log prefix, indents
+     * the body, and lays out controllers — and each GPIO chip's line map — as aligned, underline-separated
+     * tables that survive log wrapping (no full box borders that break on long, variable cells).
+     *
+     * @return formatted report text
+     */
+    public String renderSummery() {
+        var sb = new StringBuilder();
+        sb.append('\n');
+        sb.append("Hardware I/O detection\n");
+        sb.append("  Board       : ").append(boardName).append('\n');
+        sb.append("  Kernel      : ").append(kernelVersion).append('\n');
+        sb.append("  Device tree : ")
+            .append(deviceTreePresent ? "present" : "absent (x86/ACPI/closed firmware)").append('\n');
+
+        if (controllers.isEmpty()) {
+            sb.append("\n  (no I/O controllers discovered)\n");
+            return sb.toString();
+        }
+
+        // Controllers overview table.
+        sb.append('\n');
+        var rows = new ArrayList<List<String>>();
+        for (var c : controllers) {
+            rows.add(List.of(c.state().name(), c.subsystem().getLabel(), c.identifier(),
+                blankToDash(c.driver()), blankToDash(c.description())));
+        }
+        appendTable(sb, "  ", List.of("State", "Subsystem", "Identifier", "Driver", "Details"), rows);
+
+        // Enable hints for anything present but not active.
+        var hinted = controllers.stream().filter(c -> !c.isActive() && c.enableHint() != null).toList();
+        if (!hinted.isEmpty()) {
+            sb.append("\n  Enable hints:\n");
+            for (var c : hinted) {
+                sb.append("    ").append(c.subsystem().getLabel()).append(' ').append(c.identifier())
+                    .append("  →  ").append(c.enableHint()).append('\n');
+            }
+        }
+        return sb.toString();
+    }
+
+    public String renderGpioDetails() {
+        var sb = new StringBuilder();
+        // Per-chip GPIO line maps.
+        for (var c : controllers) {
+            if (c.subsystem() == HWInterfaces.GPIO && !c.lines().isEmpty()) {
+                sb.append("\n  GPIO ").append(c.identifier()).append(" line map:\n");
+                var lineRows = new ArrayList<List<String>>();
+                for (var line : c.lines()) {
+                    lineRows.add(List.of(
+                        Integer.toString(line.offset()),
+                        line.physicalPin() == null ? "-" : line.physicalPin().toString(),
+                        line.name() == null || line.name().isBlank() ? "unnamed" : line.name(),
+                        line.used() ? "yes" : "-"));
+                }
+                appendTable(sb, "    ", List.of("Offset", "Pin", "Name", "Used"), lineRows);
+            }
+        }
+        return sb.toString();
+    }
+
+    // Cap column width so a very long cell (e.g. the decoded I2C functionality list) wraps instead of
+    // producing an unreadably wide line / separator in the logs.
+    private static final int MAX_COLUMN_WIDTH = 150;
+
+    /**
+     * Appends an aligned table: a header row, an underline separator, then the data rows. Columns are
+     * left-aligned and sized to their widest cell (capped at {@link #MAX_COLUMN_WIDTH}); cells wider than
+     * their column are word-wrapped onto continuation lines. Cells are separated by a two-space gutter.
+     */
+    private static void appendTable(StringBuilder sb, String indent, List<String> headers, List<List<String>> rows) {
+        var columns = headers.size();
+        var width = new int[columns];
+        for (var i = 0; i < columns; i++) {
+            width[i] = headers.get(i).length();
+        }
+        for (var row : rows) {
+            for (var i = 0; i < columns; i++) {
+                width[i] = Math.max(width[i], row.get(i).length());
+            }
+        }
+        for (var i = 0; i < columns; i++) {
+            width[i] = Math.min(width[i], MAX_COLUMN_WIDTH);
+        }
+        appendRow(sb, indent, headers, width);
+        var separators = new ArrayList<String>(columns);
+        for (var i = 0; i < columns; i++) {
+            separators.add("─".repeat(width[i]));
+        }
+        appendRow(sb, indent, separators, width);
+        for (var row : rows) {
+            appendRow(sb, indent, row, width);
+        }
+    }
+
+    /**
+     * Renders one logical row, wrapping each over-long cell to its column width and emitting as many
+     * physical lines as the tallest cell needs (other columns left blank on the continuation lines).
+     */
+    private static void appendRow(StringBuilder sb, String indent, List<String> cells, int[] width) {
+        var wrapped = new ArrayList<List<String>>(cells.size());
+        var lineCount = 1;
+        for (var i = 0; i < cells.size(); i++) {
+            var cellLines = wrap(cells.get(i), width[i]);
+            wrapped.add(cellLines);
+            lineCount = Math.max(lineCount, cellLines.size());
+        }
+        for (var k = 0; k < lineCount; k++) {
+            var line = new StringBuilder(indent);
+            for (var i = 0; i < width.length; i++) {
+                if (i > 0) {
+                    line.append("  ");
+                }
+                var cellLines = wrapped.get(i);
+                var cell = k < cellLines.size() ? cellLines.get(k) : "";
+                line.append(cell);
+                if (i < width.length - 1) {
+                    line.repeat(" ", width[i] - cell.length()); // pad every column except the last
+                }
+            }
+            sb.append(line.toString().stripTrailing()).append('\n');
+        }
+    }
+
+    /**
+     * Word-wraps {@code text} to at most {@code width} characters per line, hard-splitting any single word
+     * longer than the column.
+     */
+    private static List<String> wrap(String text, int width) {
+        if (text.length() <= width) {
+            return List.of(text);
+        }
+        var lines = new ArrayList<String>();
+        var current = new StringBuilder();
+        for (var word : text.split(" ")) {
+            while (word.length() > width) {
+                if (!current.isEmpty()) {
+                    lines.add(current.toString());
+                    current.setLength(0);
+                }
+                lines.add(word.substring(0, width));
+                word = word.substring(width);
+            }
+            if (current.isEmpty()) {
+                current.append(word);
+            } else if (current.length() + 1 + word.length() <= width) {
+                current.append(' ').append(word);
+            } else {
+                lines.add(current.toString());
+                current.setLength(0);
+                current.append(word);
+            }
+        }
+        if (!current.isEmpty()) {
+            lines.add(current.toString());
+        }
+        return lines;
+    }
+
+    private static String blankToDash(String value) {
+        return value == null || value.isBlank() ? "-" : value;
+    }
+}

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/model/GpioLine.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/model/GpioLine.java
@@ -1,0 +1,16 @@
+package com.pi4j.plugin.ffm.detect.model;
+
+/**
+ * One line of a GPIO chip, as reported by the kernel's GPIO v2 line-info ioctl and enriched with the
+ * board's physical header-pin mapping.
+ *
+ * @param offset       the line's local offset on the chip (0-based) — on a Raspberry Pi main bank this equals
+ *                     the BCM GPIO number
+ * @param physicalPin  the physical pin on the board header this line maps to, or {@code null} when the board
+ *                     mapping is unknown (non-Raspberry-Pi, or a line not exposed on the header)
+ * @param name         the kernel-provided line name (from the device-tree {@code gpio-line-names}), or
+ *                     {@code null} when the line is unnamed
+ * @param used         whether the line is currently requested/in use by a consumer
+ */
+public record GpioLine(int offset, Integer physicalPin, String name, boolean used) {
+}

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/model/HWInterfaces.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/model/HWInterfaces.java
@@ -1,0 +1,68 @@
+package com.pi4j.plugin.ffm.detect.model;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The kinds of hardware I/O the detector can discover.
+ * <p>
+ * Each subsystem carries two pieces of knowledge used during detection:
+ * <ul>
+ *     <li>the {@code /dev} node prefixes the kernel uses when the controller is live and a driver is bound, and</li>
+ *     <li>the generic device-tree node name (the part before {@code @}) as recommended by the DT spec.</li>
+ * </ul>
+ * How to <em>enable</em> a disabled controller is board-specific and therefore lives in a
+ * {@code BoardProfile}, not here.
+ */
+public enum HWInterfaces {
+
+    GPIO("GPIO", "gpio", List.of("gpiochip")),
+
+    I2C("I2C", "i2c", List.of("i2c-")),
+
+    SPI("SPI", "spi", List.of("spidev")),
+
+    PWM("PWM", "pwm", List.of());
+
+    private final String label;
+    private final String dtGenericName;
+    private final List<String> devPrefixes;
+
+    HWInterfaces(String label, String dtGenericName, List<String> devPrefixes) {
+        this.label = label;
+        this.dtGenericName = dtGenericName;
+        this.devPrefixes = devPrefixes;
+    }
+
+    /**
+     * @return short display label, e.g. {@code "GPIO"}
+     */
+    public String getLabel() {
+        return label;
+    }
+
+    /**
+     * Returns {@code true} if the given {@code /dev} node name belongs to this subsystem.
+     *
+     * @param devNodeName a file name from {@code /dev}, e.g. {@code "i2c-1"}
+     * @return whether the node name matches one of this subsystem's prefixes
+     */
+    public boolean matchesDevNode(String devNodeName) {
+        return devPrefixes.stream().anyMatch(devNodeName::startsWith);
+    }
+
+    /**
+     * Resolves a subsystem from a device-tree generic node name.
+     *
+     * @param genericName the node name with any {@code @unit-address} suffix already stripped
+     * @return the matching subsystem, if any
+     */
+    public static Optional<HWInterfaces> byDtGenericName(String genericName) {
+        for (var sub : values()) {
+            if (sub.dtGenericName.equals(genericName)) {
+                return Optional.of(sub);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/probe/dev/DeviceNodeProbe.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/probe/dev/DeviceNodeProbe.java
@@ -1,0 +1,219 @@
+package com.pi4j.plugin.ffm.detect.probe.dev;
+
+import com.pi4j.exception.Pi4JException;
+import com.pi4j.plugin.ffm.common.FFMPermissionHelper;
+import com.pi4j.plugin.ffm.common.file.FileDescriptorNative;
+import com.pi4j.plugin.ffm.common.file.FileFlag;
+import com.pi4j.plugin.ffm.common.gpio.PinFlag;
+import com.pi4j.plugin.ffm.common.gpio.structs.ChipInfo;
+import com.pi4j.plugin.ffm.common.gpio.structs.LineAttribute;
+import com.pi4j.plugin.ffm.common.gpio.structs.LineInfo;
+import com.pi4j.plugin.ffm.common.i2c.I2cConstants;
+import com.pi4j.plugin.ffm.common.ioctl.Command;
+import com.pi4j.plugin.ffm.common.ioctl.IoctlNative;
+import com.pi4j.plugin.ffm.detect.model.GpioLine;
+import com.pi4j.plugin.ffm.detect.model.HWInterfaces;
+import com.pi4j.plugin.ffm.detect.probe.sysfs.SysfsReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Opens a live {@code /dev} character device and asks the kernel to describe the controller behind it,
+ * reusing the plugin's existing native plumbing — {@link FileDescriptorNative}, {@link IoctlNative}, the
+ * {@link Command} ioctl request numbers and the {@link ChipInfo} layout — plus {@link SysfsReader} for the
+ * driver/adapter names that {@code ioctl} does not expose.
+ * <ul>
+ *     <li>GPIO — chip {@code name}, {@code label} (driver) and line count from {@link Command#getGpioGetChipInfoIoctl()};</li>
+ *     <li>I2C — the adapter name from sysfs plus the {@link Command#getI2CFuncs()} bitmask decoded into capabilities;</li>
+ *     <li>SPI — bus/chip-select from the node name plus mode, bits-per-word, max speed and bit order.</li>
+ * </ul>
+ * A permission problem is reported with guidance rather than a failing native open.
+ */
+public final class DeviceNodeProbe {
+
+    private static final Logger logger = LoggerFactory.getLogger(DeviceNodeProbe.class);
+
+    private final FileDescriptorNative file = new FileDescriptorNative();
+    private final IoctlNative ioctl = new IoctlNative();
+    /**
+     * Outcome of probing a live device node: the driver/controller name, a free-form detail string, and
+     * (for GPIO chips) the per-line table. The physical-pin field of each line is left {@code null} here —
+     * the board-specific header mapping is applied later by the orchestrator that knows the board profile.
+     *
+     * @param driver      driver/controller/adapter name, or {@code null} when unknown
+     * @param description human readable details
+     * @param lines       the GPIO chip's lines (empty for non-GPIO controllers)
+     */
+    public record ProbeResult(String driver, String description, List<GpioLine> lines) {
+
+        /**
+         * @param driver      driver/controller/adapter name
+         * @param description human readable details
+         * @return a result with no GPIO lines
+         */
+        public static ProbeResult of(String driver, String description) {
+            return new ProbeResult(driver, description, List.of());
+        }
+
+        /**
+         * @param driver      driver/controller/adapter name
+         * @param description human readable details
+         * @param lines       the GPIO chip's lines
+         * @return a result carrying a driver name, details and a line table
+         */
+        public static ProbeResult of(String driver, String description, List<GpioLine> lines) {
+            return new ProbeResult(driver, description, lines);
+        }
+
+        /**
+         * @param description human readable details
+         * @return a result with no known driver name and no GPIO lines
+         */
+        public static ProbeResult description(String description) {
+            return new ProbeResult(null, description, List.of());
+        }
+    }
+    /**
+     * Probes a live device node for its driver name and a one-line detail string.
+     *
+     * @param subsystem the subsystem the node belongs to
+     * @param path      the {@code /dev} node path, e.g. {@code /dev/i2c-1}
+     * @return a {@link ProbeResult}; never throws — failures degrade to a "present" marker
+     */
+    public ProbeResult describe(HWInterfaces subsystem, String path) {
+//        // Reuse the plugin's permission helper: if the current user can't read the node, say why and which
+//        // group to join instead of attempting a native open that would fail with a cryptic EACCES.
+//        var accessIssue = FFMPermissionHelper.diagnoseAccess(path);
+//        if (accessIssue.isPresent()) {
+//            return ProbeResult.description("present (" + accessIssue.get() + ")");
+//        }
+
+        try {
+            FFMPermissionHelper.checkDevicePermissions(path, subsystem, false);
+        } catch (Pi4JException e) {
+            return ProbeResult.description("Error: " + e.getMessage());
+        }
+        try {
+            return switch (subsystem) {
+                case GPIO -> describeGpio(path);
+                case I2C -> describeI2c(path);
+                case SPI -> describeSpi(path);
+                default -> ProbeResult.description("present");
+            };
+        } catch (RuntimeException e) {
+            logger.debug("Probe of {} failed: {}", path, e.getMessage());
+            return ProbeResult.description("present (could not probe: " + e.getMessage() + ")");
+        }
+    }
+
+    private ProbeResult describeGpio(String path) {
+        var fd = file.open(path, FileFlag.O_RDONLY);
+        try {
+            var info = ioctl.call(fd, Command.getGpioGetChipInfoIoctl(), ChipInfo.createEmpty());
+            var name = new String(info.name()).trim();
+            var label = new String(info.label()).trim();
+            var driver = label.isEmpty() ? "gpiochip" : label;
+            var description = "name=" + (name.isEmpty() ? "?" : name) + ", lines=" + info.lines();
+            return ProbeResult.of(driver, description, readLines(fd, info.lines()));
+        } finally {
+            file.close(fd);
+        }
+    }
+
+    /**
+     * Reads each line of an open GPIO chip via {@link Command#getGpioV2GetLineInfoIoctl()}, capturing the
+     * line offset, kernel name and in-use flag. The physical header pin is left {@code null} here; it is
+     * filled in by the orchestrator from the board profile. A failure on one line is skipped, not fatal.
+     */
+    private List<GpioLine> readLines(int fd, int lineCount) {
+        var lines = new ArrayList<GpioLine>(lineCount);
+        for (int offset = 0; offset < lineCount; offset++) {
+            try {
+                var request = new LineInfo(new byte[]{}, new byte[]{}, offset, 0, 0, new LineAttribute[]{});
+                var lineInfo = ioctl.call(fd, Command.getGpioV2GetLineInfoIoctl(), request);
+                var name = new String(lineInfo.name()).trim();
+                var used = (lineInfo.flags() & PinFlag.USED.getValue()) != 0;
+                lines.add(new GpioLine(offset, null, name.isEmpty() ? null : name, used));
+            } catch (RuntimeException e) {
+                logger.debug("Could not read GPIO line {}: {}", offset, e.getMessage());
+            }
+        }
+        return lines;
+    }
+
+    private ProbeResult describeI2c(String path) {
+        var fd = file.open(path, FileFlag.O_RDONLY);
+        try {
+            var funcs = ioctl.call(fd, Command.getI2CFuncs(), 0L);
+            var adapter = SysfsReader.firstLine(Path.of("/sys/class/i2c-dev", nodeName(path), "name"));
+            var driver = adapter == null ? "i2c-adapter" : adapter;
+            var kind = (funcs & I2cConstants.I2C_FUNC_I2C.getValue()) != 0 ? "I2C+SMBus" : "SMBus-only";
+            var description = kind + String.format(", funcs=0x%08x [", funcs) + decodeFunctionality(funcs) + "]";
+            return ProbeResult.of(driver, description);
+        } finally {
+            file.close(fd);
+        }
+    }
+
+    private ProbeResult describeSpi(String path) {
+        var fd = file.open(path, FileFlag.O_RDONLY);
+        try {
+            var mode = ioctl.call(fd, Command.getSpiIocRdMode(), 0) & 0xFF;
+            var bits = ioctl.call(fd, Command.getSpiIocRdBitsPerWord(), 0) & 0xFF;
+            var maxSpeedHz = ioctl.call(fd, Command.getSpiIocRdMaxSpeedHz(), 0);
+            var lsbFirst = (ioctl.call(fd, Command.getSpiIocRdLsbFirst(), 0) & 0xFF) != 0;
+            var modalias = SysfsReader.firstLine(Path.of("/sys/class/spidev", nodeName(path), "device", "modalias"));
+            var driver = modalias == null ? "spidev" : modalias;
+            var bitsPerWord = bits == 0 ? 8 : bits; // 0 means the default of 8
+            var flags = mode > 0x3 ? String.format(" (flags=0x%02x)", mode) : "";
+            var description = busChipSelect(path)
+                + ", mode=" + (mode & 0x3) + flags
+                + ", bits=" + bitsPerWord
+                + ", max=" + maxSpeedHz + " Hz"
+                + ", LSB-first=" + (lsbFirst ? "yes" : "no");
+            return ProbeResult.of(driver, description);
+        } finally {
+            file.close(fd);
+        }
+    }
+
+    /**
+     * Decodes an I2C functionality bitmask into a comma-separated list of capability names, reusing the
+     * {@link I2cConstants} flags from {@code common}. Only atomic (single-bit) {@code I2C_FUNC_*} flags are
+     * listed, so composite aliases (e.g. {@code I2C_FUNC_SMBUS_BYTE}) do not duplicate the output.
+     *
+     * @param funcs the bitmask returned by {@code I2C_FUNCS}
+     * @return e.g. {@code "I2C, SMBUS_QUICK, SMBUS_READ_BYTE, SMBUS_WRITE_BYTE"}
+     */
+    static String decodeFunctionality(long funcs) {
+        return Arrays.stream(I2cConstants.values())
+            .filter(c -> c.name().startsWith("I2C_FUNC_"))
+            .filter(c -> Integer.bitCount(c.getValue()) == 1)
+            .filter(c -> (funcs & (c.getValue() & 0xFFFFFFFFL)) != 0)
+            .map(c -> c.name().substring("I2C_FUNC_".length()))
+            .collect(Collectors.joining(", "));
+    }
+
+    private static String nodeName(String path) {
+        return Path.of(path).getFileName().toString();
+    }
+
+    /**
+     * Turns a {@code spidevB.C} node name into a {@code "bus=B cs=C"} description.
+     */
+    private static String busChipSelect(String path) {
+        var node = nodeName(path);
+        var trimmed = node.startsWith("spidev") ? node.substring("spidev".length()) : node;
+        var dot = trimmed.indexOf('.');
+        if (dot > 0) {
+            return "bus=" + trimmed.substring(0, dot) + " cs=" + trimmed.substring(dot + 1);
+        }
+        return node;
+    }
+}

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/probe/dt/DeviceTree.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/probe/dt/DeviceTree.java
@@ -1,0 +1,112 @@
+package com.pi4j.plugin.ffm.detect.probe.dt;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Read-only access to the flattened device tree, mounted as a filesystem at {@code /proc/device-tree}
+ * (an alias of {@code /sys/firmware/devicetree/base}): one directory per node, one file per property.
+ * <p>
+ * Shared by the board-profile detection and the device-tree scanner so the NUL-separated string parsing
+ * lives in exactly one place. Reading it is plain file I/O — no {@code gpiod}, no shell, no FFM.
+ */
+public final class DeviceTree {
+
+    private static final Logger logger = LoggerFactory.getLogger(DeviceTree.class);
+
+    private static final Path[] ROOTS = {
+        Path.of("/proc/device-tree"),
+        Path.of("/sys/firmware/devicetree/base")
+    };
+
+    private DeviceTree() {
+    }
+
+    /**
+     * @return {@code true} if this platform exposes a device tree at all
+     */
+    public static boolean isAvailable() {
+        return root() != null;
+    }
+
+    /**
+     * @return the device-tree root directory, or {@code null} when none is mounted (e.g. x86)
+     */
+    public static Path root() {
+        for (var root : ROOTS) {
+            if (Files.isDirectory(root)) {
+                return root;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @return the board name from {@code <root>/model}, or an empty string if unavailable
+     */
+    public static String readModel() {
+        var strings = readStrings(propertyPath("model"));
+        return strings.isEmpty() ? "" : strings.getFirst();
+    }
+
+    /**
+     * @return the device-tree {@code compatible} list (board entry first), or an empty list
+     */
+    public static List<String> readCompatible() {
+        return readStrings(propertyPath("compatible"));
+    }
+
+    /**
+     * Reads the first string of a property (e.g. a node's {@code status}).
+     *
+     * @param path the property file
+     * @return the first NUL-delimited string, or {@code null} if the property is absent/empty
+     */
+    public static String readString(Path path) {
+        var strings = readStrings(path);
+        return strings.isEmpty() ? null : strings.getFirst();
+    }
+
+    /**
+     * Reads a device-tree string or string-list property: NUL-separated, NUL-terminated values.
+     *
+     * @param path the property file
+     * @return the parsed strings (empty if the file is missing or unreadable)
+     */
+    public static List<String> readStrings(Path path) {
+        if (path == null || !Files.exists(path)) {
+            return List.of();
+        }
+        try {
+            var raw = Files.readAllBytes(path);
+            var list = new ArrayList<String>();
+            int start = 0;
+            for (int i = 0; i < raw.length; i++) {
+                if (raw[i] == 0) {
+                    if (i > start) {
+                        list.add(new String(raw, start, i - start).strip());
+                    }
+                    start = i + 1;
+                }
+            }
+            if (start < raw.length) {
+                list.add(new String(raw, start, raw.length - start).strip());
+            }
+            return list;
+        } catch (IOException e) {
+            logger.debug("Could not read device-tree property {}: {}", path, e.getMessage());
+            return List.of();
+        }
+    }
+
+    private static Path propertyPath(String property) {
+        var root = root();
+        return root == null ? null : root.resolve(property);
+    }
+}

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/probe/dt/DeviceTreeScanner.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/probe/dt/DeviceTreeScanner.java
@@ -1,0 +1,98 @@
+package com.pi4j.plugin.ffm.detect.probe.dt;
+
+import com.pi4j.plugin.ffm.detect.model.BoardOverview;
+import com.pi4j.plugin.ffm.detect.model.DetectedHardware;
+import com.pi4j.plugin.ffm.detect.model.HWInterfaces;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * Discovers I/O controllers the SoC exposes through the device tree but that have no live {@code /dev}
+ * node — controllers that are present but switched off ({@code status = "disabled"}) or whose driver has
+ * not bound. Controllers are matched by their DT-spec generic node name (e.g. {@code i2c@…}, {@code spi@…}),
+ * which makes the scan vendor-agnostic. File access goes through {@link DeviceTree}.
+ */
+public final class DeviceTreeScanner {
+
+    private static final Logger logger = LoggerFactory.getLogger(DeviceTreeScanner.class);
+
+    private final BoardOverview profile;
+
+    /**
+     * Creates a scanner with an explicit board profile (useful for testing).
+     *
+     * @param profile supplies the platform-appropriate enable hints
+     */
+    public DeviceTreeScanner(BoardOverview profile) {
+        this.profile = profile;
+    }
+
+    /**
+     * @return {@code true} if this platform exposes a device tree at all
+     */
+    public static boolean isAvailable() {
+        return DeviceTree.isAvailable();
+    }
+
+    /**
+     * Walks the device tree and reports controllers for the requested subsystems.
+     *
+     * @param wanted only return controllers for these subsystems (typically the ones with no live node)
+     * @return discovered controllers, each carrying its {@code status} and a board-appropriate enable hint
+     */
+    public List<DetectedHardware> scan(Set<HWInterfaces> wanted) {
+        var root = DeviceTree.root();
+        if (root == null || wanted.isEmpty()) {
+            return List.of();
+        }
+        var out = new ArrayList<DetectedHardware>();
+        try (Stream<Path> tree = Files.walk(root)) {
+            tree.filter(Files::isDirectory).forEach(dir -> {
+                var generic = genericName(dir.getFileName().toString());
+                var subsystem = HWInterfaces.byDtGenericName(generic).orElse(null);
+                if (subsystem == null || !wanted.contains(subsystem)) {
+                    return;
+                }
+                // A real controller node always carries a 'compatible' property.
+                var compatibleFile = dir.resolve("compatible");
+                if (!Files.exists(compatibleFile)) {
+                    return;
+                }
+                var compatible = DeviceTree.readStrings(compatibleFile);
+                var status = DeviceTree.readString(dir.resolve("status")); // absent => "okay" per the DT spec
+                var enabled = status == null || status.equals("okay") || status.equals("ok");
+
+                // The first 'compatible' entry is the most specific binding — i.e. the driver match.
+                var driver = compatible.isEmpty() ? null : compatible.getFirst();
+                var remaining = compatible.size() > 1
+                    ? String.join(", ", compatible.subList(1, compatible.size())) + " "
+                    : "";
+                var description = remaining + "[status=" + (status == null ? "okay" : status) + "]";
+                var state = enabled
+                    ? DetectedHardware.State.NOT_BOUND // okay in DT but no /dev node => driver not bound
+                    : DetectedHardware.State.DISABLED; // explicitly switched off
+
+                out.add(new DetectedHardware(subsystem, DetectedHardware.Source.DEVICE_TREE,
+                    state, dir.getFileName().toString(), driver, description, profile.enableHint(subsystem),
+                    List.of()));
+            });
+        } catch (IOException e) {
+            logger.warn("Could not walk device tree at {}: {}", root, e.getMessage());
+        }
+        out.sort(Comparator.comparing(a -> (a.subsystem().getLabel() + a.identifier())));
+        return out;
+    }
+    private static String genericName(String node) {
+        var at = node.indexOf('@');
+        return at >= 0 ? node.substring(0, at) : node;
+    }
+}

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/probe/sysfs/SysfsBusScanner.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/probe/sysfs/SysfsBusScanner.java
@@ -1,0 +1,131 @@
+package com.pi4j.plugin.ffm.detect.probe.sysfs;
+
+import com.pi4j.plugin.ffm.detect.model.DetectedHardware;
+import com.pi4j.plugin.ffm.detect.model.HWInterfaces;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Fallback discovery for platforms that do <em>not</em> expose a device tree — typically x86/x86-64, or any
+ * machine where the firmware (UEFI/ACPI, vendor BIOS) keeps the hardware description closed.
+ * <p>
+ * Controllers are enumerated through the sysfs bus/class hierarchy via {@link SysfsReader}:
+ * <ul>
+ *     <li>{@code /sys/bus/i2c/devices}  — I2C/SMBus adapters (present even when {@code i2c-dev} is not loaded),</li>
+ *     <li>{@code /sys/class/spi_master} — SPI controllers,</li>
+ *     <li>{@code /sys/bus/gpio/devices} — GPIO chips,</li>
+ *     <li>{@code /sys/bus/pci/devices}  — PCI SMBus controllers (class {@code 0x0c05}).</li>
+ * </ul>
+ * The enable hints point at the real levers on such platforms (loading a kernel module or a BIOS/UEFI
+ * setting) rather than a {@code config.txt} overlay.
+ */
+public final class SysfsBusScanner {
+
+    private static final Path DEV = Path.of("/dev");
+    private static final Path SYS_BUS_I2C = Path.of("/sys/bus/i2c/devices");
+    private static final Path SYS_CLASS_SPI = Path.of("/sys/class/spi_master");
+    private static final Path SYS_BUS_GPIO = Path.of("/sys/bus/gpio/devices");
+    private static final Path SYS_BUS_PCI = Path.of("/sys/bus/pci/devices");
+
+    // PCI base class code (top 16 bits of the 24-bit class): serial bus controller / SMBus.
+    private static final int PCI_CLASS_SMBUS = 0x0c05;
+
+    private static final String HINT_I2C_DEV =
+        "modprobe i2c-dev  (adapter is present; only the I2C character-device interface is missing)";
+    private static final String HINT_PCI_SMBUS =
+        "load the chipset SMBus driver (e.g. i2c-i801 on Intel, i2c-piix4 on AMD), then modprobe i2c-dev; "
+            + "if the controller is hidden, enable it in BIOS/UEFI";
+    private static final String HINT_SPI =
+        "bind the spidev driver (modprobe spidev) and declare the chip via an ACPI override or board file";
+    private static final String HINT_GPIO =
+        "load the platform pinctrl/GPIO driver for your chipset (e.g. an Intel/AMD pinctrl module)";
+
+    /**
+     * Enumerates controllers visible through sysfs for the requested subsystems that have no live device node.
+     *
+     * @param wanted subsystems to look for (typically the ones with no live {@code /dev} node)
+     * @return discovered controllers, marked {@link DetectedHardware.State#NOT_BOUND} with a platform hint
+     */
+    public List<DetectedHardware> scan(Set<HWInterfaces> wanted) {
+        var out = new ArrayList<DetectedHardware>();
+        if (wanted.contains(HWInterfaces.I2C)) {
+            scanI2cAdapters(out);
+        }
+        if (wanted.contains(HWInterfaces.SPI)) {
+            scanSpiMasters(out);
+        }
+        if (wanted.contains(HWInterfaces.GPIO)) {
+            scanGpioChips(out);
+        }
+        if (wanted.contains(HWInterfaces.I2C)) {
+            scanPciSmbus(out);
+        }
+        out.sort(Comparator.comparing(a -> (a.subsystem().getLabel() + a.identifier())));
+        return out;
+    }
+
+    private void scanI2cAdapters(List<DetectedHardware> out) {
+        for (var entry : SysfsReader.listChildren(SYS_BUS_I2C, "i2c-")) {
+            var node = entry.getFileName().toString();           // e.g. "i2c-0"
+            if (Files.exists(DEV.resolve(node))) {
+                continue;                                        // already live, counted elsewhere
+            }
+            var name = SysfsReader.firstLine(entry.resolve("name"));
+            out.add(new DetectedHardware(HWInterfaces.I2C, DetectedHardware.Source.SYSFS_BUS,
+                DetectedHardware.State.NOT_BOUND, node,
+                name == null ? "i2c-adapter" : name, "I2C adapter (no character device)", HINT_I2C_DEV, List.of()));
+        }
+    }
+
+    private void scanSpiMasters(List<DetectedHardware> out) {
+        for (var entry : SysfsReader.listChildren(SYS_CLASS_SPI, "spi")) {
+            var node = entry.getFileName().toString();           // e.g. "spi0"
+            out.add(new DetectedHardware(HWInterfaces.SPI, DetectedHardware.Source.SYSFS_BUS,
+                DetectedHardware.State.NOT_BOUND, node, node,
+                "SPI master controller (no spidev node)", HINT_SPI, List.of()));
+        }
+    }
+
+    private void scanGpioChips(List<DetectedHardware> out) {
+        for (var entry : SysfsReader.listChildren(SYS_BUS_GPIO, "gpiochip")) {
+            var node = entry.getFileName().toString();           // e.g. "gpiochip0"
+            if (Files.exists(DEV.resolve(node))) {
+                continue;                                        // already live
+            }
+            var label = SysfsReader.firstLine(entry.resolve("label"));
+            out.add(new DetectedHardware(HWInterfaces.GPIO, DetectedHardware.Source.SYSFS_BUS,
+                DetectedHardware.State.NOT_BOUND, node,
+                label == null ? "gpiochip" : label, "GPIO chip (no character device)", HINT_GPIO, List.of()));
+        }
+    }
+
+    private void scanPciSmbus(List<DetectedHardware> out) {
+        for (var dev : SysfsReader.listChildren(SYS_BUS_PCI, "")) {
+            var classCode = SysfsReader.readHex(dev.resolve("class"));   // e.g. 0x0c0500
+            if (classCode < 0) {
+                continue;
+            }
+            var baseClass = (classCode >> 8) & 0xFFFF;
+            if (baseClass == PCI_CLASS_SMBUS) {
+                var address = dev.getFileName().toString();             // e.g. 0000:00:1f.4
+                out.add(new DetectedHardware(HWInterfaces.I2C, DetectedHardware.Source.SYSFS_BUS,
+                    DetectedHardware.State.NOT_BOUND, address,
+                    "PCI SMBus " + pciId(dev), "SMBus host controller (no i2c-dev node)", HINT_PCI_SMBUS, List.of()));
+            }
+        }
+    }
+
+    private static String pciId(Path dev) {
+        var vendor = SysfsReader.firstLine(dev.resolve("vendor"));
+        var device = SysfsReader.firstLine(dev.resolve("device"));
+        if (vendor == null || device == null) {
+            return "";
+        }
+        return "[" + vendor.replace("0x", "") + ":" + device.replace("0x", "") + "]";
+    }
+}

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/probe/sysfs/SysfsReader.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/detect/probe/sysfs/SysfsReader.java
@@ -1,0 +1,72 @@
+package com.pi4j.plugin.ffm.detect.probe.sysfs;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Small read-only helpers for the sysfs hierarchy ({@code /sys/bus}, {@code /sys/class}, ...).
+ * Used by the sysfs bus scanner so the file-reading boilerplate is not repeated.
+ */
+public final class SysfsReader {
+
+    private static final Logger logger = LoggerFactory.getLogger(SysfsReader.class);
+
+    private SysfsReader() {
+    }
+
+    /**
+     * @param path a sysfs attribute file
+     * @return the stripped first line, or {@code null} if the file is absent/unreadable
+     */
+    public static String firstLine(Path path) {
+        if (!Files.exists(path)) {
+            return null;
+        }
+        try {
+            return Files.readString(path).strip();
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    /**
+     * @param path a sysfs attribute file holding a {@code 0x}-prefixed hex value (e.g. a PCI {@code class})
+     * @return the decoded value, or {@code -1} if absent/unparseable
+     */
+    public static int readHex(Path path) {
+        var text = firstLine(path);
+        if (text == null) {
+            return -1;
+        }
+        try {
+            return Integer.decode(text);
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    /**
+     * Lists the children of a sysfs directory whose names start with the given prefix, sorted.
+     *
+     * @param dir    the directory to list
+     * @param prefix required child-name prefix
+     * @return matching child paths (empty if {@code dir} is not a directory or cannot be listed)
+     */
+    public static List<Path> listChildren(Path dir, String prefix) {
+        if (!Files.isDirectory(dir)) {
+            return List.of();
+        }
+        try (Stream<Path> children = Files.list(dir)) {
+            return children.filter(p -> p.getFileName().toString().startsWith(prefix)).sorted().toList();
+        } catch (IOException e) {
+            logger.warn("Could not list {}: {}", dir, e.getMessage());
+            return List.of();
+        }
+    }
+}

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMDigitalInput.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMDigitalInput.java
@@ -19,6 +19,7 @@ import com.pi4j.plugin.ffm.common.ioctl.IoctlNative;
 import com.pi4j.plugin.ffm.common.poll.PollFlag;
 import com.pi4j.plugin.ffm.common.poll.PollNative;
 import com.pi4j.plugin.ffm.common.poll.structs.PollingData;
+import com.pi4j.plugin.ffm.detect.model.HWInterfaces;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +67,7 @@ public class FFMDigitalInput extends DigitalInputBase implements DigitalInput {
         this.deviceName = "/dev/gpiochip" + config.bus();
         this.debounce = (config.debounce() != null && config.debounce() >= 0) ? config.debounce() : 0;
         this.pull = config.pull();
-        FFMPermissionHelper.checkDevicePermissions(deviceName, config);
+        FFMPermissionHelper.checkDevicePermissions(deviceName, HWInterfaces.GPIO, true);
     }
 
     @Override

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMDigitalOutput.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMDigitalOutput.java
@@ -13,6 +13,7 @@ import com.pi4j.plugin.ffm.common.gpio.PinFlag;
 import com.pi4j.plugin.ffm.common.gpio.structs.*;
 import com.pi4j.plugin.ffm.common.ioctl.Command;
 import com.pi4j.plugin.ffm.common.ioctl.IoctlNative;
+import com.pi4j.plugin.ffm.detect.model.HWInterfaces;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +36,7 @@ public class FFMDigitalOutput extends DigitalOutputBase implements DigitalOutput
         super(provider, config);
         this.bcm = config.bcm();
         this.deviceName = "/dev/gpiochip" + config.bus();
-        FFMPermissionHelper.checkDevicePermissions(deviceName, config);
+        FFMPermissionHelper.checkDevicePermissions(deviceName, HWInterfaces.GPIO, true);
     }
 
     @Override

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/FFMI2CBus.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/FFMI2CBus.java
@@ -11,6 +11,7 @@ import com.pi4j.plugin.ffm.common.file.FileDescriptorNative;
 import com.pi4j.plugin.ffm.common.file.FileFlag;
 import com.pi4j.plugin.ffm.common.ioctl.Command;
 import com.pi4j.plugin.ffm.common.ioctl.IoctlNative;
+import com.pi4j.plugin.ffm.detect.model.HWInterfaces;
 import com.pi4j.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +41,7 @@ public class FFMI2CBus extends I2CBusBase {
     public FFMI2CBus(I2CConfig config) {
         super(config);
         this.busName = I2C_BUS + bus;
-        FFMPermissionHelper.checkDevicePermissions(busName, config);
+        FFMPermissionHelper.checkDevicePermissions(busName, HWInterfaces.I2C, true);
         try {
             logger.debug("{} - setting up I2CBus...", busName);
             if (!canAccessDevice()) {

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/pwm/FFMPwmHardware.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/pwm/FFMPwmHardware.java
@@ -10,6 +10,7 @@ import com.pi4j.plugin.ffm.common.FFMPermissionHelper;
 import com.pi4j.plugin.ffm.common.FileWatcher;
 import com.pi4j.plugin.ffm.common.file.FileDescriptorNative;
 import com.pi4j.plugin.ffm.common.file.FileFlag;
+import com.pi4j.plugin.ffm.detect.model.HWInterfaces;
 import com.pi4j.util.Delay;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +49,7 @@ public class FFMPwmHardware extends PwmBase implements Pwm {
         super(provider, config);
         this.chip = config.chip();
         this.channel = config.channel();
-        FFMPermissionHelper.checkDevicePermissions(CHIP_PATH + chip, config);
+        FFMPermissionHelper.checkDevicePermissions(CHIP_PATH + chip, HWInterfaces.PWM, true);
     }
 
     /**

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/spi/FFMSpi.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/spi/FFMSpi.java
@@ -16,6 +16,7 @@ import com.pi4j.plugin.ffm.common.ioctl.Command;
 import com.pi4j.plugin.ffm.common.ioctl.IoctlNative;
 import com.pi4j.plugin.ffm.common.spi.SpiMultipleTransferBuffer;
 import com.pi4j.plugin.ffm.common.spi.SpiTransferBuffer;
+import com.pi4j.plugin.ffm.detect.model.HWInterfaces;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +36,7 @@ public class FFMSpi extends SpiBase implements Spi {
     public FFMSpi(SpiProvider provider, SpiConfig config) {
         super(provider, config);
         this.path = SPI_BUS + config.bus().getBus() + "." + config.channel();
-        FFMPermissionHelper.checkDevicePermissions(path, config);
+        FFMPermissionHelper.checkDevicePermissions(path, HWInterfaces.SPI, true);
     }
 
     /**

--- a/plugins/pi4j-plugin-ffm/src/main/java/module-info.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/module-info.java
@@ -36,6 +36,9 @@ module com.pi4j.plugin.ffm {
     exports com.pi4j.plugin.ffm.providers.spi;
     exports com.pi4j.plugin.ffm.providers.i2c;
     exports com.pi4j.plugin.ffm.providers.gpio;
+    exports com.pi4j.plugin.ffm.detect;
+    exports com.pi4j.plugin.ffm.detect.model;
+    exports com.pi4j.plugin.ffm.detect.model;
 
     provides com.pi4j.extension.Plugin with FFMPlugin;
 }

--- a/plugins/pi4j-plugin-ffm/src/main/java/module-info.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/module-info.java
@@ -38,7 +38,6 @@ module com.pi4j.plugin.ffm {
     exports com.pi4j.plugin.ffm.providers.gpio;
     exports com.pi4j.plugin.ffm.detect;
     exports com.pi4j.plugin.ffm.detect.model;
-    exports com.pi4j.plugin.ffm.detect.model;
 
     provides com.pi4j.extension.Plugin with FFMPlugin;
 }

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/detect/HardwareDetectorTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/detect/HardwareDetectorTest.java
@@ -1,0 +1,86 @@
+package com.pi4j.plugin.ffm.detect;
+
+import com.pi4j.plugin.ffm.detect.model.DetectedHardware;
+import com.pi4j.plugin.ffm.detect.model.DetectedHardware.Source;
+import com.pi4j.plugin.ffm.detect.model.DetectedHardware.State;
+import com.pi4j.plugin.ffm.detect.model.DetectionReport;
+import com.pi4j.plugin.ffm.detect.model.GpioLine;
+import com.pi4j.plugin.ffm.detect.model.HWInterfaces;
+import com.pi4j.plugin.ffm.detect.probe.sysfs.SysfsBusScanner;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the detection orchestrator and its domain model. Deterministic and hardware-free: the
+ * end-to-end {@link HardwareDetector#detect()} sweep is run only as a smoke test that must degrade
+ * gracefully on a machine with no GPIO/I2C/SPI/PWM controllers.
+ */
+public class HardwareDetectorTest {
+
+    @Test
+    public void serialSupportIsRemoved() {
+        assertThrows(IllegalArgumentException.class, () -> HWInterfaces.valueOf("SERIAL"));
+        assertEquals(EnumSet.of(HWInterfaces.GPIO, HWInterfaces.I2C, HWInterfaces.SPI, HWInterfaces.PWM),
+            EnumSet.allOf(HWInterfaces.class));
+        assertTrue(HWInterfaces.byDtGenericName("serial").isEmpty());
+    }
+
+    @Test
+    public void subsystemMatchesNodesAndDtNames() {
+        assertTrue(HWInterfaces.I2C.matchesDevNode("i2c-1"));
+        assertFalse(HWInterfaces.I2C.matchesDevNode("spidev0.0"));
+        assertTrue(HWInterfaces.GPIO.matchesDevNode("gpiochip0"));
+        assertEquals(HWInterfaces.SPI, HWInterfaces.byDtGenericName("spi").orElseThrow());
+        assertTrue(HWInterfaces.byDtGenericName("nonsense").isEmpty());
+    }
+
+    @Test
+    public void reportQueriesAndRendering() {
+        var lines = List.of(new GpioLine(0, 27, "ID_SD", true), new GpioLine(2, 3, "GPIO2", false));
+        var gpio = DetectedHardware.active(HWInterfaces.GPIO, "/dev/gpiochip0", "pinctrl-rp1",
+            "name=gpiochip0, lines=54", lines);
+        var spi = new DetectedHardware(HWInterfaces.SPI, Source.DEVICE_TREE, State.DISABLED,
+            "spi@7e204000", "brcm,bcm2835-spi", "[status=disabled]", "dtparam=spi=on", List.of());
+        var report = new DetectionReport("Raspberry Pi", "6.8.0-52-generic", List.of(gpio, spi), true);
+
+        assertEquals(List.of(spi), report.of(HWInterfaces.SPI));
+        assertEquals(EnumSet.of(HWInterfaces.GPIO), report.activeSubsystems());
+
+        var text = report.renderSummery();
+        assertTrue(text.contains("Raspberry Pi"), text); // board name in the header
+        assertTrue(text.contains("6.8.0-52-generic"), text); // kernel version in the header
+        assertTrue(text.contains("/dev/gpiochip0"), text);
+        assertTrue(text.contains("pinctrl-rp1"), text);   // driver column
+        assertTrue(text.contains("lines=54"), text);      // description detail
+        assertTrue(text.contains("dtparam=spi=on"), text); // enable hint shown only for the non-active controller
+    }
+
+    @Test
+    public void scannersHandleEmptyRequest() {
+        assertTrue(new SysfsBusScanner().scan(EnumSet.noneOf(HWInterfaces.class)).isEmpty());
+    }
+
+    @Test
+    public void detectIsHardwareSafeAndSerialFree() {
+        var report = new HardwareDetector().detect();
+
+        assertNotNull(report);
+        assertNotNull(report.boardName());
+        assertNotNull(report.controllers());
+        assertNotNull(report.renderSummery());
+        for (var controller : report.controllers()) {
+            assertNotNull(controller.subsystem());
+            assertNotNull(controller.identifier());
+            assertNotEquals("SERIAL", controller.subsystem().name());
+        }
+    }
+}

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/detect/model/BoardOverviewTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/detect/model/BoardOverviewTest.java
@@ -1,0 +1,62 @@
+package com.pi4j.plugin.ffm.detect.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BoardOverviewTest {
+
+    @Test
+    public void detectedProfileProvidesHintForEverySubsystem() {
+        var profile = BoardOverview.detect();
+        assertNotNull(profile.name());
+        assertFalse(profile.name().isBlank());
+        for (var subsystem : HWInterfaces.values()) {
+            var hint = profile.enableHint(subsystem);
+            assertNotNull(hint);
+            assertFalse(hint.isBlank(), subsystem.name());
+        }
+    }
+
+    @Test
+    public void raspberryPiProfileUsesDtparam() {
+        var profile = BoardOverview.forName("Raspberry Pi");
+        assertEquals("Raspberry Pi", profile.name());
+        assertTrue(profile.enableHint(HWInterfaces.SPI).contains("dtparam=spi=on"));
+        assertTrue(profile.enableHint(HWInterfaces.SPI).contains("config.txt"));
+    }
+
+    @Test
+    public void overlayProfilesUseTheRightMechanism() {
+        assertTrue(BoardOverview.forName("Armbian").enableHint(HWInterfaces.SPI).contains("overlays="));
+        assertTrue(BoardOverview.forName("Armbian").enableHint(HWInterfaces.SPI).contains("armbianEnv.txt"));
+        assertTrue(BoardOverview.forName("Radxa").enableHint(HWInterfaces.SPI).contains("rsetup"));
+        assertTrue(BoardOverview.forName("NVIDIA Jetson").enableHint(HWInterfaces.SPI).contains("jetson-io"));
+        assertTrue(BoardOverview.forName("Hardkernel ODROID").enableHint(HWInterfaces.I2C).contains("config.ini"));
+        assertTrue(BoardOverview.forName("Khadas").enableHint(HWInterfaces.PWM).contains("env.txt"));
+        assertTrue(BoardOverview.forName("Libre Computer").enableHint(HWInterfaces.SPI).contains("ldto"));
+    }
+
+    @Test
+    public void detectMatchesVendorFromDeviceTreeCompatible() {
+        assertEquals("Radxa", BoardOverview.detect("", List.of("radxa,rock-5b", "rockchip,rk3588")).name());
+        assertEquals("NVIDIA Jetson", BoardOverview.detect("", List.of("nvidia,p3450-0000", "nvidia,tegra210")).name());
+        assertEquals("Hardkernel ODROID", BoardOverview.detect("", List.of("hardkernel,odroid-n2", "amlogic,g12b")).name());
+        // A bare SoC vendor is not a board vendor — fall through to the generic profile.
+        assertEquals("Generic Linux", BoardOverview.detect("", List.of("rockchip,rk3399")).name());
+        // Model-string fallback when 'compatible' carries no known board vendor.
+        assertTrue(BoardOverview.detect("Pine64 RockPro64", List.of()).name().contains("Pine64"));
+    }
+
+    @Test
+    public void detectFoldsModelIntoName() {
+        var profile = BoardOverview.detect("ROCK 5B", List.of("radxa,rock-5b", "rockchip,rk3588"));
+        assertTrue(profile.name().contains("Radxa"), profile.name());
+        assertTrue(profile.name().contains("ROCK 5B"), profile.name());
+    }
+}

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/mocks/PermissionHelperMock.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/mocks/PermissionHelperMock.java
@@ -3,14 +3,13 @@ package com.pi4j.plugin.ffm.mocks;
 import com.pi4j.plugin.ffm.common.FFMPermissionHelper;
 import org.mockito.MockedStatic;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mockStatic;
 
 public class PermissionHelperMock {
     public static MockedStatic<FFMPermissionHelper> echo() {
         var mock = mockStatic(FFMPermissionHelper.class);
-        mock.when(() -> FFMPermissionHelper.checkDevicePermissions(anyString(), any())).thenAnswer((_) -> null);
+        mock.when(() -> FFMPermissionHelper.checkDevicePermissions(anyString(), any(), anyBoolean())).thenAnswer((_) -> null);
         mock.when(() -> FFMPermissionHelper.checkUserPermissions(any())).thenAnswer((_) -> null);
         return mock;
     }


### PR DESCRIPTION
New hardware detection system. Consists of steps:

1) Look at alive interfaces in /dev and PWM
2) Look at device tree to determine "disabled" interfaces
3) Fallback to ACPI if nothing found

I put this in FFM plugin right now, not to mess up with dependencies in pi4j-core. When it will be in core we can decide how to move this functions.

Example output (rpi5):
```
13:45:01.210 [main] DEBUG com.pi4j.plugin.ffm.FFMPlugin - FFM plugin hardware detection:

Hardware I/O detection
  Board       : Raspberry Pi
  Kernel      : 6.8.0-1057-raspi
  Device tree : present

  State   Subsystem  Identifier               Driver                   Details
  ──────  ─────────  ───────────────────────  ───────────────────────  ─────────────────────────────────────────────────────────────────────────────
  ACTIVE  GPIO       /dev/gpiochip0           gpio-brcmstb@107d508500  name=gpiochip0, lines=32
  ACTIVE  GPIO       /dev/gpiochip1           gpio-brcmstb@107d508520  name=gpiochip1, lines=4
  ACTIVE  GPIO       /dev/gpiochip2           gpio-brcmstb@107d517c00  name=gpiochip2, lines=15
  ACTIVE  GPIO       /dev/gpiochip3           gpio-brcmstb@107d517c20  name=gpiochip3, lines=6
  ACTIVE  GPIO       /dev/gpiochip4           pinctrl-rp1              name=gpiochip4, lines=54
  ACTIVE  I2C        /dev/i2c-1               -                        Error: Device '/dev/i2c-1' (root:dialout) does not belong to group 'i2c'.
  ACTIVE  I2C        /dev/i2c-13              -                        Error: Device '/dev/i2c-13' (root:root) does not belong to group 'i2c'.
  ACTIVE  I2C        /dev/i2c-14              -                        Error: Device '/dev/i2c-14' (root:root) does not belong to group 'i2c'.
  ACTIVE  SPI        /dev/spidev0.0           -                        Error: Device '/dev/spidev0.0' (root:dialout) does not belong to group 'spi'.
  ACTIVE  SPI        /dev/spidev0.1           -                        Error: Device '/dev/spidev0.1' (root:dialout) does not belong to group 'spi'.
  ACTIVE  SPI        /dev/spidev10.0          -                        Error: Device '/dev/spidev10.0' (root:root) does not belong to group 'spi'.
  ACTIVE  PWM        /sys/class/pwm/pwmchip0  107d517a80.pwm           2 channels

```

And GPIO related:
```
13:45:01.212 [main] TRACE com.pi4j.plugin.ffm.FFMPlugin - GPIO details:

  GPIO /dev/gpiochip0 line map:
    Offset  Pin  Name            Used
    ──────  ───  ──────────────  ────
    0       27   -               -
    1       28   2712_BOOT_CS_N  yes
    2       3    2712_BOOT_MISO  -
    3       5    2712_BOOT_MOSI  -
    4       7    2712_BOOT_SCLK  -
    5       29   -               -
    6       31   -               -
    7       26   -               -
    8       24   -               -
    9       21   -               -
    10      19   -               -
    11      23   -               -
    12      32   -               -
    13      33   -               -
    14      8    PCIE_SDA        -
    15      10   PCIE_SCL        -
    16      36   -               -
    17      11   -               -
    18      12   -               -
    19      35   -               -
    20      38   PWR_GPIO        yes
    21      40   2712_G21_FS     -
    22      15   -               -
    23      16   -               -
    24      18   BT_RTS          -
    25      22   BT_CTS          -
    26      37   BT_TXD          -
    27      13   BT_RXD          -
    28      -    WL_ON           yes
    29      -    BT_ON           yes
    30      -    WIFI_SDIO_CLK   -
    31      -    WIFI_SDIO_CMD   -

```