### PR TITLE
Clarify newBuilder(context) deprecation.

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogInputConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogInputConfig.java
@@ -41,6 +41,7 @@ public interface AnalogInputConfig
      *
      * @param context {@link Context}
      * @return a {@link com.pi4j.io.gpio.analog.AnalogInputConfigBuilder} object.
+     * @deprecated As of version 5, please use {@link #newBuilder()} instead.
      */
     @Deprecated
     static AnalogInputConfigBuilder newBuilder(Context context)  {

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogOutputConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogOutputConfig.java
@@ -124,6 +124,7 @@ public interface AnalogOutputConfig
      *
      * @param context {@link Context}
      * @return a {@link com.pi4j.io.gpio.analog.AnalogOutputConfigBuilder} object.
+     * @deprecated As of version 5, please use {@link #newBuilder()} instead.
      */
     @Deprecated
     static AnalogOutputConfigBuilder newBuilder(Context context)  {

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalInputConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalInputConfig.java
@@ -74,7 +74,7 @@ public interface DigitalInputConfig extends DigitalConfig<DigitalInputConfig> {
      *
      * @param context {@link Context}
      * @return a {@link com.pi4j.io.gpio.digital.DigitalInputConfigBuilder} object.
-     * @deprecated use {@link #newBuilder()}
+     * @deprecated As of version 5, please use {@link #newBuilder()} instead.
      */
     @Deprecated
     static DigitalInputConfigBuilder newBuilder(Context context)  {

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalOutputConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalOutputConfig.java
@@ -89,6 +89,7 @@ public interface DigitalOutputConfig extends DigitalConfig<DigitalOutputConfig> 
      *
      * @param context {@link Context}
      * @return a {@link com.pi4j.io.gpio.digital.DigitalOutputConfigBuilder} object.
+     * @deprecated As of version 5, please use {@link #newBuilder()} instead.
      */
     @Deprecated
     static DigitalOutputConfigBuilder newBuilder(Context context)  {

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CConfig.java
@@ -51,6 +51,7 @@ public interface I2CConfig extends IOConfig<I2CConfig>, BusConfig<I2CConfig>, De
      *
      * @param context {@link Context}
      * @return a {@link com.pi4j.io.i2c.I2CConfigBuilder} object.
+     * @deprecated As of version 5, please use {@link #newBuilder()} instead.
      */
     static I2CConfigBuilder newBuilder(Context context) {
         return I2CConfigBuilder.newInstance(context);

--- a/pi4j-core/src/main/java/com/pi4j/io/spi/SpiConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/SpiConfig.java
@@ -73,6 +73,7 @@ public interface SpiConfig extends ChannelConfig<SpiConfig>, IOConfig<SpiConfig>
      *
      * @param context {@link Context}
      * @return a {@link com.pi4j.io.spi.SpiConfigBuilder} object.
+     * @deprecated As of version 5, please use {@link #newBuilder()} instead.
      */
     @Deprecated
     static SpiConfigBuilder newBuilder(Context context) {


### PR DESCRIPTION
 I have skipped doing the same  for newInstance methods, which seem to be internal primarily