### PR TITLE
Repository and build cleanup

### DIFF
--- a/.github/workflows/ci-release-tags.yml
+++ b/.github/workflows/ci-release-tags.yml
@@ -18,11 +18,10 @@ jobs:
           sudo apt-get remove --purge man-db
           sudo apt-get install --yes build-essential linux-headers-$(uname -r) sudo libi2c-dev linux-modules-extra-$(uname -r)
 
-      - name: Set up Zulu JDK 25
-        uses: actions/setup-java@v4
+      - name: Install JDK25
+        uses: sfesenko/setup-sdkman@v1
         with:
-          java-version: '25'
-          distribution: 'zulu'
+          deps: java:25-zulu
 
       - name: Create and add current user to suitable groups
         run: |
@@ -48,7 +47,7 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-        run: mvn clean package
+        run: sudo -u $USER bash -c 'source ~/.sdkman/bin/sdkman-init.sh && ./mvnw clean package'
 
       - name: Make staging directory
         run: mkdir staging

--- a/pi4j-core/src/main/java/com/pi4j/config/impl/PortConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/impl/PortConfigBuilderBase.java
@@ -47,7 +47,7 @@ public abstract class PortConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder, 
      * PRIVATE CONSTRUCTOR
      */
     protected PortConfigBuilderBase(Context context) {
-        super(context);
+        super();
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogInput.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogInput.java
@@ -42,7 +42,7 @@ public interface AnalogInput extends Analog<AnalogInput, AnalogInputConfig, Anal
      * @return a {@link com.pi4j.io.gpio.analog.AnalogInputConfigBuilder} object.
      */
     static AnalogInputConfigBuilder newConfigBuilder(Context context){
-        return AnalogInputConfigBuilder.newInstance(context);
+        return AnalogInputConfigBuilder.newInstance();
     }
 }
 

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogInputProvider.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogInputProvider.java
@@ -45,7 +45,7 @@ public interface AnalogInputProvider extends AnalogProvider<AnalogInputProvider,
      * @return a T object.
      */
     default <T extends AnalogInput> T create(Integer bcm) {
-        var builder = AnalogInputConfigBuilder.newInstance(context());
+        var builder = AnalogInputConfigBuilder.newInstance();
         builder.bcm(bcm);
         return (T) create(builder.build());
     }
@@ -59,7 +59,7 @@ public interface AnalogInputProvider extends AnalogProvider<AnalogInputProvider,
      * @return a T object.
      */
     default <T extends AnalogInput> T create(Integer bcm, String id) {
-        var builder = AnalogInputConfigBuilder.newInstance(context());
+        var builder = AnalogInputConfigBuilder.newInstance();
         builder.id(id).bcm(bcm).id(id);
         return (T) create(builder.build());
     }
@@ -74,7 +74,7 @@ public interface AnalogInputProvider extends AnalogProvider<AnalogInputProvider,
      * @return a T object.
      */
     default <T extends AnalogInput> T create(Integer bcm, String id, String name) {
-        var builder = AnalogInputConfigBuilder.newInstance(context());
+        var builder = AnalogInputConfigBuilder.newInstance();
         builder.id(id).bcm(bcm).id(id).name(name);
         return (T) create(builder.build());
     }
@@ -90,7 +90,7 @@ public interface AnalogInputProvider extends AnalogProvider<AnalogInputProvider,
      * @return a T object.
      */
     default <T extends AnalogInput> T create(Integer bcm, String id, String name, String description) {
-        var builder = AnalogInputConfigBuilder.newInstance(context());
+        var builder = AnalogInputConfigBuilder.newInstance();
         builder.id(id).bcm(bcm).id(id).name(name).description(description);
         return (T) create(builder.build());
     }

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogOutput.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogOutput.java
@@ -45,7 +45,7 @@ public interface AnalogOutput extends Analog<AnalogOutput, AnalogOutputConfig, A
      * @return a {@link com.pi4j.io.gpio.analog.AnalogOutputConfigBuilder} object.
      */
     static AnalogOutputConfigBuilder newConfigBuilder(Context context){
-        return AnalogOutputConfigBuilder.newInstance(context);
+        return AnalogOutputConfigBuilder.newInstance();
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogOutputProvider.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/analog/AnalogOutputProvider.java
@@ -45,7 +45,7 @@ public interface AnalogOutputProvider extends AnalogProvider<AnalogOutputProvide
      * @return a T object.
      */
     default <T extends AnalogOutput> T create(Integer bcm) {
-        var builder = AnalogOutputConfigBuilder.newInstance(context());
+        var builder = AnalogOutputConfigBuilder.newInstance();
         builder.bcm(bcm);
         return (T) create(builder.build());
     }
@@ -59,7 +59,7 @@ public interface AnalogOutputProvider extends AnalogProvider<AnalogOutputProvide
      * @return a T object.
      */
     default <T extends AnalogOutput> T create(Integer bcm, String id) {
-        var builder = AnalogOutputConfigBuilder.newInstance(context());
+        var builder = AnalogOutputConfigBuilder.newInstance();
         builder.id(id).bcm(bcm).id(id);
         return (T) create(builder.build());
     }
@@ -74,7 +74,7 @@ public interface AnalogOutputProvider extends AnalogProvider<AnalogOutputProvide
      * @return a T object.
      */
     default <T extends AnalogOutput> T create(Integer bcm, String id, String name) {
-        var builder = AnalogOutputConfigBuilder.newInstance(context());
+        var builder = AnalogOutputConfigBuilder.newInstance();
         builder.id(id).bcm(bcm).id(id).name(name);
         return (T) create(builder.build());
     }
@@ -90,7 +90,7 @@ public interface AnalogOutputProvider extends AnalogProvider<AnalogOutputProvide
      * @return a T object.
      */
     default <T extends AnalogOutput> T create(Integer bcm, String id, String name, String description) {
-        var builder = AnalogOutputConfigBuilder.newInstance(context());
+        var builder = AnalogOutputConfigBuilder.newInstance();
         builder.id(id).bcm(bcm).id(id).name(name).description(description);
         return (T) create(builder.build());
     }

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalInput.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalInput.java
@@ -46,7 +46,7 @@ public interface DigitalInput extends Digital<DigitalInput, DigitalInputConfig, 
      * @return a {@link com.pi4j.io.gpio.digital.DigitalInputConfigBuilder} object.
      */
     static DigitalInputConfigBuilder newConfigBuilder(Context context){
-        return DigitalInputConfigBuilder.newInstance(context);
+        return DigitalInputConfigBuilder.newInstance();
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalOutputProvider.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalOutputProvider.java
@@ -52,7 +52,7 @@ public interface DigitalOutputProvider extends DigitalProvider<DigitalOutputProv
      * @return a T object.
      */
     default <T extends DigitalOutput> T create(Integer bcm) {
-        var config = DigitalOutput.newConfigBuilder(context())
+        var config = DigitalOutput.newConfigBuilder()
             .bcm(bcm)
             .build();
         return (T) create(config);
@@ -67,7 +67,7 @@ public interface DigitalOutputProvider extends DigitalProvider<DigitalOutputProv
      * @return a T object.
      */
     default <T extends DigitalOutput> T create(Integer bcm, String id) {
-        var config = DigitalOutput.newConfigBuilder(context())
+        var config = DigitalOutput.newConfigBuilder()
             .id(id)
             .bcm(bcm)
             .build();
@@ -84,7 +84,7 @@ public interface DigitalOutputProvider extends DigitalProvider<DigitalOutputProv
      * @return a T object.
      */
     default <T extends DigitalOutput> T create(Integer bcm, String id, String name) {
-        var config = DigitalOutput.newConfigBuilder(context())
+        var config = DigitalOutput.newConfigBuilder()
             .bcm(bcm)
             .id(id)
             .name(name)
@@ -103,7 +103,7 @@ public interface DigitalOutputProvider extends DigitalProvider<DigitalOutputProv
      * @return a T object.
      */
     default <T extends DigitalOutput> T create(Integer bcm, String id, String name, String description) {
-        var config = DigitalOutput.newConfigBuilder(context())
+        var config = DigitalOutput.newConfigBuilder()
             .bcm(bcm)
             .id(id)
             .name(name)

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalOutputBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalOutputBuilder.java
@@ -63,7 +63,7 @@ public class DefaultDigitalOutputBuilder implements DigitalOutputBuilder {
     protected DefaultDigitalOutputBuilder(Context context) {
         super();
         this.context = context;
-        this.builder = DigitalOutputConfigBuilder.newInstance(context);
+        this.builder = DigitalOutputConfigBuilder.newInstance();
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2C.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2C.java
@@ -61,7 +61,7 @@ public interface I2C
      * @return a {@link com.pi4j.io.i2c.I2CConfigBuilder} object.
      */
     static I2CConfigBuilder newConfigBuilder(Context context) {
-        return I2CConfigBuilder.newInstance(context);
+        return I2CConfigBuilder.newInstance();
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmConfigBuilder.java
@@ -46,7 +46,7 @@ public interface PwmConfigBuilder extends
      * @return a {@link com.pi4j.io.pwm.PwmConfigBuilder} object.
      */
     static PwmConfigBuilder newInstance(Context context) {
-        return DefaultPwmConfigBuilder.newInstance(context);
+        return DefaultPwmConfigBuilder.newInstance();
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/io/spi/Spi.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/Spi.java
@@ -77,7 +77,7 @@ public interface Spi extends IO<Spi, SpiConfig, SpiProvider>, AutoCloseable, IOD
      * @return a {@link com.pi4j.io.spi.SpiConfigBuilder} object.
      */
     static SpiConfigBuilder newConfigBuilder(Context context) {
-        return SpiConfigBuilder.newInstance(context);
+        return SpiConfigBuilder.newInstance();
     }
 
     /**

--- a/pi4j-core/src/test/resources/simplelogger.properties
+++ b/pi4j-core/src/test/resources/simplelogger.properties
@@ -1,0 +1,7 @@
+# SLF4J's SimpleLogger configuration file
+# Simple implementation of Logger that sends all enabled log messages, for all defined loggers, to System.err.
+
+# Default logging detail level for all instances of SimpleLogger.
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, defaults to "info".
+org.slf4j.simpleLogger.defaultLogLevel=off

--- a/pi4j-test/pom.xml
+++ b/pi4j-test/pom.xml
@@ -72,14 +72,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>
-                        --illegal-access=permit
-                        --add-opens com.pi4j.test/com.pi4j.test=com.pi4j,ALL-UNNAMED
-                        --add-opens com.pi4j.test/com.pi4j.test.context=com.pi4j,ALL-UNNAMED
-                        --add-opens com.pi4j.test/com.pi4j.test.io.i2c=com.pi4j,ALL-UNNAMED
-                        --add-opens com.pi4j.test/com.pi4j.test.io.serial=com.pi4j,ALL-UNNAMED
-                        --add-opens com.pi4j.test/com.pi4j.test.platform=com.pi4j,ALL-UNNAMED
-                        --add-opens com.pi4j.test/com.pi4j.test.provider=com.pi4j,ALL-UNNAMED
-                        --add-opens com.pi4j.test/com.pi4j.test.registry=com.pi4j,ALL-UNNAMED
+                        --enable-native-access=ALL-UNNAMED
                     </argLine>
                 </configuration>
             </plugin>

--- a/pi4j-test/src/main/java/com/pi4j/test/smoketest/TestCase.java
+++ b/pi4j-test/src/main/java/com/pi4j/test/smoketest/TestCase.java
@@ -23,7 +23,7 @@ public class TestCase {
     }
 
     protected static DigitalOutput createDigitalOutput(Context pi4j, int bcm, DigitalState initial, DigitalState shutDown) {
-        var outputConfig3 = DigitalOutput.newConfigBuilder(pi4j)
+        var outputConfig3 = DigitalOutput.newConfigBuilder()
             .bcm(bcm)
             .initial(initial)
             .shutdown(shutDown);

--- a/pi4j-test/src/test/java/com/pi4j/test/Slf4jStreamBridge.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/Slf4jStreamBridge.java
@@ -1,0 +1,32 @@
+package com.pi4j.test;
+
+import org.slf4j.Logger;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+public class Slf4jStreamBridge {
+
+    public static PrintStream createPrintStream(Logger logger) {
+        return new PrintStream(new OutputStream() {
+            private final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+
+            @Override
+            public void write(int b) {
+                if (b == '\n') {
+                    String line = bos.toString(StandardCharsets.UTF_8);
+                    // Filter out trailing carriage returns if present
+                    if (line.endsWith("\r")) {
+                        line = line.substring(0, line.length() - 1);
+                    }
+                    logger.info(line);
+                    bos.reset();
+                } else {
+                    bos.write(b);
+                }
+            }
+        }, true); // auto-flush enabled
+    }
+}

--- a/pi4j-test/src/test/java/com/pi4j/test/context/ContextTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/context/ContextTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.pi4j.Pi4J;
 import com.pi4j.context.Context;
 import com.pi4j.exception.Pi4JException;
+import com.pi4j.test.Slf4jStreamBridge;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -67,6 +68,7 @@ public class ContextTest {
         logger.info("-------------------------------------------------");
         logger.info("Pi4J CONTEXT <acquired via factory accessor>");
         logger.info("-------------------------------------------------");
-        pi4j.describe().print(System.out);
+        var ps = Slf4jStreamBridge.createPrintStream(logger);
+        pi4j.describe().print(ps);
     }
 }

--- a/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalOutputOffTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalOutputOffTest.java
@@ -65,7 +65,7 @@ public class DigitalOutputOffTest {
     public void testIsOffDefault() {
 
         // create GPIO digital output config
-        var config = DigitalOutput.newConfigBuilder(pi4j)
+        var config = DigitalOutput.newConfigBuilder()
             .id("test-output")
             .name("Test Digital Output")
             .bcm(1)
@@ -89,7 +89,7 @@ public class DigitalOutputOffTest {
     public void testIsOffLow() {
 
         // create GPIO digital output config
-        var config = DigitalOutput.newConfigBuilder(pi4j)
+        var config = DigitalOutput.newConfigBuilder()
             .id("test-output")
             .name("Test Digital Output")
             .bcm(1)
@@ -114,7 +114,7 @@ public class DigitalOutputOffTest {
     public void testIsOffHigh() {
 
         // create GPIO digital output config
-        var config = DigitalOutput.newConfigBuilder(pi4j)
+        var config = DigitalOutput.newConfigBuilder()
             .id("test-output")
             .name("Test Digital Output")
             .onState(DigitalState.LOW)
@@ -139,7 +139,7 @@ public class DigitalOutputOffTest {
     public void testOffDefault() {
 
         // create GPIO digital output config
-        var config = DigitalOutput.newConfigBuilder(pi4j)
+        var config = DigitalOutput.newConfigBuilder()
             .id("test-output")
             .name("Test Digital Output")
             .bcm(1)
@@ -163,7 +163,7 @@ public class DigitalOutputOffTest {
     public void testOffHigh() {
 
         // create GPIO digital output config
-        var config = DigitalOutput.newConfigBuilder(pi4j)
+        var config = DigitalOutput.newConfigBuilder()
             .id("test-output")
             .name("Test Digital Output")
             .bcm(1)
@@ -188,7 +188,7 @@ public class DigitalOutputOffTest {
     public void testOffLow() {
 
         // create GPIO digital output config
-        var config = DigitalOutput.newConfigBuilder(pi4j)
+        var config = DigitalOutput.newConfigBuilder()
             .id("test-output")
             .name("Test Digital Output")
             .bcm(1)

--- a/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalOutputOnTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalOutputOnTest.java
@@ -65,7 +65,7 @@ public class DigitalOutputOnTest {
     public void testIsOnDefault() {
 
         // create GPIO digital output config
-        var config = DigitalOutput.newConfigBuilder(pi4j)
+        var config = DigitalOutput.newConfigBuilder()
             .id("test-output")
             .name("Test Digital Output")
             .bcm(1)
@@ -89,7 +89,7 @@ public class DigitalOutputOnTest {
     public void testIsOnHigh() {
 
         // create GPIO digital output config
-        var config = DigitalOutput.newConfigBuilder(pi4j)
+        var config = DigitalOutput.newConfigBuilder()
             .id("test-output")
             .name("Test Digital Output")
             .bcm(1)
@@ -114,7 +114,7 @@ public class DigitalOutputOnTest {
     public void testIsOnLow() {
 
         // create GPIO digital output config
-        var config = DigitalOutput.newConfigBuilder(pi4j)
+        var config = DigitalOutput.newConfigBuilder()
             .id("test-output")
             .name("Test Digital Output")
             .onState(DigitalState.LOW)
@@ -139,7 +139,7 @@ public class DigitalOutputOnTest {
     public void testOnDefault() {
 
         // create GPIO digital output config
-        var config = DigitalOutput.newConfigBuilder(pi4j)
+        var config = DigitalOutput.newConfigBuilder()
             .id("test-output")
             .name("Test Digital Output")
             .bcm(1)
@@ -163,7 +163,7 @@ public class DigitalOutputOnTest {
     public void testOnHigh() {
 
         // create GPIO digital output config
-        var config = DigitalOutput.newConfigBuilder(pi4j)
+        var config = DigitalOutput.newConfigBuilder()
             .id("test-output")
             .name("Test Digital Output")
             .bcm(1)
@@ -188,7 +188,7 @@ public class DigitalOutputOnTest {
     public void testOnLow() {
 
         // create GPIO digital output config
-        var config = DigitalOutput.newConfigBuilder(pi4j)
+        var config = DigitalOutput.newConfigBuilder()
             .id("test-output")
             .name("Test Digital Output")
             .bcm(1)

--- a/pi4j-test/src/test/java/com/pi4j/test/provider/AutoProvidersTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/provider/AutoProvidersTest.java
@@ -31,15 +31,19 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.pi4j.Pi4J;
 import com.pi4j.context.Context;
 import com.pi4j.exception.Pi4JException;
+import com.pi4j.test.Slf4jStreamBridge;
+import com.pi4j.test.context.ContextTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class AutoProvidersTest {
-
+    private static final Logger logger = LoggerFactory.getLogger(AutoProvidersTest.class);
     private Context pi4j;
 
     @BeforeAll
@@ -70,8 +74,8 @@ public class AutoProvidersTest {
     public void testProvidersNotEmpty() {
         // ensure that 1 or more providers were detected/loaded into the Pi4J context
         assertFalse(pi4j.providers().all().isEmpty());
-
+        var ps = Slf4jStreamBridge.createPrintStream(logger);
         // print out the detected Pi4J io libraries found on the class path
-        pi4j.providers().describe().print(System.out);
+        pi4j.providers().describe().print(ps);
     }
 }

--- a/pi4j-test/src/test/java/com/pi4j/test/provider/ManualProvidersCtorTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/provider/ManualProvidersCtorTest.java
@@ -28,18 +28,21 @@ package com.pi4j.test.provider;
 import com.pi4j.Pi4J;
 import com.pi4j.context.Context;
 import com.pi4j.exception.Pi4JException;
+import com.pi4j.test.Slf4jStreamBridge;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ManualProvidersCtorTest {
-
+    private static final Logger logger = LoggerFactory.getLogger(ManualProvidersCtorTest.class);
     private Context pi4j;
 
     @BeforeAll
@@ -72,8 +75,8 @@ public class ManualProvidersCtorTest {
     public void testProviderCount() {
         // ensure that only 3 providers were detected/loaded into the Pi4J context
         assertEquals(2, pi4j.providers().all().size());
-
+        var ps = Slf4jStreamBridge.createPrintStream(logger);
         // print out the detected Pi4J providers
-        pi4j.providers().describe().print(System.out);
+        pi4j.providers().describe().print(ps);
     }
 }

--- a/pi4j-test/src/test/java/com/pi4j/test/provider/ManualProvidersTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/provider/ManualProvidersTest.java
@@ -32,6 +32,7 @@ import com.pi4j.Pi4J;
 import com.pi4j.context.Context;
 import com.pi4j.io.i2c.I2CProvider;
 import com.pi4j.io.pwm.PwmProvider;
+import com.pi4j.test.Slf4jStreamBridge;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,7 +64,8 @@ public class ManualProvidersTest {
 
         // print out the detected Pi4J io libraries found on the class path
         logger.info("2 CUSTOM PROVIDERS (added via API)");
-        pi4j.providers().describe().print(System.out);
+        var ps = Slf4jStreamBridge.createPrintStream(logger);
+        pi4j.providers().describe().print(ps);
 
         // shutdown Pi4J runtime
         pi4j.shutdown();

--- a/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
@@ -96,7 +96,7 @@ class RegistryTest {
     @Test
     void testCreateMultipleSameAddress() throws Pi4JException {
         var inputConfig = DigitalInput.newConfigBuilder(pi4j).id("DIN-3").name("DIN-3").bcm(3);
-        var outputConfig = DigitalOutput.newConfigBuilder(pi4j).id("DOUT-3").name("DOUT-3").bcm(3);
+        var outputConfig = DigitalOutput.newConfigBuilder().id("DOUT-3").name("DOUT-3").bcm(3);
         var pwmConfig = Pwm.newConfigBuilder(pi4j).id("PWM-3").name("PWM-3").channel(3);
 
         // create I/O instances

--- a/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
@@ -35,6 +35,7 @@ import com.pi4j.io.i2c.I2C;
 import com.pi4j.io.pwm.Pwm;
 import com.pi4j.io.spi.Spi;
 import com.pi4j.registry.Registry;
+import com.pi4j.test.Slf4jStreamBridge;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -75,7 +76,8 @@ class RegistryTest {
         logger.info("-------------------------------------------------");
         logger.info("Pi4J I/O REGISTRY <acquired via factory accessor>");
         logger.info("-------------------------------------------------");
-        registry.describe().print(System.out);
+        var ps = Slf4jStreamBridge.createPrintStream(logger);
+        registry.describe().print(ps);
     }
 
     @Test

--- a/pi4j-test/src/test/java/com/pi4j/test/runtime/RuntimeTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/runtime/RuntimeTest.java
@@ -30,6 +30,7 @@ import com.pi4j.context.Context;
 import com.pi4j.event.ShutdownEvent;
 import com.pi4j.event.ShutdownListener;
 import com.pi4j.exception.Pi4JException;
+import com.pi4j.test.Slf4jStreamBridge;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -57,7 +58,8 @@ public class RuntimeTest {
         logger.info("-------------------------------------------------");
         logger.info("Pi4J CONTEXT <acquired via factory accessor>");
         logger.info("-------------------------------------------------");
-        pi4j.describe().print(System.out);
+        var ps = Slf4jStreamBridge.createPrintStream(logger);
+        pi4j.describe().print(ps);
 
         // add shutdown listener
         pi4j.addListener(new ShutdownListener() {

--- a/pi4j-test/src/test/resources/simplelogger.properties
+++ b/pi4j-test/src/test/resources/simplelogger.properties
@@ -1,0 +1,7 @@
+# SLF4J's SimpleLogger configuration file
+# Simple implementation of Logger that sends all enabled log messages, for all defined loggers, to System.err.
+
+# Default logging detail level for all instances of SimpleLogger.
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, defaults to "info".
+org.slf4j.simpleLogger.defaultLogLevel=off

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/api/RaspberryPi.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/api/RaspberryPi.java
@@ -47,7 +47,7 @@ public interface RaspberryPi extends Pi4JApi.API {
         }
 
         public I2C i2c1(int device, I2CImplementation implementation) {
-            var config = I2CConfig.newBuilder(context)
+            var config = I2CConfig.newBuilder()
                 .bus(1)
                 .device(device)
                 .i2cImplementation(implementation)
@@ -60,7 +60,7 @@ public interface RaspberryPi extends Pi4JApi.API {
         }
 
         public Spi spi0(int baudRate, SpiMode mode) {
-            var config = SpiConfig.newBuilder(context)
+            var config = SpiConfig.newBuilder()
                 .bus(0)
                 .baud(baudRate)
                 .mode(mode)
@@ -81,7 +81,7 @@ public interface RaspberryPi extends Pi4JApi.API {
         }
 
         public Spi spi1() {
-            var config = SpiConfig.newBuilder(context)
+            var config = SpiConfig.newBuilder()
                 .bus(1)
                 .baud(40_000)
                 .mode(SpiMode.MODE_1)
@@ -120,7 +120,7 @@ public interface RaspberryPi extends Pi4JApi.API {
         }
 
         public DigitalInput input(int pin) {
-            var config = DigitalInputConfig.newBuilder(context)
+            var config = DigitalInputConfig.newBuilder()
                 .bcm(pin)
                 .build();
             return context.create(config);
@@ -131,7 +131,7 @@ public interface RaspberryPi extends Pi4JApi.API {
         }
 
         public DigitalOutput output(int pin) {
-            var config = DigitalOutputConfig.newBuilder(context)
+            var config = DigitalOutputConfig.newBuilder()
                 .bcm(pin)
                 .build();
             return context.create(config);

--- a/plugins/pi4j-plugin-mock/src/test/java/com/pi4j/plugin/mock/MockPluginTest.java
+++ b/plugins/pi4j-plugin-mock/src/test/java/com/pi4j/plugin/mock/MockPluginTest.java
@@ -21,7 +21,7 @@ class MockPluginTest {
 
     @Test
     void canRecreateOutput() {
-        var config = DigitalOutputConfigBuilder.newInstance(pi4j)
+        var config = DigitalOutputConfigBuilder.newInstance()
             .bcm(1)
             .build();
 
@@ -54,7 +54,7 @@ class MockPluginTest {
 
     @Test
     void canRecreateDevice() {
-        var config = SpiConfigBuilder.newInstance(pi4j)
+        var config = SpiConfigBuilder.newInstance()
             .bus(0)
             .channel(0)
             .build();

--- a/plugins/pi4j-plugin-mock/src/test/resources/simplelogger.properties
+++ b/plugins/pi4j-plugin-mock/src/test/resources/simplelogger.properties
@@ -1,0 +1,7 @@
+# SLF4J's SimpleLogger configuration file
+# Simple implementation of Logger that sends all enabled log messages, for all defined loggers, to System.err.
+
+# Default logging detail level for all instances of SimpleLogger.
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, defaults to "info".
+org.slf4j.simpleLogger.defaultLogLevel=off


### PR DESCRIPTION
1) Fixed CI build for tags
2) Reduced warning messages during build
3) Switched default logging to off, not to spam build time
4) Added a special slf4j bridge in tests to route all 'describe' to logger
5) Removed jvm redundant flags from pom