### PR TITLE
Support 16GB Compute Module 5 variant

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/boardinfo/definition/BoardModel.java
+++ b/pi4j-core/src/main/java/com/pi4j/boardinfo/definition/BoardModel.java
@@ -244,7 +244,7 @@ public enum BoardModel {
         List.of(1024 * 1024, 2048 * 1024, 4096 * 1024, 8192 * 1024)),
     // https://www-cnx--software-com.cdn.ampproject.org/c/s/www.cnx-software.com/2024/11/27/raspberry-pi-cm5-broadcom-bcm2712-soc-16gb-lpddr4-ecc-memory/?amp=1
     COMPUTE_5("Compute Module 5", STACK_ON_COMPUTER,
-        List.of("a04180", "b04180", "c04180", "d04180", "a041a0", "b041a0", "c041a0", "c041a0"),
+        List.of("b04180", "c04180", "d04180", "e04180", "b041a0", "c041a0", "d041a0", "e041a0"),
         PiModel.COMPUTE,
         HeaderVersion.COMPUTE,
         LocalDate.of(2024, 11, 27),
@@ -256,7 +256,8 @@ public enum BoardModel {
             "20241127: The board codes are not documented yet with the Compute 5 announcement.",
             "20241129: Confirmed by Jeff Geerling who has evaluation version: c04180 for the 4Gb version.",
             "When compared with Compute 4, we can assume the other boards should have be a, b, d.",
-            "Will be further completed or modified when more info is available."
+            "Will be further completed or modified when more info is available.",
+            "20260619: CM5 board codes documented at https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#new-style-revision-codes-in-use"
         ),
         true),
     ZERO_PCB_1_2("Raspberry Pi Zero PCB V1.2", SINGLE_BOARD_COMPUTER,


### PR DESCRIPTION
Updated BoardModel.COMPUTE_5's 'boardCodes' to reflect reality.

The CM5 and CM5 Lite exist today in 2GB, 4GB, 8GB, and 16GB variants with revision code prefix b, c, d, and e, respectively.

Removed the revision codes prefixed with 'a' (1GB) and added revision codes prefixed with 'e' (16GB) to allow for automatic BoardModel detection of CM5/CM5 Lite 16GB variants.

Updated BoardModel.COMPUTE_5's 'remarks' to include a link to official documentation of the current known revision codes.