### PR TITLE
fix: guard deploy workflows so they do not run in forks

### DIFF
--- a/.github/workflows/ci-develop-snapshot.yml
+++ b/.github/workflows/ci-develop-snapshot.yml
@@ -9,6 +9,7 @@ jobs:
   Build:
     name: Build & Deploy Snapshot
     runs-on: ubuntu-latest
+    if: github.repository == 'Pi4J/pi4j'
     steps:
       - uses: actions/checkout@v4
 
@@ -108,6 +109,7 @@ jobs:
     name: Deploy to Download Repo
     needs: [ Build ]
     runs-on: ubuntu-latest
+    if: github.repository == 'Pi4J/pi4j'
     concurrency:
       group: deploy-to-download-repo
       cancel-in-progress: false

--- a/.github/workflows/ci-release-tags.yml
+++ b/.github/workflows/ci-release-tags.yml
@@ -10,6 +10,7 @@ jobs:
   Build:
     name: Build & Deploy Tag
     runs-on: ubuntu-latest
+    if: github.repository == 'Pi4J/pi4j'
     steps:
       - uses: actions/checkout@v4
 
@@ -76,6 +77,7 @@ jobs:
     name: Deploy to APT/Download Repo
     needs: [ Build ]
     runs-on: ubuntu-latest
+    if: github.repository == 'Pi4J/pi4j'
     environment:
       name: Release
       url: 'https://github.com/Pi4J/download'


### PR DESCRIPTION
## Summary

Adds a job-level guard `if: github.repository == 'Pi4J/pi4j'` to the deploy/publish jobs in the two `push`-triggered workflows that require org-only secrets, so those jobs are skipped entirely when the workflow runs from a fork:

- `.github/workflows/ci-develop-snapshot.yml` - guards the `Build` job (runs `./mvnw deploy` against OSSRH) and the dependent `DeployPackages` job (pushes to `Pi4J/download`).
- `.github/workflows/ci-release-tags.yml` - guards the `Build` job and the `DeployPackages` job that use `OSSRH_*` and `API_TOKEN_GITHUB`.

## Why this matters

Closes #270. When a contributor forks the repo and pushes to their fork's `develop` branch (or a tag), `ci-develop-snapshot.yml` / `ci-release-tags.yml` trigger and attempt to deploy a snapshot to OSSRH and push artifacts to `Pi4J/download`. These operations require org-only secrets (`OSSRH_USERNAME`, `OSSRH_TOKEN`, `API_TOKEN_GITHUB`) that do not exist in a fork, so the run fails. FDelporte's suggested fix on the issue was to "adapt the build script to not run completely in forks," and DigitalSmile re-pinged the thread on 2026-06-19 asking whether it was still present - the deploy-on-push workflows still lacked any fork guard.

With this guard the deploy jobs are skipped (reported as green/success) rather than failing in forks, giving fork contributors a clean run. The canonical `Pi4J/pi4j` repo is unaffected: the guard evaluates true there, so deploys continue exactly as before.

The PR-validation (`ci-pull-request.yml`) and CodeQL (`ci-codeql-analysis.yml`) workflows are intentionally left untouched - they are meant to run in forks/PRs and only use the auto-provided `GITHUB_TOKEN`. The scheduled `ci-jmh-biweekly.yaml` is also left as-is, since GitHub disables scheduled workflows in forks by default.

## Testing

- `python3 -c "import yaml; yaml.safe_load(...)"` confirms both workflow files still parse as valid YAML.
- The `if:` is added as a job-level key (sibling to `name`/`runs-on`/`needs`), which is the correct location for a GitHub Actions job conditional.
- Behavior: push to `Pi4J/pi4j` -> deploy jobs run (guard true); push to a fork -> deploy jobs skipped (guard false), no failure on missing secrets. The `needs: [ Build ]` chain on `DeployPackages` still resolves because both jobs are guarded with the same condition.

Fixes #270
