### PR TITLE
Smoketest   Changes to core context required testcase changes. Deleti…

### DIFF
--- a/pi4j-test/src/main/java/com/pi4j/test/smoketest/I2CWithOffsetTestCase.java
+++ b/pi4j-test/src/main/java/com/pi4j/test/smoketest/I2CWithOffsetTestCase.java
@@ -56,7 +56,6 @@ public class I2CWithOffsetTestCase extends TestCase {
         } finally {
             if (i2c != null) {
                 i2c.close();
-                providerContext.getContext().shutdown(i2c.id());
             }
         }
     }

--- a/pi4j-test/src/main/java/com/pi4j/test/smoketest/SpiTestCase.java
+++ b/pi4j-test/src/main/java/com/pi4j/test/smoketest/SpiTestCase.java
@@ -54,6 +54,8 @@ public class SpiTestCase extends TestCase {
             return new TestResult(TEST_NAME, false, "Test failure: " + e.getMessage());
         } finally {
             if (spi != null) {
+                // this is a workaround as spi.close() no longer removes the ID  runtime context
+                providerContext.getContext().shutdown(spi.id());
                 spi.close();
             }
 

--- a/pi4j-test/src/main/java/com/pi4j/test/smoketest/SpiWithOffsetTestCase.java
+++ b/pi4j-test/src/main/java/com/pi4j/test/smoketest/SpiWithOffsetTestCase.java
@@ -83,6 +83,8 @@ public class SpiWithOffsetTestCase  extends TestCase {
             return new TestResult(TEST_NAME, false, "Test failure: " + e.getMessage());
         } finally {
             if (spi != null) {
+                // this is a workaround as spi.close() no longer removes the ID  runtime context
+                providerContext.getContext().shutdown(spi.id());
                 spi.close();
             }
         }

--- a/pi4j-test/src/main/java/com/pi4j/test/smoketest/SpiWriteReadTestCase.java
+++ b/pi4j-test/src/main/java/com/pi4j/test/smoketest/SpiWriteReadTestCase.java
@@ -83,6 +83,8 @@ public class SpiWriteReadTestCase   extends TestCase{
             return new TestResult(TEST_NAME, false, "Test failure: " + e.getMessage());
         } finally {
             if (spi != null) {
+                // this is a workaround as spi.close() no longer removes the ID  runtime context
+                providerContext.getContext().shutdown(spi.id());
                 spi.close();
             }
         }


### PR DESCRIPTION
…ng an individual ID from the context must happen before closing the applicable device. Also a workaround in spi testcases.  closing the spi device no longer removes the spi IDs from the context.