### PR TITLE
spi.close() does not remove the ID from the Context.  Not sure how th…

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/spi/SpiBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/SpiBase.java
@@ -64,6 +64,7 @@ public abstract class SpiBase extends IOBase<Spi, SpiConfig, SpiProvider> implem
     @Override
     public void close() {
         logger.trace("invoked 'closed()'");
+        super.close();
         this.isOpen = false;
     }
 }


### PR DESCRIPTION
…e context rework created this, calling super.close() fixed it.  Maybe Stefan will understand the previous code path that did the removel.