### PR TITLE
Automate release flow from main with jreleaser

### DIFF
--- a/.github/workflows/ci-codeql-analysis.yml
+++ b/.github/workflows/ci-codeql-analysis.yml
@@ -9,13 +9,13 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL Advanced"
+name: "CodeQL analysis"
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "develop" ]
+    branches: [ "main" ]
   schedule:
     - cron: '24 8 * * 3'
 

--- a/.github/workflows/ci-jmh-biweekly.yml
+++ b/.github/workflows/ci-jmh-biweekly.yml
@@ -1,4 +1,4 @@
-name: JMH Weekly run and report
+name: "JMH Weekly run and report"
 
 on:
   schedule:
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: develop
+          ref: "main"
 
       - name: Check for new commits since last run
         id: check
@@ -41,7 +41,7 @@ jobs:
             echo "should_run=true" >> "$GITHUB_OUTPUT"
           elif [ "${HEAD_SHA#"$LAST"}" != "$HEAD_SHA" ]; then
             # HEAD_SHA starts with the stored short SHA -> same commit -> nothing new.
-            echo "No new commits on develop since last run ($LAST); skipping benchmarks."
+            echo "No new commits on main since last run ($LAST); skipping benchmarks."
             echo "should_run=false" >> "$GITHUB_OUTPUT"
           else
             echo "New commits since last run ($LAST -> $HEAD_SHA); benchmarks will run."

--- a/.github/workflows/ci-main-snapshot.yml
+++ b/.github/workflows/ci-main-snapshot.yml
@@ -1,8 +1,8 @@
-name: Build develop snapshot and push to download repo
+name: "Build snapshot and deploy to Maven"
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci-publish-download-bundle.yml
+++ b/.github/workflows/ci-publish-download-bundle.yml
@@ -1,4 +1,4 @@
-name: Build release tags and push to download repo
+name: "Package release zip and publish to pi4j/download"
 
 on:
   push:

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -1,8 +1,8 @@
-name: Build pull-request to develop branch
+name: "Build pull-request to main branch"
 
 on:
   pull_request:
-    branches: [ develop ]
+    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci-release-to-maven.yml
+++ b/.github/workflows/ci-release-to-maven.yml
@@ -43,12 +43,19 @@ jobs:
         run: |
           VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          if [[ "$VERSION" != *"-SNAPSHOT" ]]; then
+
+          # Ensure tags are available for existence checks
+          git fetch --tags --force
+
+          if [[ "$VERSION" != *"-SNAPSHOT" ]] && git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            echo "is-release=false" >> "$GITHUB_OUTPUT"
+            echo "Tag already exists; skipping release: $VERSION"
+          elif [[ "$VERSION" != *"-SNAPSHOT" ]]; then
             echo "is-release=true" >> "$GITHUB_OUTPUT"
-            echo "✅ Release version detected: $VERSION"
+            echo "Release version detected: $VERSION"
           else
             echo "is-release=false" >> "$GITHUB_OUTPUT"
-            echo "⏭️  Snapshot version – skipping release: $VERSION"
+            echo "Snapshot version – skipping release: $VERSION"
           fi
 
   # ── Step 2: build, stage locally, approve, then release via JReleaser ──────

--- a/.github/workflows/ci-release-to-maven.yml
+++ b/.github/workflows/ci-release-to-maven.yml
@@ -1,0 +1,164 @@
+# Release with JReleaser
+# https://jreleaser.org/guide/latest/continuous-integration/github-actions.html
+#
+# Triggers automatically on pushes to main that touch pom.xml, and can also be
+# started manually from the GitHub Actions UI.
+# The "check-version" job gates the actual release: it only proceeds when the
+# version is NOT a SNAPSHOT, so bumping 5.0.0-SNAPSHOT → 5.0.0 is all it takes
+# to kick off a full release.
+
+name: "Release to Maven Central with JReleaser"
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'pom.xml'
+  workflow_dispatch:
+
+jobs:
+  # ── Step 1: decide whether this is a real release ──────────────────────────
+  check-version:
+    name: Check version
+    runs-on: ubuntu-latest
+    outputs:
+      is-release: ${{ steps.version.outputs.is-release }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'zulu'
+
+      - name: Read project version
+        id: version
+        run: |
+          VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$VERSION" != *"-SNAPSHOT" ]]; then
+            echo "is-release=true" >> "$GITHUB_OUTPUT"
+            echo "✅ Release version detected: $VERSION"
+          else
+            echo "is-release=false" >> "$GITHUB_OUTPUT"
+            echo "⏭️  Snapshot version – skipping release: $VERSION"
+          fi
+
+  # ── Step 2: build, stage locally, approve, then release via JReleaser ──────
+  release:
+    name: Release v${{ needs.check-version.outputs.version }}
+    needs: check-version
+    if: needs.check-version.outputs.is-release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # needed to create GitHub Release & tag
+      issues: write     # needed by manual-approval to open an issue
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so JReleaser can build the changelog
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'zulu'
+
+      - name: Grant execute permission for mvnw
+        run: chmod +x mvnw
+
+      - name: Validate release secrets are available
+        run: |
+          required=(
+            JRELEASER_MAVENCENTRAL_USERNAME
+            JRELEASER_MAVENCENTRAL_TOKEN
+            JRELEASER_GPG_PASSPHRASE
+            JRELEASER_GPG_SECRET_KEY
+            JRELEASER_GPG_PUBLIC_KEY
+          )
+          for name in "${required[@]}"; do
+            if [ -z "${!name}" ]; then
+              echo "ERROR: Required secret '$name' is not set"
+              exit 1
+            fi
+          done
+          echo "All required release secrets are present."
+        env:
+          JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
+          JRELEASER_MAVENCENTRAL_TOKEN: ${{ secrets.JRELEASER_MAVENCENTRAL_TOKEN }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
+
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      # Build + generate sources & javadoc JARs, deploy to a local staging dir.
+      # JReleaser will sign and upload everything from there.
+      # Note: Maven 4 altDeploymentRepository syntax is id::url (no layout field)
+      - name: Build for release
+        run: |
+          ./mvnw -ntp -B -Prelease -DskipTests \
+            -DaltDeploymentRepository=local::file:./target/staging-deploy \
+            deploy
+
+      - name: List files staged for release
+        run: ls -laR ./target/staging-deploy
+
+      # Check JReleaser config before asking for approval
+      - name: Check JReleaser configuration
+        env:
+          JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
+          JRELEASER_MAVENCENTRAL_TOKEN: ${{ secrets.JRELEASER_MAVENCENTRAL_TOKEN }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./mvnw -ntp -B -Prelease -Djreleaser.config.file=jreleaser.yml jreleaser:config
+
+      # Manual gate: one of the listed approvers must react on the auto-created
+      # GitHub issue before the release continues.
+      - name: Get release approval
+        uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ secrets.GITHUB_TOKEN }}
+          approvers: FDelporte,stefanhaustein
+          minimum-approvals: 1
+          issue-title: "Release v${{ needs.check-version.outputs.version }} to Maven Central"
+          issue-body: "Please approve or deny the release of **v${{ needs.check-version.outputs.version }}** to Maven Central."
+          exclude-workflow-initiator-as-approver: false
+          fail-on-denial: true
+          polling-interval-seconds: 10
+
+      # Post JARs to Maven Central
+      # https://jreleaser.org/guide/latest/examples/maven/maven-central.html
+      - name: Release to Maven Central
+        env:
+          JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
+          JRELEASER_MAVENCENTRAL_TOKEN: ${{ secrets.JRELEASER_MAVENCENTRAL_TOKEN }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./mvnw -ntp -B -Prelease -Djreleaser.config.file=jreleaser.yml jreleaser:full-release
+
+      # Always upload JReleaser logs so failures are easy to diagnose
+      - name: Upload JReleaser output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jreleaser-output
+          path: target/jreleaser/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,10 +5,10 @@
 To release pi4j use the following:
 
 ```shell
-MVN_PROFILES=-P\!default ./autoReleaseBranch minor develop release/<version>
+MVN_PROFILES=-P\!default ./autoReleaseBranch minor main release/<version>
 ```
 
-this merges the `develop` branch into `release/<version>`, increments the current tag on the `release/<version>`
+this merges the `main` branch into `release/<version>`, increments the current tag on the `release/<version>`
 branch and then builds it locally. It uses `mvn versions:set` to set the version, and after the version is set, 
 does a test build to make sure all dependencies are really there.
 

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -1,0 +1,76 @@
+---
+# JReleaser configuration for pi4j
+# See https://jreleaser.org/guide/latest/index.html
+#
+# Environment variables required (set as GitHub Actions secrets):
+#   JRELEASER_GITHUB_TOKEN             – GitHub token (GITHUB_TOKEN is fine)
+#   JRELEASER_GPG_PASSPHRASE           – GPG key passphrase
+#   JRELEASER_GPG_SECRET_KEY           – ASCII-armored GPG secret key
+#   JRELEASER_GPG_PUBLIC_KEY           – ASCII-armored GPG public key
+#   JRELEASER_MAVENCENTRAL_USERNAME    – User Token username from central.sonatype.com/account
+#   JRELEASER_MAVENCENTRAL_TOKEN       – User Token password from central.sonatype.com/account
+
+project:
+  name: pi4j
+  description: Pi4J - Friendly GPIO Library for Single-Board Computers
+  longDescription: |
+    Pi4J is intended to provide a friendly object abstraction layer on top of
+    the low-level I/O capabilities of Raspberry Pi and other Linux-based Single-Board Computers.
+  authors:
+    - Pi4J Contributors
+  license: APACHE-2.0
+  links:
+    homepage: https://github.com/Pi4J/pi4j
+    documentation: https://pi4j.com
+  java:
+    groupId: com.pi4j
+    artifactId: pi4j-parent
+    # version is read automatically from Maven's ${project.version}
+    multiProject: true
+
+# ── Signing ──────────────────────────────────────────────────────────────────
+# JReleaser signs every artifact with the GPG key provided via env vars.
+signing:
+  active: ALWAYS
+  armored: true
+  # JRELEASER_GPG_PASSPHRASE, JRELEASER_GPG_SECRET_KEY, JRELEASER_GPG_PUBLIC_KEY
+
+# ── Release (GitHub) ─────────────────────────────────────────────────────────
+release:
+  github:
+    # Repo details are inferred from git remote; override if needed:
+    # owner: Pi4J
+    # name: pi4j
+    tagName: "{{projectVersion}}"
+    releaseName: "{{projectVersion}}"
+    overwrite: false          # fail if the tag already exists (prevents accidental re-release)
+    draft: false
+    prerelease:
+      enabled: false
+    changelog:
+      formatted: ALWAYS
+      preset: conventional-commits
+      contributors:
+        format: "- {{contributorName}}{{#contributorUsernameAsLink}} ({{.}}){{/contributorUsernameAsLink}}"
+      hide:
+        uncategorized: true
+    milestone:
+      close: false
+    # JRELEASER_GITHUB_TOKEN
+
+# ── Deploy to Maven Central Portal (modern API) ───────────────────────────────
+deploy:
+  maven:
+    mavenCentral:
+      sonatype:
+        active: ALWAYS
+        url: https://central.sonatype.com/api/v1/publisher
+        # Local staging directory populated by:
+        #   ./mvnw -Prelease -DskipTests
+        #          -DaltDeploymentRepository=local::file:./target/staging-deploy
+        #          deploy
+        stagingRepositories:
+          - target/staging-deploy
+        retryDelay: 20
+        maxRetries: 60
+        # JRELEASER_MAVENCENTRAL_USERNAME / JRELEASER_MAVENCENTRAL_TOKEN

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -18,7 +18,7 @@ project:
     the low-level I/O capabilities of Raspberry Pi and other Linux-based Single-Board Computers.
   authors:
     - Pi4J Contributors
-  license: APACHE-2.0
+  license: Apache-2.0
   links:
     homepage: https://github.com/Pi4J/pi4j
     documentation: https://pi4j.com


### PR DESCRIPTION
Similar to pi4j-drivers aligning with Commonhaus release requirements.

This will move the ongoing branch from `develop` (to be removed) to `main`, with reviewed GitHub Actions and a new one to publish to Maven, also from an Action based on the version number in the pom + manual override if needed.

When a new commit to main includes a version number without `-SNAPSHOT`, a ticket is created to confirm the release to Maven Central. This can also be triggered manually when needed.