### PR TITLE
fix: don't attempt unpassable test on non-linux os

### DIFF
--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/unit/Pi4JNativeLibraryTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/unit/Pi4JNativeLibraryTest.java
@@ -75,6 +75,7 @@ class Pi4JNativeLibraryTest {
 
     @Test
     void throwsPi4JExceptionForUnknownLibrary() {
+        assumeTrue(isLinux(), "load asserts linux os at runtime");
         try (Arena arena = Arena.ofConfined()) {
             Pi4JException ex = assertThrows(Pi4JException.class,
                 () -> Pi4JNativeLibrary.load("pi4j-definitely-not-a-real-library", arena));


### PR DESCRIPTION
`Pi4JNativeLibrary.load` explicitly requires a Linux OS, but test executes on non-Linux platforms. 

This change adds a JUnit assumption for Linux before executing a test which will always fail on other OSs