### PR TITLE
Nws/remove generics from config types

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/config/BcmConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/BcmConfig.java
@@ -4,10 +4,8 @@ package com.pi4j.config;
  * Configuration contract for I/O instances that are addressed by a Broadcom (BCM) GPIO pin number,
  * such as digital inputs/outputs and PWM pins. The {@code bcm} value identifies the physical SoC
  * GPIO pin the I/O is bound to.
- *
- * @param <CONFIG_TYPE> the concrete configuration sub-type, returned by fluent accessors to enable type-safe chaining
  */
-public interface BcmConfig<CONFIG_TYPE extends Config> extends Config<CONFIG_TYPE> {
+public interface BcmConfig {
     /**
      * Property key under which the legacy "address" value is stored in the configuration properties map.
      *

--- a/pi4j-core/src/main/java/com/pi4j/config/BusConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/BusConfig.java
@@ -3,10 +3,8 @@ package com.pi4j.config;
 /**
  * Configuration contract for I/O instances that communicate over a numbered hardware bus, such as
  * I2C, SPI and PWM. The {@code bus} value selects which of the platform's buses the I/O uses.
- *
- * @param <CONFIG_TYPE> the concrete configuration sub-type, returned by fluent accessors to enable type-safe chaining
  */
-public interface BusConfig<CONFIG_TYPE extends Config> extends Config<CONFIG_TYPE> {
+public interface BusConfig {
     /**
      * Property key under which the bus number is stored in the configuration properties map.
      */

--- a/pi4j-core/src/main/java/com/pi4j/config/ChannelConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/ChannelConfig.java
@@ -4,10 +4,8 @@ package com.pi4j.config;
  * Configuration contract for I/O instances that are addressed by a channel number within a bus,
  * such as SPI and PWM. The {@code channel} value selects a specific line on the bus identified by
  * the accompanying {@link BusConfig}.
- *
- * @param <CONFIG_TYPE> the concrete configuration sub-type, returned by fluent accessors to enable type-safe chaining
  */
-public interface ChannelConfig<CONFIG_TYPE extends Config> extends Config<CONFIG_TYPE> {
+public interface ChannelConfig {
     /**
      * Property key under which the channel number is stored in the configuration properties map.
      */

--- a/pi4j-core/src/main/java/com/pi4j/config/ChipConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/ChipConfig.java
@@ -4,10 +4,8 @@ package com.pi4j.config;
  * Configuration contract for I/O instances that are addressed by a chip number, for example the
  * GPIO chip exposed by the Linux GPIO character-device interface. The {@code chip} value selects
  * which controller chip the I/O belongs to.
- *
- * @param <CONFIG_TYPE> the concrete configuration sub-type, returned by fluent accessors to enable type-safe chaining
  */
-public interface ChipConfig<CONFIG_TYPE extends Config> extends Config<CONFIG_TYPE> {
+public interface ChipConfig {
     /**
      * Property key under which the chip number is stored in the configuration properties map.
      */

--- a/pi4j-core/src/main/java/com/pi4j/config/Config.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/Config.java
@@ -8,10 +8,8 @@ import java.util.Map;
  * the raw underlying property map, and validates its own required values. I/O-specific
  * configurations (such as {@link BcmConfig}, {@link BusConfig} or {@link ChannelConfig}) extend
  * this interface, and instances are typically assembled with a {@link ConfigBuilder}.
- *
- * @param <CONFIG_TYPE> the concrete configuration sub-type
  */
-public interface Config<CONFIG_TYPE> {
+public interface Config {
     /**
      * Property key under which the configuration identifier is stored in the properties map.
      */

--- a/pi4j-core/src/main/java/com/pi4j/config/ConfigBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/ConfigBase.java
@@ -12,10 +12,8 @@ import java.util.Map;
  * I/O configurations and exposes their raw property map. Concrete I/O configuration classes extend
  * this base to inherit handling of {@code id}, {@code name} and {@code description}, and override
  * {@link #getUniqueIdentifier()} to supply an I/O-type-specific identity.
- *
- * @param <CONFIG_TYPE> the concrete configuration sub-type
  */
-public class ConfigBase<CONFIG_TYPE extends Config> implements Config<CONFIG_TYPE> {
+public class ConfigBase implements Config {
 
     // private configuration variables
     protected String id = null;

--- a/pi4j-core/src/main/java/com/pi4j/config/DeviceConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/DeviceConfig.java
@@ -3,10 +3,8 @@ package com.pi4j.config;
 /**
  * Configuration contract for I/O instances that are addressed by a device number, for example a
  * specific peripheral on a bus. The {@code device} value selects which device the I/O targets.
- *
- * @param <CONFIG_TYPE> the concrete configuration sub-type, returned by fluent accessors to enable type-safe chaining
  */
-public interface DeviceConfig<CONFIG_TYPE extends Config> extends Config<CONFIG_TYPE> {
+public interface DeviceConfig {
 
     /**
      * Property key under which the device number is stored in the configuration properties map.

--- a/pi4j-core/src/main/java/com/pi4j/config/PortConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/PortConfig.java
@@ -4,10 +4,8 @@ package com.pi4j.config;
  * Configuration contract for I/O that is addressed by a named port.
  * Extends the base {@link Config} contract with a single
  * {@code port} property identified by {@link #PORT_KEY}.
- *
- * @param <CONFIG_TYPE> the concrete configuration type, enabling fluent access on subtypes
  */
-public interface PortConfig<CONFIG_TYPE extends Config> extends Config<CONFIG_TYPE> {
+public interface PortConfig {
 
     /**
      * Property key under which the port value is stored in the configuration.

--- a/pi4j-core/src/main/java/com/pi4j/config/impl/BcmConfigBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/impl/BcmConfigBase.java
@@ -1,7 +1,6 @@
 package com.pi4j.config.impl;
 
 import com.pi4j.config.BcmConfig;
-import com.pi4j.config.Config;
 import com.pi4j.config.ConfigBase;
 import com.pi4j.config.exception.ConfigMissingRequiredKeyException;
 
@@ -9,12 +8,10 @@ import java.util.Map;
 
 /**
  * <p>Abstract AddressConfigBase class.</p>
- *
- * @param <CONFIG_TYPE>
  */
-public abstract class BcmConfigBase<CONFIG_TYPE extends Config>
-    extends ConfigBase<CONFIG_TYPE>
-    implements BcmConfig<CONFIG_TYPE> {
+public abstract class BcmConfigBase
+    extends ConfigBase
+    implements BcmConfig {
 
     // private configuration properties
     protected Integer bcm = null;

--- a/pi4j-core/src/main/java/com/pi4j/config/impl/DeviceConfigBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/impl/DeviceConfigBase.java
@@ -1,6 +1,5 @@
 package com.pi4j.config.impl;
 
-import com.pi4j.config.Config;
 import com.pi4j.config.ConfigBase;
 import com.pi4j.config.DeviceConfig;
 import com.pi4j.config.exception.ConfigMissingRequiredKeyException;
@@ -9,12 +8,10 @@ import java.util.Map;
 
 /**
  * <p>Abstract DeviceConfigBase class.</p>
- *
- * @param <CONFIG_TYPE>
  */
-public abstract class DeviceConfigBase<CONFIG_TYPE extends Config<CONFIG_TYPE>>
-    extends ConfigBase<CONFIG_TYPE>
-    implements DeviceConfig<CONFIG_TYPE> {
+public abstract class DeviceConfigBase
+    extends ConfigBase
+    implements DeviceConfig {
 
     // private configuration variables
     protected Integer device = null;

--- a/pi4j-core/src/main/java/com/pi4j/config/impl/PortConfigBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/impl/PortConfigBase.java
@@ -1,6 +1,5 @@
 package com.pi4j.config.impl;
 
-import com.pi4j.config.Config;
 import com.pi4j.config.ConfigBase;
 import com.pi4j.config.PortConfig;
 import com.pi4j.config.exception.ConfigMissingRequiredKeyException;
@@ -9,12 +8,10 @@ import java.util.Map;
 
 /**
  * <p>Abstract AddressConfigBase class.</p>
- *
- * @param <CONFIG_TYPE>
  */
-public abstract class PortConfigBase<CONFIG_TYPE extends Config>
-    extends ConfigBase<CONFIG_TYPE>
-    implements PortConfig<CONFIG_TYPE> {
+public abstract class PortConfigBase
+    extends ConfigBase
+    implements PortConfig {
 
     // private configuration properties
     protected String port = null;

--- a/pi4j-core/src/main/java/com/pi4j/io/IOConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IOConfig.java
@@ -7,10 +7,8 @@ import com.pi4j.config.Config;
  * <p>
  * In addition to the generic properties from {@link Config}, it identifies the {@link com.pi4j.provider.Provider}
  * and platform that should service the I/O instance described by this configuration.
- *
- * @param <CONFIG_TYPE> the concrete configuration type, used for self-referential fluent typing
  */
-public interface IOConfig<CONFIG_TYPE> extends Config<CONFIG_TYPE> {
+public interface IOConfig extends Config {
     /** Configuration property key identifying the target platform. */
     String PLATFORM_KEY = "platform";
     /** Configuration property key identifying the I/O provider. */

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioBase.java
@@ -13,7 +13,7 @@ import com.pi4j.provider.Provider;
  * @param <PROVIDER_TYPE> the {@link Provider} type that instantiated and backs this I/O instance
  */
 public abstract class GpioBase<IO_TYPE extends Gpio<IO_TYPE, CONFIG_TYPE, PROVIDER_TYPE>,
-    CONFIG_TYPE extends GpioConfig<CONFIG_TYPE>, PROVIDER_TYPE extends Provider>
+    CONFIG_TYPE extends GpioConfig, PROVIDER_TYPE extends Provider>
     extends IOBase<IO_TYPE, CONFIG_TYPE, PROVIDER_TYPE>
     implements Gpio<IO_TYPE, CONFIG_TYPE, PROVIDER_TYPE> {
 

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioConfig.java
@@ -2,17 +2,14 @@ package com.pi4j.io.gpio;
 
 import com.pi4j.config.BcmConfig;
 import com.pi4j.config.BusConfig;
-import com.pi4j.config.Config;
 import com.pi4j.io.IOConfig;
 
 /**
  * Configuration contract for {@link Gpio} I/O instances. It combines the {@link IOConfig} identity and
  * lifecycle properties with the GPIO addressing model of {@link BcmConfig} (Broadcom pin number) and the
  * bus addressing of {@link BusConfig}, so a single configuration can fully describe a GPIO pin to its provider.
- *
- * @param <CONFIG_TYPE> the concrete configuration sub-type, returned by fluent accessors to enable type-safe chaining
  */
-public interface GpioConfig<CONFIG_TYPE extends Config> extends BusConfig<CONFIG_TYPE>, BcmConfig<CONFIG_TYPE>, IOConfig<CONFIG_TYPE> {
+public interface GpioConfig extends BusConfig, BcmConfig, IOConfig {
 
     /**
      * Returns the unique identifier used to distinguish GPIO devices, derived from the configured

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioConfigBuilder.java
@@ -10,7 +10,7 @@ import com.pi4j.io.IOBcmConfigBuilder;
  * @param <BUILDER_TYPE> the concrete builder sub-type, returned by fluent setters to enable type-safe chaining
  * @param <CONFIG_TYPE>  the {@link GpioConfig} type produced by this builder
  */
-public interface GpioConfigBuilder<BUILDER_TYPE extends GpioConfigBuilder, CONFIG_TYPE extends GpioConfig>
+public interface GpioConfigBuilder<BUILDER_TYPE extends GpioConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>, CONFIG_TYPE extends GpioConfig>
     extends IOBcmConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {
 
     /**
@@ -19,5 +19,5 @@ public interface GpioConfigBuilder<BUILDER_TYPE extends GpioConfigBuilder, CONFI
      * @param bus the bus number to associate with the configured GPIO device
      * @return this builder instance for method chaining
      */
-    GpioConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> bus(int bus);
+    BUILDER_TYPE bus(int bus);
 }

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/Digital.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/Digital.java
@@ -14,7 +14,7 @@ import com.pi4j.io.gpio.Gpio;
  * @param <PROVIDER_TYPE> the {@link DigitalProvider} type that created this instance
  */
 public interface Digital<DIGITAL_TYPE extends Digital<DIGITAL_TYPE, CONFIG_TYPE, PROVIDER_TYPE>,
-    CONFIG_TYPE extends DigitalConfig<CONFIG_TYPE>,
+    CONFIG_TYPE extends DigitalConfig,
     PROVIDER_TYPE extends DigitalProvider>
     extends Gpio<DIGITAL_TYPE, CONFIG_TYPE, PROVIDER_TYPE>,
     ListenableOnOffRead<DIGITAL_TYPE> {

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalBase.java
@@ -19,7 +19,7 @@ import java.util.function.Consumer;
  * @param <PROVIDER_TYPE> the {@link DigitalProvider} type that created this instance
  */
 public abstract class DigitalBase<DIGITAL_TYPE extends Digital<DIGITAL_TYPE, CONFIG_TYPE, PROVIDER_TYPE>,
-        CONFIG_TYPE extends DigitalConfig<CONFIG_TYPE>,
+        CONFIG_TYPE extends DigitalConfig,
         PROVIDER_TYPE extends DigitalProvider>
         extends GpioBase<DIGITAL_TYPE, CONFIG_TYPE, PROVIDER_TYPE>
         implements Digital<DIGITAL_TYPE, CONFIG_TYPE, PROVIDER_TYPE>

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalConfig.java
@@ -1,15 +1,12 @@
 package com.pi4j.io.gpio.digital;
 
-import com.pi4j.config.Config;
 import com.pi4j.io.gpio.GpioConfig;
 
 /**
  * Configuration contract for a {@link Digital} I/O instance, extending the generic {@link GpioConfig}
  * with the BCM pin assignment and the {@link DigitalState} that is considered the logical "on" state.
- *
- * @param <CONFIG_TYPE> the concrete configuration type, used as the self-referencing builder/return type
  */
-public interface DigitalConfig<CONFIG_TYPE extends Config> extends GpioConfig<CONFIG_TYPE> {
+public interface DigitalConfig extends GpioConfig {
 
     /**
      * Property key under which the on-state value is stored in a configuration map.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalConfigBuilder.java
@@ -9,7 +9,7 @@ import com.pi4j.io.gpio.GpioConfigBuilder;
  * @param <BUILDER_TYPE> the concrete builder type, used as the self-referencing return type for chaining
  * @param <CONFIG_TYPE> the {@link DigitalConfig} type produced by this builder
  */
-public interface DigitalConfigBuilder<BUILDER_TYPE extends DigitalConfigBuilder, CONFIG_TYPE extends DigitalConfig>
+public interface DigitalConfigBuilder<BUILDER_TYPE extends DigitalConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>, CONFIG_TYPE extends DigitalConfig>
     extends GpioConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalEvent.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalEvent.java
@@ -11,7 +11,7 @@ import com.pi4j.event.Event;
  * @param <PROVIDER_TYPE> the {@link DigitalProvider} type of the source
  */
 public interface DigitalEvent<DIGITAL_TYPE extends Digital<DIGITAL_TYPE, CONFIG_TYPE, PROVIDER_TYPE>,
-        CONFIG_TYPE extends DigitalConfig<CONFIG_TYPE>,
+        CONFIG_TYPE extends DigitalConfig,
         PROVIDER_TYPE extends DigitalProvider>
         extends Event {
     /**

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalInputConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalInputConfig.java
@@ -1,6 +1,5 @@
 package com.pi4j.io.gpio.digital;
 
-
 import com.pi4j.context.Context;
 
 /**
@@ -8,7 +7,7 @@ import com.pi4j.context.Context;
  * pull resistance and debounce interval. Instances are typically assembled through a
  * {@link DigitalInputConfigBuilder}.
  */
-public interface DigitalInputConfig extends DigitalConfig<DigitalInputConfig> {
+public interface DigitalInputConfig extends DigitalConfig {
 
     /** Property key under which the pull resistance value is stored in a configuration map. */
     String PULL_RESISTANCE_KEY = "pull";

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalOutputConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalOutputConfig.java
@@ -7,7 +7,7 @@ import com.pi4j.context.Context;
  * settings: the state applied when the output is initialized and the state applied when Pi4J shuts down.
  * Instances are assembled with a {@link DigitalOutputConfigBuilder}.
  */
-public interface DigitalOutputConfig extends DigitalConfig<DigitalOutputConfig> {
+public interface DigitalOutputConfig extends DigitalConfig {
     /** Configuration property key for the shutdown state value. */
     String SHUTDOWN_STATE_KEY = "shutdown";
     /** Configuration property key for the initial state value. */

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalInputConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalInputConfig.java
@@ -10,7 +10,7 @@ import com.pi4j.util.StringUtil;
 import java.util.Map;
 
 public class DefaultDigitalInputConfig
-    extends IOBcmConfigBase<DigitalInputConfig>
+    extends IOBcmConfigBase
     implements DigitalInputConfig {
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalOutputConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalOutputConfig.java
@@ -8,7 +8,7 @@ import com.pi4j.util.StringUtil;
 import java.util.Map;
 
 public class DefaultDigitalOutputConfig
-    extends IOBcmConfigBase<DigitalOutputConfig>
+    extends IOBcmConfigBase
     implements DigitalOutputConfig {
 
     // private configuration properties

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DigitalConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DigitalConfigBuilderBase.java
@@ -11,7 +11,7 @@ import com.pi4j.io.impl.IOBcmConfigBuilderBase;
  * @param <BUILDER_TYPE>
  * @param <CONFIG_TYPE>
  */
-public abstract class DigitalConfigBuilderBase<BUILDER_TYPE extends DigitalConfigBuilder, CONFIG_TYPE extends DigitalConfig>
+public abstract class DigitalConfigBuilderBase<BUILDER_TYPE extends DigitalConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>, CONFIG_TYPE extends DigitalConfig>
     extends IOBcmConfigBuilderBase<BUILDER_TYPE, CONFIG_TYPE>
     implements DigitalConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {
 

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DigitalConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DigitalConfigBuilderBase.java
@@ -21,6 +21,7 @@ public abstract class DigitalConfigBuilderBase<BUILDER_TYPE extends DigitalConfi
     protected DigitalConfigBuilderBase() {
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public BUILDER_TYPE onState(DigitalState state) {
         this.properties.put(DigitalConfig.ON_STATE_KEY, state.toString());

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CConfig.java
@@ -10,7 +10,7 @@ import com.pi4j.io.IOConfig;
  * desired {@link I2CImplementation}. Instances are produced by an {@link I2CConfigBuilder} and consumed by an
  * {@link I2CProvider} when creating a device.
  */
-public interface I2CConfig extends IOConfig<I2CConfig>, BusConfig<I2CConfig>, DeviceConfig<I2CConfig> {
+public interface I2CConfig extends IOConfig, BusConfig, DeviceConfig {
 
     /** Configuration property key identifying the selected {@link I2CImplementation}. */
     String I2C_IMPLEMENTATION = "i2c_implementation";

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/DefaultI2CConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/DefaultI2CConfig.java
@@ -10,7 +10,7 @@ import com.pi4j.util.StringUtil;
 import java.util.Map;
 
 public class DefaultI2CConfig
-    extends IOConfigBase<I2CConfig>
+    extends IOConfigBase
     implements I2CConfig {
 
     // private configuration properties

--- a/pi4j-core/src/main/java/com/pi4j/io/impl/IOBcmConfigBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/impl/IOBcmConfigBase.java
@@ -1,18 +1,16 @@
 package com.pi4j.io.impl;
 
 import com.pi4j.config.BcmConfig;
-import com.pi4j.config.Config;
 import com.pi4j.config.impl.BcmConfigBase;
 import com.pi4j.io.IOConfig;
 
 import java.util.Map;
 
 /**
- * @param <CONFIG_TYPE>
  */
-public class IOBcmConfigBase<CONFIG_TYPE extends Config>
-    extends BcmConfigBase<CONFIG_TYPE>
-    implements IOConfig<CONFIG_TYPE>, BcmConfig<CONFIG_TYPE> {
+public class IOBcmConfigBase
+    extends BcmConfigBase
+    implements IOConfig, BcmConfig {
 
     // private configuration variables
     protected String provider = null;

--- a/pi4j-core/src/main/java/com/pi4j/io/impl/IOConfigBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/impl/IOConfigBase.java
@@ -1,15 +1,13 @@
 package com.pi4j.io.impl;
 
-import com.pi4j.config.Config;
 import com.pi4j.config.ConfigBase;
 import com.pi4j.io.IOConfig;
 
 import java.util.Map;
 
 /**
- * @param <CONFIG_TYPE>
  */
-public abstract class IOConfigBase<CONFIG_TYPE extends Config> extends ConfigBase<CONFIG_TYPE> implements IOConfig<CONFIG_TYPE> {
+public abstract class IOConfigBase extends ConfigBase implements IOConfig {
 
     // private configuration variables
     protected String provider = null;

--- a/pi4j-core/src/main/java/com/pi4j/io/impl/IODeviceConfigBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/impl/IODeviceConfigBase.java
@@ -1,6 +1,5 @@
 package com.pi4j.io.impl;
 
-import com.pi4j.config.Config;
 import com.pi4j.config.DeviceConfig;
 import com.pi4j.config.impl.DeviceConfigBase;
 import com.pi4j.io.IOConfig;
@@ -8,11 +7,10 @@ import com.pi4j.io.IOConfig;
 import java.util.Map;
 
 /**
- * @param <CONFIG_TYPE>
  */
-public class IODeviceConfigBase<CONFIG_TYPE extends Config<CONFIG_TYPE>>
-    extends DeviceConfigBase<CONFIG_TYPE>
-    implements IOConfig<CONFIG_TYPE>, DeviceConfig<CONFIG_TYPE> {
+public class IODeviceConfigBase
+    extends DeviceConfigBase
+    implements IOConfig, DeviceConfig {
 
     // private configuration variables
     protected String provider = null;

--- a/pi4j-core/src/main/java/com/pi4j/io/impl/IOPortConfigBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/impl/IOPortConfigBase.java
@@ -1,6 +1,5 @@
 package com.pi4j.io.impl;
 
-import com.pi4j.config.Config;
 import com.pi4j.config.PortConfig;
 import com.pi4j.config.impl.PortConfigBase;
 import com.pi4j.io.IOConfig;
@@ -8,11 +7,10 @@ import com.pi4j.io.IOConfig;
 import java.util.Map;
 
 /**
- * @param <CONFIG_TYPE>
  */
-public class IOPortConfigBase<CONFIG_TYPE extends Config>
-    extends PortConfigBase<CONFIG_TYPE>
-    implements PortConfig<CONFIG_TYPE>, IOConfig<CONFIG_TYPE> {
+public class IOPortConfigBase
+    extends PortConfigBase
+    implements PortConfig, IOConfig {
 
     // private configuration variables
     protected String provider = null;

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmConfig.java
@@ -13,7 +13,7 @@ import com.pi4j.io.IOConfig;
  * shutdown values. Instances are assembled with a {@link PwmConfigBuilder} and consumed by a {@link PwmProvider} when
  * creating the PWM I/O.
  */
-public interface PwmConfig extends ChipConfig<PwmConfig>, ChannelConfig<PwmConfig>, BcmConfig<PwmConfig>, IOConfig<PwmConfig> {
+public interface PwmConfig extends ChipConfig, ChannelConfig, BcmConfig, IOConfig {
 
     /**
      * Property key for the legacy PWM address.

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/impl/DefaultPwmConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/impl/DefaultPwmConfig.java
@@ -10,7 +10,7 @@ import com.pi4j.util.StringUtil;
 import java.util.Map;
 
 public class DefaultPwmConfig
-    extends IOConfigBase<PwmConfig>
+    extends IOConfigBase
     implements PwmConfig {
 
     protected Integer chip = null;

--- a/pi4j-core/src/main/java/com/pi4j/io/spi/SpiConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/SpiConfig.java
@@ -9,7 +9,7 @@ import com.pi4j.io.IOConfig;
  * mode, baud rate, bit ordering, and provider flags. Instances are produced by a {@link SpiConfigBuilder}
  * and consumed by a {@link SpiProvider} when creating an SPI device.
  */
-public interface SpiConfig extends ChannelConfig<SpiConfig>, IOConfig<SpiConfig> {
+public interface SpiConfig extends ChannelConfig, IOConfig {
     /**
      * Configuration property key for the legacy SPI address.
      *

--- a/pi4j-core/src/main/java/com/pi4j/io/spi/impl/DefaultSpiConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/impl/DefaultSpiConfig.java
@@ -7,7 +7,7 @@ import com.pi4j.util.StringUtil;
 import java.util.Map;
 
 public class DefaultSpiConfig
-    extends IOConfigBase<SpiConfig>
+    extends IOConfigBase
     implements SpiConfig {
 
     // private configuration properties

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/common/FFMPermissionHelper.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/common/FFMPermissionHelper.java
@@ -160,7 +160,7 @@ public class FFMPermissionHelper {
      *                       belong to the expected group, it lacks group read/write permission, or
      *                       the configuration type is not recognized
      */
-    public static void checkDevicePermissions(String devicePath, IOConfig<?> config) {
+    public static void checkDevicePermissions(String devicePath, IOConfig config) {
         var path = Paths.get(devicePath);
         // checking that device is physically exists
         if (!path.toFile().exists()) {

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/unit/Pi4JNativeLibraryTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/unit/Pi4JNativeLibraryTest.java
@@ -2,7 +2,6 @@ package com.pi4j.plugin.ffm.unit;
 
 import com.pi4j.exception.Pi4JException;
 import com.pi4j.plugin.ffm.common.Pi4JNativeLibrary;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/unit/Pi4JNativeLibraryTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/unit/Pi4JNativeLibraryTest.java
@@ -2,6 +2,7 @@ package com.pi4j.plugin.ffm.unit;
 
 import com.pi4j.exception.Pi4JException;
 import com.pi4j.plugin.ffm.common.Pi4JNativeLibrary;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,11 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>maven-central</id>
+            <name>Maven Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
     </repositories>
 
     <!-- PROJECT MODULES -->

--- a/pom.xml
+++ b/pom.xml
@@ -187,11 +187,6 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
-        <repository>
-            <id>maven-central</id>
-            <name>Maven Central Repository</name>
-            <url>https://repo.maven.apache.org/maven2</url>
-        </repository>
     </repositories>
 
     <!-- PROJECT MODULES -->


### PR DESCRIPTION
This PR removes unnecessary type parameters from configuration classes, aiming to simplify the code in this area. 

It includes no functional changes. However, it does include breaking changes to the public API. It does not include any changes to the builder APIs.

Relates to #705 