### PR TITLE
remove redeclaration of bcm() method in DigitalConfig

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalConfig.java
@@ -4,7 +4,7 @@ import com.pi4j.io.gpio.GpioConfig;
 
 /**
  * Configuration contract for a {@link Digital} I/O instance, extending the generic {@link GpioConfig}
- * with the BCM pin assignment and the {@link DigitalState} that is considered the logical "on" state.
+ * with the {@link DigitalState} that is considered the logical "on" state.
  */
 public interface DigitalConfig extends GpioConfig {
 
@@ -12,13 +12,6 @@ public interface DigitalConfig extends GpioConfig {
      * Property key under which the on-state value is stored in a configuration map.
      */
     String ON_STATE_KEY = "onstate";
-
-    /**
-     * Returns the BCM (Broadcom) GPIO pin number this I/O instance is bound to.
-     *
-     * @return the configured BCM pin number, or {@code null} if none was set
-     */
-    Integer bcm();
 
     /**
      * Returns the {@link DigitalState} that is treated as the logical "on" state for this instance,


### PR DESCRIPTION
`DigitalConfig` doesn't need to redeclare `bcm()` when it's inherited via GpioConfig