### PR TITLE
Enable context construction for falling back to mocks #619

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/context/ContextBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/context/ContextBuilder.java
@@ -1,6 +1,5 @@
 package com.pi4j.context;
 
-import com.pi4j.boardinfo.util.BoardInfoHelper;
 import com.pi4j.config.Builder;
 import com.pi4j.context.impl.DefaultContext;
 import com.pi4j.exception.Pi4JException;

--- a/pi4j-core/src/main/java/com/pi4j/context/ContextBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/context/ContextBuilder.java
@@ -24,7 +24,7 @@ public class ContextBuilder implements Builder<Context> {
     protected Logger logger = LoggerFactory.getLogger(ContextBuilder.class);
 
     // auto detection flags
-    protected boolean autoDetectMockPlugins = !BoardInfoHelper.runningOnRaspberryPi();
+    protected boolean autoDetectMockPlugins = false;
     protected boolean autoDetectProviders = false;
     protected boolean enableShutdownHook = false;
 

--- a/pi4j-core/src/main/java/com/pi4j/context/impl/DefaultContext.java
+++ b/pi4j-core/src/main/java/com/pi4j/context/impl/DefaultContext.java
@@ -94,7 +94,7 @@ public class DefaultContext implements Context {
             Map<IOType, Provider> providers = new HashMap<>();
 
             // only attempt to load platforms and providers from the classpath if an auto detect option is enabled
-            if (config.autoDetectProviders()) {
+            if (config.autoDetectProviders() || config.autoDetectMockPlugins()) {
 
                 // detect available Pi4J Plugins by scanning the classpath looking for plugin instances
                 ServiceLoader<Plugin> serviceLoaderPlugins = ServiceLoader.load(Plugin.class);
@@ -104,6 +104,10 @@ public class DefaultContext implements Context {
 
                     if (!config.autoDetectMockPlugins() && plugin.isMock()) {
                         logger.trace("Ignoring mock plugin: [{}] in classpath", plugin.getClass().getName());
+                        continue;
+                    }
+                    if (!config.autoDetectProviders() && !plugin.isMock()) {
+                        logger.trace("Ignoring non-mock plugin: [{}] in classpath", plugin.getClass().getName());
                         continue;
                     }
 
@@ -120,9 +124,7 @@ public class DefaultContext implements Context {
                         //    OR
                         // Detecting Mocks is enabled and this is a mock plugin
                         // then add any detected providers to the collection to load
-                        if (config.autoDetectProviders() ||  (config.autoDetectMockPlugins() && plugin.isMock())) {
-                            store.providers.forEach(provider -> addProvider(provider, providers));
-                        }
+                        store.providers.forEach(provider -> addProvider(provider, providers));
 
                     } catch (Exception ex) {
                         // unable to initialize this provider instance

--- a/pi4j-test/src/test/java/com/pi4j/test/context/ContextTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/context/ContextTest.java
@@ -23,11 +23,7 @@ public class ContextTest {
 
     @BeforeAll
     public void beforeTest() throws Pi4JException {
-        // initialize Pi4J with an auto context
-        // An auto context includes AUTO-DETECT BINDINGS enabled
-        // which will load all detected Pi4J extension libraries
-        // (Platforms and Providers) in the class path
-        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().autoDetectProviders().build();
+        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().build();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/io/i2c/I2CRawDataTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/i2c/I2CRawDataTest.java
@@ -42,7 +42,7 @@ public class I2CRawDataTest {
         // An auto context enabled AUTO-DETECT loading
         // which will load any detected Pi4J extension
         // libraries (Platforms and Providers) from the class path
-        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().autoDetectProviders().build();
+        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().build();
 
     }
 

--- a/pi4j-test/src/test/java/com/pi4j/test/io/i2c/I2CRegisterDataTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/i2c/I2CRegisterDataTest.java
@@ -42,7 +42,7 @@ public class I2CRegisterDataTest {
         // An auto context enabled AUTO-DETECT loading
         // which will load any detected Pi4J extension
         // libraries (Platforms and Providers) from the class path
-        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().autoDetectProviders().build();
+        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().build();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/io/spi/SpiRawDataTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/spi/SpiRawDataTest.java
@@ -41,7 +41,7 @@ public class SpiRawDataTest {
         // An auto context enabled AUTO-DETECT loading
         // which will load any detected Pi4J extension
         // libraries (Platforms and Providers) from the class path
-        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().autoDetectProviders().build();
+        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().build();
     }
 
     @AfterEach

--- a/pi4j-test/src/test/java/com/pi4j/test/provider/AutoProvidersTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/provider/AutoProvidersTest.java
@@ -26,11 +26,7 @@ public class AutoProvidersTest {
 
         System.setProperty(org.slf4j.simple.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, "TRACE");
 
-        // initialize Pi4J with an auto context
-        // An auto context includes AUTO-DETECT BINDINGS enabled
-        // which will load all detected Pi4J extension libraries
-        // (Platforms and Providers) in the class path
-        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().autoDetectProviders().build();
+        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().build();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryGetIoInstance.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryGetIoInstance.java
@@ -24,11 +24,7 @@ public class RegistryGetIoInstance {
     public void beforeTest() throws Pi4JException {
         System.setProperty(org.slf4j.simple.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, "INFO");
 
-        // initialize Pi4J with an auto context
-        // An auto context includes AUTO-DETECT BINDINGS enabled
-        // which will load all detected Pi4J extension libraries
-        // (Platforms and Providers) in the class path
-        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().autoDetectProviders().build();
+        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().build();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
@@ -34,7 +34,7 @@ class RegistryTest {
         // An auto context includes AUTO-DETECT BINDINGS enabled
         // which will load all detected Pi4J extension libraries
         // (Platforms and Providers) in the class path
-        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().autoDetectProviders().build();
+        pi4j = Pi4J.newContextBuilder().autoDetectMockPlugins().build();
     }
 
     @AfterEach

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/Mock.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/Mock.java
@@ -10,6 +10,12 @@ package com.pi4j.plugin.mock;
  * @see MockPlugin
  */
 public class Mock {
+
+    /**
+     * A deliberately low priority, ensuring that actual hardware providers are loaded first when auto-detection of
+     * both is enabled. This allows some code to run on "real" and unsupported hardware platforms without change.
+     */
+    public static final int MOCK_PROVIDER_PRIORITY = -1;
     /**
      * Human-readable display name shared by the Mock platform and providers.
      */

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/digital/MockDigitalInputProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/digital/MockDigitalInputProviderImpl.java
@@ -3,6 +3,7 @@ package com.pi4j.plugin.mock.provider.gpio.digital;
 import com.pi4j.io.gpio.digital.DigitalInput;
 import com.pi4j.io.gpio.digital.DigitalInputConfig;
 import com.pi4j.io.gpio.digital.DigitalInputProviderBase;
+import com.pi4j.plugin.mock.Mock;
 
 /**
  * Default implementation of {@link MockDigitalInputProvider}. Extends the pi4j-core
@@ -22,15 +23,11 @@ public class MockDigitalInputProviderImpl extends DigitalInputProviderBase imple
     }
 
     /**
-     * {@inheritDoc}
-     * <p>
-     * Returns a deliberately high priority ({@code 1000}) so that, when the mock plugin is on
-     * the classpath, it is preferred over real hardware providers during testing.
+     * Returns Mock.MOCK_PROVIDER_PRIORITY.
      */
     @Override
     public int getPriority() {
-        // if the mock is loaded, then we most probably want to use it for testing
-        return 1000;
+        return Mock.MOCK_PROVIDER_PRIORITY;
     }
 
     /**

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/digital/MockDigitalOutputProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/digital/MockDigitalOutputProviderImpl.java
@@ -3,6 +3,7 @@ package com.pi4j.plugin.mock.provider.gpio.digital;
 import com.pi4j.io.gpio.digital.DigitalOutput;
 import com.pi4j.io.gpio.digital.DigitalOutputConfig;
 import com.pi4j.io.gpio.digital.DigitalOutputProviderBase;
+import com.pi4j.plugin.mock.Mock;
 
 /**
  * Default implementation of {@link MockDigitalOutputProvider}. Extends the pi4j-core
@@ -22,15 +23,11 @@ public class MockDigitalOutputProviderImpl extends DigitalOutputProviderBase imp
     }
 
     /**
-     * {@inheritDoc}
-     * <p>
-     * Returns a deliberately high priority ({@code 1000}) so that, when the mock plugin is on
-     * the classpath, it is preferred over real hardware providers during testing.
+     * Returns Mock.MOCK_PROVIDER_PRIORITY.
      */
     @Override
     public int getPriority() {
-        // if the mock is loaded, then we most probably want to use it for testing
-        return 1000;
+        return Mock.MOCK_PROVIDER_PRIORITY;
     }
 
     /**

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/i2c/MockI2CProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/i2c/MockI2CProviderImpl.java
@@ -3,6 +3,7 @@ package com.pi4j.plugin.mock.provider.i2c;
 import com.pi4j.io.i2c.I2C;
 import com.pi4j.io.i2c.I2CConfig;
 import com.pi4j.io.i2c.I2CProviderBase;
+import com.pi4j.plugin.mock.Mock;
 
 /**
  * Default in-memory implementation of {@link MockI2CProvider}, extending {@link I2CProviderBase}.
@@ -20,15 +21,11 @@ public class MockI2CProviderImpl extends I2CProviderBase implements MockI2CProvi
     }
 
     /**
-     * {@inheritDoc}
-     * <p>
-     * Returns a deliberately high priority so that, when the mock plugin is present on the
-     * classpath, it is preferred over hardware providers during testing.
+     * Returns Mock.MOCK_PRIORITY.
      */
     @Override
     public int getPriority() {
-        // if the mock is loaded, then we most probably want to use it for testing
-        return 1000;
+        return Mock.MOCK_PROVIDER_PRIORITY;
     }
 
     /**

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/pwm/MockPwmProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/pwm/MockPwmProviderImpl.java
@@ -3,6 +3,7 @@ package com.pi4j.plugin.mock.provider.pwm;
 import com.pi4j.io.pwm.Pwm;
 import com.pi4j.io.pwm.PwmConfig;
 import com.pi4j.io.pwm.PwmProviderBase;
+import com.pi4j.plugin.mock.Mock;
 
 /**
  * Default in-memory implementation of {@link MockPwmProvider}, extending {@link PwmProviderBase}.
@@ -20,15 +21,12 @@ public class MockPwmProviderImpl extends PwmProviderBase implements MockPwmProvi
     }
 
     /**
-     * {@inheritDoc}
-     * <p>
-     * Returns a deliberately high priority so that, when the mock plugin is present on the
-     * classpath, it is preferred over hardware providers during testing.
+     * Returns Mock.MOCK_PROVIDER_PRIORITY.
      */
     @Override
     public int getPriority() {
         // if the mock is loaded, then we most probably want to use it for testing
-        return 1000;
+        return Mock.MOCK_PROVIDER_PRIORITY;
     }
 
     /**

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/spi/MockSpiProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/spi/MockSpiProviderImpl.java
@@ -3,6 +3,7 @@ package com.pi4j.plugin.mock.provider.spi;
 import com.pi4j.io.spi.Spi;
 import com.pi4j.io.spi.SpiConfig;
 import com.pi4j.io.spi.SpiProviderBase;
+import com.pi4j.plugin.mock.Mock;
 
 /**
  * Default in-memory implementation of {@link MockSpiProvider}, extending {@link SpiProviderBase}.
@@ -20,15 +21,11 @@ public class MockSpiProviderImpl extends SpiProviderBase implements MockSpiProvi
     }
 
     /**
-     * {@inheritDoc}
-     * <p>
-     * Returns a deliberately high priority so that, when the mock plugin is present on the
-     * classpath, it is preferred over hardware providers during testing.
+     * Returns Mock.MOCK_PROVIDER_PRIORITY.
      */
     @Override
     public int getPriority() {
-        // if the mock is loaded, then we most probably want to use it for testing
-        return 1000;
+        return Mock.MOCK_PROVIDER_PRIORITY;
     }
 
     /**


### PR DESCRIPTION
This change 

1. Lowers the mock provider priority to -1, so they can become a fallback option instead of always taking precedence.
2. Makes sure mocks are actually loaded when requested, no longer gating on autoDetectProviders (which used to block having auto mocks without auto providers)
3. Adjust tests where we want to use only mocks specifically to request only mocks.
4. Stops automagically enabling mocks on non-pi boards

This covers the following three "real world" cases:

1. We want to run or test actual hardware `Pi4J.newContextBuilder().autoDetectProviders().build(); ` (aka 
`newAutoContext()`
5. We want to run mock-based tests: `Pi4J.newContextBuilder().autoDetectMockPlugins().build();`
6. We want to run or test actual hardware, but fall back to mocks on other platforms (#619)

The following hypothetical case is no longer covered:

- We want to run mocks and fall back to actual hardware

This case doesn't really exist, as we have mocks for all IO types, so we would never fall back to real hardware before, given the previously high priority of mocks.

This should also address the main issue in #616

The fallback relies on "real" providers failing early if they won't work, which FFM providers check via hardware group presence (if they can be loaded at all on the given platform)