### PR TITLE
declare generic type arguments in builder interfaces

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/config/impl/BcmConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/impl/BcmConfigBuilderBase.java
@@ -11,7 +11,10 @@ import com.pi4j.config.ConfigBuilder;
  * @param <BUILDER_TYPE>
  * @param <CONFIG_TYPE>
  */
-public abstract class BcmConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder, CONFIG_TYPE extends Config>
+public abstract class BcmConfigBuilderBase<
+    BUILDER_TYPE extends ConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>,
+    CONFIG_TYPE extends Config
+    >
     extends ConfigBuilderBase<BUILDER_TYPE, CONFIG_TYPE>
     implements BcmConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {
 
@@ -21,6 +24,7 @@ public abstract class BcmConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder, C
     protected BcmConfigBuilderBase() {
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public BUILDER_TYPE bcm(Integer bcm) {
         this.properties.put(BcmConfig.BCM_KEY, bcm.toString());

--- a/pi4j-core/src/main/java/com/pi4j/config/impl/ConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/impl/ConfigBuilderBase.java
@@ -18,8 +18,11 @@ import java.util.stream.Collectors;
  * @param <BUILDER_TYPE>
  * @param <CONFIG_TYPE>
  */
-public abstract class ConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder, CONFIG_TYPE extends Config>
-        implements ConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {
+public abstract class ConfigBuilderBase<
+    BUILDER_TYPE extends ConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>,
+    CONFIG_TYPE extends Config
+    >
+    implements ConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {
 
     // private configuration variables
     protected final ConcurrentHashMap<String, String> properties = new ConcurrentHashMap<>();
@@ -34,6 +37,7 @@ public abstract class ConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder, CONF
     protected ConfigBuilderBase() {
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public BUILDER_TYPE id(String id){
         this.properties.put(Config.ID_KEY, id);
@@ -45,24 +49,28 @@ public abstract class ConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder, CONF
         return this.properties.get(Config.ID_KEY);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public BUILDER_TYPE name(String name){
         this.properties.put(Config.NAME_KEY, name);
         return (BUILDER_TYPE) this;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public BUILDER_TYPE description(String description){
         this.properties.put(Config.DESCRIPTION_KEY, description);
         return (BUILDER_TYPE) this;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public BUILDER_TYPE load(Map<String, String> properties) {
         this.properties.putAll(properties);
         return (BUILDER_TYPE) this;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public BUILDER_TYPE load(Map<String, String> properties, String prefixFilter) {
         // if a filter was not provided, then load properties without a filter

--- a/pi4j-core/src/main/java/com/pi4j/config/impl/DeviceConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/impl/DeviceConfigBuilderBase.java
@@ -11,7 +11,10 @@ import com.pi4j.config.DeviceConfigBuilder;
  * @param <BUILDER_TYPE>
  * @param <CONFIG_TYPE>
  */
-public abstract class DeviceConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder, CONFIG_TYPE extends Config>
+public abstract class DeviceConfigBuilderBase<
+    BUILDER_TYPE extends ConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>,
+    CONFIG_TYPE extends Config
+    >
     extends ConfigBuilderBase<BUILDER_TYPE, CONFIG_TYPE>
     implements DeviceConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {
 
@@ -21,6 +24,7 @@ public abstract class DeviceConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder
     protected DeviceConfigBuilderBase() {
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public BUILDER_TYPE device(Integer device) {
         this.properties.put(DeviceConfig.DEVICE_KEY, device.toString());

--- a/pi4j-core/src/main/java/com/pi4j/config/impl/PortConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/impl/PortConfigBuilderBase.java
@@ -12,7 +12,10 @@ import com.pi4j.context.Context;
  * @param <BUILDER_TYPE>
  * @param <CONFIG_TYPE>
  */
-public abstract class PortConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder, CONFIG_TYPE extends Config>
+public abstract class PortConfigBuilderBase<
+    BUILDER_TYPE extends ConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>,
+    CONFIG_TYPE extends Config
+    >
     extends ConfigBuilderBase<BUILDER_TYPE, CONFIG_TYPE>
     implements PortConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {
 
@@ -23,6 +26,7 @@ public abstract class PortConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder, 
         super();
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public BUILDER_TYPE port(String port) {
         this.properties.put(PortConfig.PORT_KEY, port);

--- a/pi4j-core/src/main/java/com/pi4j/context/Context.java
+++ b/pi4j-core/src/main/java/com/pi4j/context/Context.java
@@ -223,7 +223,7 @@ public interface Context extends Describable, IOCreator, ProviderProvider, Initi
     // ------------------------------------------------------------------------
 
     @Override
-    default <I extends IO> I create(IOConfig config, IOType ioType) {
+    default <I extends IO<?, ?, ?>> I create(IOConfig config, IOType ioType) {
         // create by explicitly configured IO <PROVIDER> from IO config
         String providerId = config.provider();
         if (StringUtil.isNotNullOrEmpty(providerId)) {

--- a/pi4j-core/src/main/java/com/pi4j/internal/IOCreator.java
+++ b/pi4j-core/src/main/java/com/pi4j/internal/IOCreator.java
@@ -24,17 +24,17 @@ import com.pi4j.io.spi.SpiConfigBuilder;
  */
 public interface IOCreator {
 
-    <I extends IO> I create(IOConfig config, IOType type);
+    <I extends IO<?, ?, ?>> I create(IOConfig config, IOType type);
 
-    default <I extends IO> I create(IOConfig config, Class<I> ioClass) {
+    default <I extends IO<?, ?, ?>> I create(IOConfig config, Class<I> ioClass) {
         return (ioClass.cast(create(config, IOType.getByIOClass(ioClass))));
     }
 
-    default <I extends IO> I create(IOConfigBuilder builder, IOType ioType) {
+    default <I extends IO<?, ?, ?>> I create(IOConfigBuilder<?, ?> builder, IOType ioType) {
         return create((IOConfig) builder.build(), ioType);
     }
 
-    default <I extends IO> I create(IOConfigBuilder builder, Class<I> ioClass) {
+    default <I extends IO<?, ?, ?>> I create(IOConfigBuilder<?, ?> builder, Class<I> ioClass) {
         return create((IOConfig) builder.build(), ioClass);
     }
 

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioConfigBuilder.java
@@ -10,7 +10,10 @@ import com.pi4j.io.IOBcmConfigBuilder;
  * @param <BUILDER_TYPE> the concrete builder sub-type, returned by fluent setters to enable type-safe chaining
  * @param <CONFIG_TYPE>  the {@link GpioConfig} type produced by this builder
  */
-public interface GpioConfigBuilder<BUILDER_TYPE extends GpioConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>, CONFIG_TYPE extends GpioConfig>
+public interface GpioConfigBuilder<
+    BUILDER_TYPE extends GpioConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>,
+    CONFIG_TYPE extends GpioConfig
+    >
     extends IOBcmConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalConfigBuilder.java
@@ -9,7 +9,10 @@ import com.pi4j.io.gpio.GpioConfigBuilder;
  * @param <BUILDER_TYPE> the concrete builder type, used as the self-referencing return type for chaining
  * @param <CONFIG_TYPE> the {@link DigitalConfig} type produced by this builder
  */
-public interface DigitalConfigBuilder<BUILDER_TYPE extends DigitalConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>, CONFIG_TYPE extends DigitalConfig>
+public interface DigitalConfigBuilder<
+    BUILDER_TYPE extends DigitalConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>,
+    CONFIG_TYPE extends DigitalConfig
+    >
     extends GpioConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DigitalConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DigitalConfigBuilderBase.java
@@ -11,7 +11,10 @@ import com.pi4j.io.impl.IOBcmConfigBuilderBase;
  * @param <BUILDER_TYPE>
  * @param <CONFIG_TYPE>
  */
-public abstract class DigitalConfigBuilderBase<BUILDER_TYPE extends DigitalConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>, CONFIG_TYPE extends DigitalConfig>
+public abstract class DigitalConfigBuilderBase<
+    BUILDER_TYPE extends DigitalConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>,
+    CONFIG_TYPE extends DigitalConfig
+    >
     extends IOBcmConfigBuilderBase<BUILDER_TYPE, CONFIG_TYPE>
     implements DigitalConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {
 

--- a/pi4j-core/src/main/java/com/pi4j/io/impl/IOBcmConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/impl/IOBcmConfigBuilderBase.java
@@ -14,7 +14,10 @@ import com.pi4j.provider.Provider;
  * @param <BUILDER_TYPE>
  * @param <CONFIG_TYPE>
  */
-public abstract class IOBcmConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder, CONFIG_TYPE extends Config>
+public abstract class IOBcmConfigBuilderBase<
+    BUILDER_TYPE extends ConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>,
+    CONFIG_TYPE extends Config
+    >
     extends BcmConfigBuilderBase<BUILDER_TYPE, CONFIG_TYPE>
     implements IOConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>,
     BcmConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {
@@ -25,12 +28,14 @@ public abstract class IOBcmConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder,
     protected IOBcmConfigBuilderBase() {
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public BUILDER_TYPE provider(String provider) {
         this.properties.put(IOConfig.PROVIDER_KEY, provider);
         return (BUILDER_TYPE) this;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public BUILDER_TYPE provider(Class<? extends Provider> providerClass) {
         this.properties.put(IOConfig.PROVIDER_KEY, providerClass.getName());

--- a/pi4j-core/src/main/java/com/pi4j/io/impl/IOConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/impl/IOConfigBuilderBase.java
@@ -13,9 +13,12 @@ import com.pi4j.provider.Provider;
  * @param <BUILDER_TYPE>
  * @param <CONFIG_TYPE>
  */
-public abstract class IOConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder, CONFIG_TYPE extends Config>
-        extends ConfigBuilderBase<BUILDER_TYPE, CONFIG_TYPE>
-        implements IOConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>
+public abstract class IOConfigBuilderBase<
+    BUILDER_TYPE extends ConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>,
+    CONFIG_TYPE extends Config
+    >
+    extends ConfigBuilderBase<BUILDER_TYPE, CONFIG_TYPE>
+    implements IOConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>
 {
     /**
      * PRIVATE CONSTRUCTOR
@@ -23,12 +26,14 @@ public abstract class IOConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder, CO
     protected IOConfigBuilderBase(){
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public BUILDER_TYPE provider(String provider){
         this.properties.put(IOConfig.PROVIDER_KEY, provider);
         return (BUILDER_TYPE) this;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public BUILDER_TYPE provider(Class<? extends Provider> providerClass){
         this.properties.put(IOConfig.PROVIDER_KEY, providerClass.getName());

--- a/pi4j-core/src/main/java/com/pi4j/io/impl/IODeviceConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/impl/IODeviceConfigBuilderBase.java
@@ -14,10 +14,12 @@ import com.pi4j.provider.Provider;
  * @param <BUILDER_TYPE>
  * @param <CONFIG_TYPE>
  */
-public abstract class IODeviceConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder, CONFIG_TYPE extends Config>
-        extends DeviceConfigBuilderBase<BUILDER_TYPE, CONFIG_TYPE>
-        implements IOConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>,
-        DeviceConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {
+public abstract class IODeviceConfigBuilderBase<
+    BUILDER_TYPE extends ConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>,
+    CONFIG_TYPE extends Config
+    >
+    extends DeviceConfigBuilderBase<BUILDER_TYPE, CONFIG_TYPE>
+    implements IOConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>, DeviceConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {
 
     /**
      * PRIVATE CONSTRUCTOR
@@ -25,12 +27,14 @@ public abstract class IODeviceConfigBuilderBase<BUILDER_TYPE extends ConfigBuild
     protected IODeviceConfigBuilderBase(){
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public BUILDER_TYPE provider(String provider){
         this.properties.put(IOConfig.PROVIDER_KEY, provider);
         return (BUILDER_TYPE) this;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public BUILDER_TYPE provider(Class<? extends Provider> providerClass){
         this.properties.put(IOConfig.PROVIDER_KEY, providerClass.getName());

--- a/pi4j-core/src/main/java/com/pi4j/io/impl/IOPortConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/impl/IOPortConfigBuilderBase.java
@@ -15,7 +15,10 @@ import com.pi4j.provider.Provider;
  * @param <BUILDER_TYPE>
  * @param <CONFIG_TYPE>
  */
-public abstract class IOPortConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder, CONFIG_TYPE extends Config>
+public abstract class IOPortConfigBuilderBase<
+    BUILDER_TYPE extends ConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>,
+    CONFIG_TYPE extends Config
+    >
     extends PortConfigBuilderBase<BUILDER_TYPE, CONFIG_TYPE>
     implements IOConfigBuilder<BUILDER_TYPE, CONFIG_TYPE>,
     PortConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {
@@ -27,12 +30,14 @@ public abstract class IOPortConfigBuilderBase<BUILDER_TYPE extends ConfigBuilder
         super(context);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public BUILDER_TYPE provider(String provider) {
         this.properties.put(IOConfig.PROVIDER_KEY, provider);
         return (BUILDER_TYPE) this;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public BUILDER_TYPE provider(Class<? extends Provider> providerClass) {
         this.properties.put(IOConfig.PROVIDER_KEY, providerClass.getName());


### PR DESCRIPTION
This PR takes advantage of #711 to clarify the generic type arguments used on builder types.

Functionally, this doesn't change anything. As with anything generics-related, it's largely cosmetic, but it does stop and IDE's linter from warning about unparameterised type declarations.

This does emphasise the complexity that can that is perceived to exist in the builder hierarchy 