### PR TITLE
remove re-declaration of bcm operations

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/config/BcmConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/BcmConfigBuilder.java
@@ -16,8 +16,9 @@ public interface BcmConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> extends ConfigBuild
      * @deprecated use {@link #bcm(Integer)} instead.
      */
     @Deprecated(forRemoval = true)
-    BUILDER_TYPE address(Integer address);
-
+    default BUILDER_TYPE address(Integer address) {
+        return bcm(address);
+    }
     /**
      * Sets the Broadcom (BCM) GPIO pin number this I/O is bound to.
      *

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalConfigBuilder.java
@@ -13,26 +13,6 @@ public interface DigitalConfigBuilder<BUILDER_TYPE extends DigitalConfigBuilder<
     extends GpioConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {
 
     /**
-     * Sets the BCM (Broadcom) GPIO pin number for the configuration being built.
-     *
-     * @param address the BCM pin number
-     * @return this builder for method chaining
-     * @deprecated use {@link #bcm(Integer)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default BUILDER_TYPE address(Integer address) {
-        return bcm(address);
-    }
-
-    /**
-     * Sets the BCM (Broadcom) GPIO pin number for the configuration being built.
-     *
-     * @param bcm the BCM pin number to bind the digital I/O instance to
-     * @return this builder for method chaining
-     */
-    BUILDER_TYPE bcm(Integer bcm);
-
-    /**
      * Sets the {@link DigitalState} to be treated as the logical "on" state for the configuration being built.
      *
      * @param state the state that should map to "on"


### PR DESCRIPTION
This PR removes re-declarations of methods already defined in `BcmConfigBuilder`.