### PR TITLE
fix: correct SPI IOType enum entry

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/IOType.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IOType.java
@@ -3,6 +3,7 @@ package com.pi4j.io;
 import com.pi4j.context.Context;
 import com.pi4j.exception.Pi4JException;
 import com.pi4j.io.gpio.digital.*;
+import com.pi4j.io.i2c.I2C;
 import com.pi4j.io.i2c.I2CConfig;
 import com.pi4j.io.i2c.I2CConfigBuilder;
 import com.pi4j.io.i2c.I2CProvider;
@@ -11,6 +12,8 @@ import com.pi4j.io.pwm.PwmConfig;
 import com.pi4j.io.pwm.PwmConfigBuilder;
 import com.pi4j.io.pwm.PwmProvider;
 import com.pi4j.io.spi.Spi;
+import com.pi4j.io.spi.SpiConfig;
+import com.pi4j.io.spi.SpiConfigBuilder;
 import com.pi4j.io.spi.SpiProvider;
 import com.pi4j.provider.Provider;
 
@@ -33,9 +36,9 @@ public enum IOType {
     /** Pulse-width modulation output. */
     PWM(PwmProvider.class, Pwm.class, PwmConfig.class, PwmConfigBuilder.class),
     /** I2C (Inter-Integrated Circuit) bus device. */
-    I2C(I2CProvider.class, com.pi4j.io.i2c.I2C.class, I2CConfig.class, I2CConfigBuilder.class),
+    I2C(I2CProvider.class, I2C.class, I2CConfig.class, I2CConfigBuilder.class),
     /** SPI (Serial Peripheral Interface) bus device. */
-    SPI(SpiProvider.class, Spi.class, I2CConfig.class, I2CConfigBuilder.class);
+    SPI(SpiProvider.class, Spi.class, SpiConfig.class, SpiConfigBuilder.class);
 
     private Class<? extends Provider> providerClass;
     private Class<? extends IO> ioClass;


### PR DESCRIPTION
`SPI` incorrectly specified i2c config and config builder types.

This would have caused obvious problems if it was ever used. 

It would be invoked by `Provider.create(String)`. So It might be fair to assume that this function is never used and can be removed. (Also, it doesn't seem to make sense to create a device with only and id and no configuration)

https://github.com/Pi4J/pi4j/blob/2fdff679ee9579c8103d2b30d22b88c4022b7e21/pi4j-core/src/main/java/com/pi4j/provider/Provider.java#L96-L104

invokes:

https://github.com/Pi4J/pi4j/blob/77be80407483c5ad9a7680750fa31fe6bdc108f9/pi4j-core/src/main/java/com/pi4j/io/IOType.java#L103-L110

In the latter, I'd question why runtime reflection is required and suggest code-smell. It's probably doesn't participate in any canonical construction workflow and should also be removed

#704 