### PR TITLE
call super after custom shutdownInternal implementation in PwmBase

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmBase.java
@@ -131,6 +131,6 @@ public abstract class PwmBase extends IOBase<Pwm, PwmConfig, PwmProvider> implem
                 throw new ShutdownException(e);
             }
         }
-        return this;
+        return super.shutdownInternal(context);
     }
 }


### PR DESCRIPTION
Unless there an undocumented reason not to, `PwmBase.shutdownInternal()` should call the super method to be consistent with other devices.