### PR TITLE
call super after custom shutdownInternal implementation in I2CBase

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBase.java
@@ -1,7 +1,5 @@
 package com.pi4j.io.i2c;
 
-import com.pi4j.context.Context;
-import com.pi4j.exception.ShutdownException;
 import com.pi4j.io.IOBase;
 import com.pi4j.io.i2c.impl.DefaultI2CRegister;
 
@@ -55,18 +53,5 @@ public abstract class I2CBase<T extends I2CBus> extends IOBase<I2C, I2CConfig, I
         if (action == null)
             throw new NullPointerException("Parameter 'action' is mandatory!");
         return this.i2CBus.execute(this, action);
-    }
-
-    @Override
-    public I2C shutdownInternal(Context context) throws ShutdownException {
-        // if this I2C device is still open, then we need to close it since we are shutting down
-        if (this.isOpen()) {
-            try {
-                close();
-            } catch (Exception e) {
-                throw new ShutdownException(e);
-            }
-        }
-        return this;
     }
 }

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBase.java
@@ -1,5 +1,7 @@
 package com.pi4j.io.i2c;
 
+import com.pi4j.context.Context;
+import com.pi4j.exception.ShutdownException;
 import com.pi4j.io.IOBase;
 import com.pi4j.io.i2c.impl.DefaultI2CRegister;
 
@@ -53,5 +55,18 @@ public abstract class I2CBase<T extends I2CBus> extends IOBase<I2C, I2CConfig, I
         if (action == null)
             throw new NullPointerException("Parameter 'action' is mandatory!");
         return this.i2CBus.execute(this, action);
+    }
+
+    @Override
+    public I2C shutdownInternal(Context context) throws ShutdownException {
+        // if this I2C device is still open, then we need to close it since we are shutting down
+        if (this.isOpen()) {
+            try {
+                close();
+            } catch (Exception e) {
+                throw new ShutdownException(e);
+            }
+        }
+        return super.shutdownInternal(context);
     }
 }


### PR DESCRIPTION
Calling `close()` from `shutdownInternal()` doesn't seem right. `close()` eventually invokes `shutdown(id)` which in turn calls `shutdownInternal()`. This is possibly unnecessary complexity. If such logic is required, it could suggest a more fundamental problem.

This change makes `I2CBase` behaviour more consistent with other devices and also allows the base class method to be invoked.