### PR TITLE
remove calls to deprecated factory methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For example, for a minimal example to blink a LED ([fully explained here](https:
 ```java
 var pi4j = Pi4J.newAutoContext();
 
-var led = pi4j.digitalOutput().create(PIN_LED);
+var led = pi4j.create(PIN_LED);
 
 while (true) {
   if (led.state() == DigitalState.HIGH) {

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalOutputBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalOutputBuilder.java
@@ -95,6 +95,6 @@ public class DefaultDigitalOutputBuilder implements DigitalOutputBuilder {
         }
 
         // use default digital output provider
-        return context.dout().create(config);
+        return context.create(config);
     }
 }

--- a/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalInputOffTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalInputOffTest.java
@@ -49,7 +49,7 @@ public class DigitalInputOffTest {
             .build();
 
         // create GPIO digital input instance
-        var input = pi4j.din().create(config);
+        var input = pi4j.create(config);
 
         // set MOCK state to LOW
         MockDigitalInput mockInput = (MockDigitalInput) input;
@@ -72,7 +72,7 @@ public class DigitalInputOffTest {
             .build();
 
         // create GPIO digital input instance
-        var input = pi4j.din().create(config);
+        var input = pi4j.create(config);
 
         // set MOCK state to LOW
         MockDigitalInput mockInput = (MockDigitalInput) input;
@@ -95,7 +95,7 @@ public class DigitalInputOffTest {
             .build();
 
         // create GPIO digital input instance
-        var input = pi4j.din().create(config);
+        var input = pi4j.create(config);
 
         // set MOCK state to HIGH
         MockDigitalInput mockInput = (MockDigitalInput) input;

--- a/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalInputOnTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalInputOnTest.java
@@ -49,7 +49,7 @@ public class DigitalInputOnTest {
             .build();
 
         // create GPIO digital input instance
-        var input = pi4j.din().create(config);
+        var input = pi4j.create(config);
 
         // set MOCK state to HIGH
         MockDigitalInput mockInput = (MockDigitalInput) input;
@@ -72,7 +72,7 @@ public class DigitalInputOnTest {
             .build();
 
         // create GPIO digital input instance
-        var input = pi4j.din().create(config);
+        var input = pi4j.create(config);
 
         // set MOCK state to HIGH
         MockDigitalInput mockInput = (MockDigitalInput) input;
@@ -95,7 +95,7 @@ public class DigitalInputOnTest {
             .build();
 
         // create GPIO digital input instance
-        var input = pi4j.din().create(config);
+        var input = pi4j.create(config);
 
         // set MOCK state to LOW
         MockDigitalInput mockInput = (MockDigitalInput) input;

--- a/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalOutputOffTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalOutputOffTest.java
@@ -47,7 +47,7 @@ public class DigitalOutputOffTest {
             .build();
 
         // create GPIO digital output instance
-        var output = pi4j.dout().create(config);
+        var output = pi4j.create(config);
 
         // set output to LOW
         output.low();
@@ -72,7 +72,7 @@ public class DigitalOutputOffTest {
             .build();
 
         // create GPIO digital output instance
-        var output = pi4j.dout().create(config);
+        var output = pi4j.create(config);
 
         // set output to LOW
         output.low();
@@ -97,7 +97,7 @@ public class DigitalOutputOffTest {
             .build();
 
         // create GPIO digital output instance
-        var output = pi4j.dout().create(config);
+        var output = pi4j.create(config);
 
         // set output to HIGH
         output.high();
@@ -121,7 +121,7 @@ public class DigitalOutputOffTest {
             .build();
 
         // create GPIO digital output instance
-        var output = pi4j.dout().create(config);
+        var output = pi4j.create(config);
 
         // set output to OFF
         output.off();
@@ -146,7 +146,7 @@ public class DigitalOutputOffTest {
             .build();
 
         // create GPIO digital output instance
-        var output = pi4j.dout().create(config);
+        var output = pi4j.create(config);
 
         // set output to OFF
         output.off();
@@ -171,7 +171,7 @@ public class DigitalOutputOffTest {
             .build();
 
         // create GPIO digital output instance
-        var output = pi4j.dout().create(config);
+        var output = pi4j.create(config);
 
         // set output to OFF
         output.off();

--- a/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalOutputOnTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalOutputOnTest.java
@@ -47,7 +47,7 @@ public class DigitalOutputOnTest {
             .build();
 
         // create GPIO digital output instance
-        var output = pi4j.dout().create(config);
+        var output = pi4j.create(config);
 
         // set output to HIGH
         output.high();
@@ -72,7 +72,7 @@ public class DigitalOutputOnTest {
             .build();
 
         // create GPIO digital output instance
-        var output = pi4j.dout().create(config);
+        var output = pi4j.create(config);
 
         // set output to HIGH
         output.high();
@@ -97,7 +97,7 @@ public class DigitalOutputOnTest {
             .build();
 
         // create GPIO digital output instance
-        var output = pi4j.dout().create(config);
+        var output = pi4j.create(config);
 
         // set output to LOW
         output.low();
@@ -121,7 +121,7 @@ public class DigitalOutputOnTest {
             .build();
 
         // create GPIO digital output instance
-        var output = pi4j.dout().create(config);
+        var output = pi4j.create(config);
 
         // set output to ON
         output.on();
@@ -146,7 +146,7 @@ public class DigitalOutputOnTest {
             .build();
 
         // create GPIO digital output instance
-        var output = pi4j.dout().create(config);
+        var output = pi4j.create(config);
 
         // set output to ON
         output.on();
@@ -171,7 +171,7 @@ public class DigitalOutputOnTest {
             .build();
 
         // create GPIO digital output instance
-        var output = pi4j.dout().create(config);
+        var output = pi4j.create(config);
 
         // set output to ON
         output.on();

--- a/pi4j-test/src/test/java/com/pi4j/test/io/i2c/I2CRawDataTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/i2c/I2CRawDataTest.java
@@ -65,7 +65,7 @@ public class I2CRawDataTest {
                 .build();
 
         // use try-with-resources to auto-close I2C when complete
-        try (var i2c = pi4j.i2c().create(config)) {
+        try (var i2c = pi4j.create(config)) {
 
             // ensure that the I2C instance is not null;
             assertNotNull(i2c);
@@ -118,7 +118,7 @@ public class I2CRawDataTest {
                 .build();
 
         // use try-with-resources to auto-close I2C when complete
-        try (var i2c = pi4j.i2c().create(config)) {
+        try (var i2c = pi4j.create(config)) {
 
             // write sample data using output stream
             i2c.out().write(sample);

--- a/pi4j-test/src/test/java/com/pi4j/test/io/i2c/I2CRegisterDataTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/i2c/I2CRegisterDataTest.java
@@ -103,7 +103,7 @@ public class I2CRegisterDataTest {
             .build();
 
         // use try-with-resources to auto-close I2C when complete
-        try (var i2c = pi4j.i2c().create(config)) {
+        try (var i2c = pi4j.create(config)) {
 
             // ensure that the I2C instance is not null;
             assertNotNull(i2c);

--- a/pi4j-test/src/test/java/com/pi4j/test/io/spi/SpiRawDataTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/spi/SpiRawDataTest.java
@@ -64,7 +64,7 @@ public class SpiRawDataTest {
             .build();
 
         // use try-with-resources to auto-close SPI when complete
-        try (var spi = pi4j.spi().create(config)) {
+        try (var spi = pi4j.create(config)) {
 
             // ensure that the SPI instance is not null;
             assertNotNull(spi);
@@ -118,7 +118,7 @@ public class SpiRawDataTest {
             .build();
 
         // use try-with-resources to auto-close SPI when complete
-        try (var spi = pi4j.spi().create(config)) {
+        try (var spi = pi4j.create(config)) {
 
             // write sample data using output stream
             spi.out().write(sample);

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/integration/GPIOTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/integration/GPIOTest.java
@@ -53,7 +53,7 @@ public class GPIOTest extends BaseSetup {
 
     @Test
     public void testInputUnavailable() {
-        assertThrows(Pi4JException.class, () -> pi4j1.digitalInput().create(
+        assertThrows(Pi4JException.class, () -> pi4j1.create(
             DigitalInputConfigBuilder.newInstance()
                 .bus(98)
                 .bcm(99)
@@ -63,7 +63,7 @@ public class GPIOTest extends BaseSetup {
 
     @Test
     public void testInputNonExistent() {
-        assertThrows(Pi4JException.class, () -> pi4jNonExistent.digitalInput().create(
+        assertThrows(Pi4JException.class, () -> pi4jNonExistent.create(
             DigitalInputConfigBuilder.newInstance()
                 .bus(99)
                 .bcm(0)
@@ -73,7 +73,7 @@ public class GPIOTest extends BaseSetup {
 
     @Test
     public void testInputCreate() {
-        var input = pi4j0.digitalInput().create(
+        var input = pi4j0.create(
             DigitalInputConfigBuilder.newInstance()
                 .bus(97)
                 .bcm(0)
@@ -84,7 +84,7 @@ public class GPIOTest extends BaseSetup {
 
     @Test
     public void testInputState() {
-        var input = pi4j0.digitalInput().create(
+        var input = pi4j0.create(
             DigitalInputConfigBuilder.newInstance()
                 .bus(97)
                 .bcm(1)
@@ -95,7 +95,7 @@ public class GPIOTest extends BaseSetup {
 
     @Test
     public void testInputIsOccupied() {
-        assertThrows(IllegalStateException.class, () -> pi4j0.digitalInput().create(
+        assertThrows(IllegalStateException.class, () -> pi4j0.create(
             DigitalInputConfigBuilder.newInstance()
                 .bus(97)
                 .bcm(2)
@@ -111,7 +111,7 @@ public class GPIOTest extends BaseSetup {
             .debounce(99L, TimeUnit.MICROSECONDS)
             .pull(PullResistance.PULL_DOWN)
             .build();
-        var input = pi4j0.digitalInput().create(config);
+        var input = pi4j0.create(config);
         assertEquals(99, input.config().debounce());
         assertEquals(3, input.bcm());
         assertEquals(PullResistance.PULL_DOWN, input.pull());
@@ -119,7 +119,7 @@ public class GPIOTest extends BaseSetup {
 
     @Test
     public void testOutputCreate() {
-        var output = pi4j0.digitalOutput().create(
+        var output = pi4j0.create(
             DigitalOutputConfigBuilder.newInstance()
                 .bus(97)
                 .bcm(4)
@@ -130,7 +130,7 @@ public class GPIOTest extends BaseSetup {
 
     @Test
     public void testOutputChangeState() {
-        var pin = pi4j0.digitalOutput().create(
+        var pin = pi4j0.create(
             DigitalOutputConfigBuilder.newInstance()
                 .bus(97)
                 .bcm(5)
@@ -149,7 +149,7 @@ public class GPIOTest extends BaseSetup {
             .bcm(6)
             .initial(DigitalState.HIGH)
             .build();
-        var output = pi4j0.digitalOutput().create(config);
+        var output = pi4j0.create(config);
         assertEquals(DigitalState.HIGH, output.config().initialState());
         assertEquals(6, output.bcm());
     }
@@ -166,7 +166,7 @@ public class GPIOTest extends BaseSetup {
             .bcm(7)
             .initial(DigitalState.HIGH)
             .build();
-        var output = pi4j0.digitalOutput().create(config);
+        var output = pi4j0.create(config);
         assertEquals(7, output.bcm());
         assertEquals(DigitalState.HIGH, output.config().initialState());
         assertEquals(DigitalState.HIGH, output.state());

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/integration/PwmTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/integration/PwmTest.java
@@ -34,7 +34,7 @@ public class PwmTest extends BaseSetup {
         pi4j = Pi4J.newContextBuilder()
             .add(new FFMPwmProviderImpl())
             .build();
-        pwm = pi4j.pwm().create(PwmConfigBuilder.newInstance(pi4j)
+        pwm = pi4j.create(PwmConfigBuilder.newInstance(pi4j)
             .pwmType(PwmType.HARDWARE)
             .chip(findMockPwmChip())
             .channel(0)

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/integration/SPITest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/integration/SPITest.java
@@ -39,7 +39,7 @@ public class SPITest extends BaseSetup {
             .mode(0)
             .baud(50_000)
             .build();
-        spi = pi4j.spi().create(config);
+        spi = pi4j.create(config);
     }
 
     @AfterAll

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/unit/GPIOTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/unit/GPIOTest.java
@@ -83,7 +83,7 @@ public class GPIOTest {
 
             var builder = DigitalInputConfigBuilder.newInstance().bus(-1)
                 .bcm(99).build();
-            assertThrows(IllegalStateException.class, () -> pi4j1.digitalInput().create(builder));
+            assertThrows(IllegalStateException.class, () -> pi4j1.create(builder));
         }
     }
 
@@ -97,7 +97,7 @@ public class GPIOTest {
 
             var builder = DigitalInputConfigBuilder.newInstance().bus(-1)
                 .bcm(0).build();
-            assertThrows(IllegalStateException.class, () -> pi4jNonExistent.digitalInput().create(builder));
+            assertThrows(IllegalStateException.class, () -> pi4jNonExistent.create(builder));
         }
     }
 
@@ -115,7 +115,7 @@ public class GPIOTest {
 
             var builder = DigitalInputConfigBuilder.newInstance().bus(-1)
                 .bcm(0).build();
-            var pin = pi4j0.digitalInput().create(builder);
+            var pin = pi4j0.create(builder);
             assertEquals(0, pin.bcm());
         }
     }
@@ -134,7 +134,7 @@ public class GPIOTest {
 
             var builder = DigitalInputConfigBuilder.newInstance().bus(-1)
                 .bcm(1).build();
-            var pin = pi4j0.digitalInput().create(builder);
+            var pin = pi4j0.create(builder);
             assertEquals(DigitalState.LOW, pin.state());
         }
     }
@@ -178,7 +178,7 @@ public class GPIOTest {
                 .bcm(7)
                 .debounce(0L)
                 .build();
-            var pin = pi4j0.digitalInput().create(builder);
+            var pin = pi4j0.create(builder);
             assertEquals(DigitalState.LOW, pin.state());
             var passed = new AtomicBoolean(false);
             pin.addListener(event -> {
@@ -235,7 +235,7 @@ public class GPIOTest {
                 .bcm(17)
                 .debounce(0L)
                 .build();
-            var pin = pi4j0.digitalInput().create(builder);
+            var pin = pi4j0.create(builder);
             assertEquals(DigitalState.LOW, pin.state());
             var passed = new AtomicBoolean(false);
             pin.addListener(event -> {
@@ -294,7 +294,7 @@ public class GPIOTest {
                 .bcm(8)
                 .debounce(50L) // 50ms debounce
                 .build();
-            var pin = pi4j0.digitalInput().create(builder);
+            var pin = pi4j0.create(builder);
             assertEquals(DigitalState.LOW, pin.state());
             var passed = new AtomicBoolean(false);
             pin.addListener(event -> {
@@ -321,7 +321,7 @@ public class GPIOTest {
 
             var builder = DigitalInputConfigBuilder.newInstance().bus(-1)
                 .bcm(2).build();
-            assertThrows(IllegalStateException.class, () -> pi4j0.digitalInput().create(builder));
+            assertThrows(IllegalStateException.class, () -> pi4j0.create(builder));
         }
     }
 
@@ -343,7 +343,7 @@ public class GPIOTest {
                 .debounce(99L, TimeUnit.MICROSECONDS)
                 .pull(PullResistance.PULL_DOWN)
                 .build();
-            var pin = pi4j0.digitalInput().create(config);
+            var pin = pi4j0.create(config);
             assertEquals(99, pin.config().debounce());
             assertEquals(3, pin.bcm());
             assertEquals(PullResistance.PULL_DOWN, pin.pull());
@@ -366,7 +366,7 @@ public class GPIOTest {
                 .bus(-1)
                 .bcm(4)
                 .build();
-            var pin = pi4j0.digitalOutput().create(builder);
+            var pin = pi4j0.create(builder);
             assertEquals(4, pin.bcm());
         }
     }
@@ -387,7 +387,7 @@ public class GPIOTest {
                 .bus(-1)
                 .bcm(5)
                 .build();
-            var pin = pi4j0.digitalOutput().create(builder);
+            var pin = pi4j0.create(builder);
             pin.state(DigitalState.HIGH);
             assertEquals(DigitalState.HIGH, pin.state());
             pin.state(DigitalState.LOW);
@@ -419,7 +419,7 @@ public class GPIOTest {
                 .bcm(9)
                 .initial(DigitalState.HIGH)
                 .build();
-            var pin = pi4j0.digitalOutput().create(builder);
+            var pin = pi4j0.create(builder);
 
             assertEquals(DigitalState.HIGH, pin.state());
 
@@ -459,7 +459,7 @@ public class GPIOTest {
                 .bcm(10)
                 .initial(DigitalState.LOW)
                 .build();
-            var pin = pi4j0.digitalOutput().create(builder);
+            var pin = pi4j0.create(builder);
 
             assertEquals(DigitalState.LOW, pin.state());
 
@@ -497,7 +497,7 @@ public class GPIOTest {
                 .bus(-1)
                 .bcm(11)
                 .build();
-            pi4j0.digitalOutput().create(builder);
+            pi4j0.create(builder);
 
             var request = capturedRequest.get();
             assertNotNull(request, "LineRequest was not sent to the kernel");
@@ -610,7 +610,7 @@ public class GPIOTest {
                     .bcm(20 + i)
                     .debounce(0L)
                     .build();
-                var pin = pi4j0.digitalInput().create(builder);
+                var pin = pi4j0.create(builder);
                 final int pinIndex = i;
                 pin.addListener(event -> {
                     if (event.state() == DigitalState.HIGH && pinReceivedEvent[pinIndex].compareAndSet(false, true)) {

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/unit/I2CTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/unit/I2CTest.java
@@ -56,9 +56,9 @@ public class I2CTest {
             | I2CFunctionality.I2C_FUNC_SMBUS_WORD_DATA.getValue();
         try (var _ = FileDescriptorNativeMock.setup(I2C_FILE); var _ = IoctlNativeMock.i2c(functionalities);
              var _ = SMBusNativeMock.setup();
-             var smbus = pi4j.i2c().create(I2CConfigBuilder.newInstance().bus(1).device(0x1C).i2cImplementation(I2CImplementation.SMBUS));
-             var direct = pi4j.i2c().create(I2CConfigBuilder.newInstance().bus(2).device(0x1C).i2cImplementation(I2CImplementation.DIRECT));
-             var file = pi4j.i2c().create(I2CConfigBuilder.newInstance().bus(3).device(0x1C).i2cImplementation(I2CImplementation.FILE))) {
+             var smbus = pi4j.create(I2CConfigBuilder.newInstance().bus(1).device(0x1C).i2cImplementation(I2CImplementation.SMBUS));
+             var direct = pi4j.create(I2CConfigBuilder.newInstance().bus(2).device(0x1C).i2cImplementation(I2CImplementation.DIRECT));
+             var file = pi4j.create(I2CConfigBuilder.newInstance().bus(3).device(0x1C).i2cImplementation(I2CImplementation.FILE))) {
 
             assertInstanceOf(I2CSMBus.class, smbus);
             assertEquals(1, smbus.bus());
@@ -81,7 +81,7 @@ public class I2CTest {
         try (var _ = FileDescriptorNativeMock.setup(I2C_FILE);
              var _ = IoctlNativeMock.i2c(functionalities);
              var _ = SMBusNativeMock.setup();
-             var smbus = pi4j.i2c().create(I2CConfigBuilder.newInstance().bus(4).device(0x1C).i2cImplementation(I2CImplementation.SMBUS))) {
+             var smbus = pi4j.create(I2CConfigBuilder.newInstance().bus(4).device(0x1C).i2cImplementation(I2CImplementation.SMBUS))) {
 
             var result = smbus.write((byte) 0x1C);
             assertEquals(1, result);
@@ -108,7 +108,7 @@ public class I2CTest {
         try (var _ = FileDescriptorNativeMock.setup(I2C_FILE);
              var _ = IoctlNativeMock.i2c(functionalities);
              var _ = SMBusNativeMock.setup();
-             var smbus = pi4j.i2c().create(I2CConfigBuilder.newInstance().bus(5).device(0x1C).i2cImplementation(I2CImplementation.SMBUS))) {
+             var smbus = pi4j.create(I2CConfigBuilder.newInstance().bus(5).device(0x1C).i2cImplementation(I2CImplementation.SMBUS))) {
 
             var result = smbus.readByte();
             assertEquals((byte) 0xff, result);
@@ -141,7 +141,7 @@ public class I2CTest {
         var i2cData = new IoctlNativeMock.IoctlTestData(RDWRData.class, (answer) -> answer.<RDWRData>getArgument(2));
         try (var _ = FileDescriptorNativeMock.setup(I2C_FILE);
              var _ = IoctlNativeMock.i2c(functionalities, i2cData);
-             var direct = pi4j.i2c().create(I2CConfigBuilder.newInstance().bus(6).device(0x1C).i2cImplementation(I2CImplementation.DIRECT))) {
+             var direct = pi4j.create(I2CConfigBuilder.newInstance().bus(6).device(0x1C).i2cImplementation(I2CImplementation.DIRECT))) {
 
             var result = direct.write((byte) 0x1C);
             assertEquals(1, result);
@@ -178,7 +178,7 @@ public class I2CTest {
         });
         try (var _ = FileDescriptorNativeMock.setup(I2C_FILE);
              var _ = IoctlNativeMock.i2c(functionalities, i2cData);
-             var direct = pi4j.i2c().create(I2CConfigBuilder.newInstance().bus(7).device(0x1C).i2cImplementation(I2CImplementation.DIRECT))) {
+             var direct = pi4j.create(I2CConfigBuilder.newInstance().bus(7).device(0x1C).i2cImplementation(I2CImplementation.DIRECT))) {
 
             var data = direct.read();
             assertEquals((byte) 0xff, data);
@@ -210,7 +210,7 @@ public class I2CTest {
         var i2cWriteRegister3 = new FileDescriptorNativeMock.FileDescriptorTestData("/dev/null", 1, new byte[]{0x54, 0x65, 0x73, 0x74, 0x54, 0x65, 0x73, 0x74});
         try (var _ = FileDescriptorNativeMock.setup(I2C_FILE, i2cWriteByte, i2cWriteBytes, i2cWriteRegister1, i2cWriteRegister2, i2cWriteRegister3);
              var _ = IoctlNativeMock.i2c(functionalities);
-             var file = pi4j.i2c().create(I2CConfigBuilder.newInstance().bus(8).device(0x1C).i2cImplementation(I2CImplementation.FILE))) {
+             var file = pi4j.create(I2CConfigBuilder.newInstance().bus(8).device(0x1C).i2cImplementation(I2CImplementation.FILE))) {
 
             var result = file.write((byte) 0x1C);
             assertEquals(1, result);
@@ -236,7 +236,7 @@ public class I2CTest {
         var i2cReadBytes = new FileDescriptorNativeMock.FileDescriptorTestData("/dev/null", 1, ("Test").getBytes());
         try (var _ = FileDescriptorNativeMock.setup(I2C_FILE, i2cReadByte, i2cReadBytes);
              var _ = IoctlNativeMock.i2c(functionalities);
-             var file = pi4j.i2c().create(I2CConfigBuilder.newInstance().bus(9).device(0x1C).i2cImplementation(I2CImplementation.FILE))) {
+             var file = pi4j.create(I2CConfigBuilder.newInstance().bus(9).device(0x1C).i2cImplementation(I2CImplementation.FILE))) {
 
             var data = file.read();
             assertEquals(("T").getBytes()[0], data);

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/unit/PWMTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/unit/PWMTest.java
@@ -59,7 +59,7 @@ public class PWMTest {
         var pwmPeriod = new FileDescriptorNativeMock.FileDescriptorTestData("/sys/class/pwm/pwmchip0/pwm0/period", 4, ("1").getBytes());
         try (var _ = FileDescriptorNativeMock.setup(pwmEnable, pwmDutyCycle, pwmPolarity, pwmPeriod)) {
 
-            pi4j.pwm().create(PwmConfigBuilder.newInstance(pi4j)
+            pi4j.create(PwmConfigBuilder.newInstance(pi4j)
                 .pwmType(PwmType.HARDWARE)
                 .chip(0)
                 .channel(0)
@@ -77,7 +77,7 @@ public class PWMTest {
         var pwmPolarity = new FileDescriptorNativeMock.FileDescriptorTestData(path + "/polarity", 3, ("normal").getBytes());
         var pwmPeriod = new FileDescriptorNativeMock.FileDescriptorTestData(path + "/period", 4, ("1").getBytes());
         try (var _ = FileDescriptorNativeMock.setup(pwmEnable, pwmDutyCycle, pwmPolarity, pwmPeriod)) {
-            var pwm = pi4j.pwm().create(PwmConfigBuilder.newInstance(pi4j)
+            var pwm = pi4j.create(PwmConfigBuilder.newInstance(pi4j)
                 .pwmType(PwmType.HARDWARE)
                 .chip(chip)
                 .channel(channel)
@@ -102,7 +102,7 @@ public class PWMTest {
         var pwmPeriod = new FileDescriptorNativeMock.FileDescriptorTestData(path + "/period", 4, ("1").getBytes());
 
         try (var _ = FileDescriptorNativeMock.setup(pwmEnable, pwmDutyCycle, pwmPolarity, pwmPeriod)) {
-            var pwm = pi4j.pwm().create(PwmConfigBuilder.newInstance(pi4j)
+            var pwm = pi4j.create(PwmConfigBuilder.newInstance(pi4j)
                 .pwmType(PwmType.HARDWARE)
                 .chip(chip)
                 .channel(channel)
@@ -140,7 +140,7 @@ public class PWMTest {
         var pwmPeriod = new FileDescriptorNativeMock.FileDescriptorTestData(path + "/period", 4, ("1").getBytes());
 
         try (var construction = FileDescriptorNativeMock.setup(pwmEnable, pwmDutyCycle, pwmPolarity, pwmPeriod)) {
-            var pwm = pi4j.pwm().create(PwmConfigBuilder.newInstance(pi4j)
+            var pwm = pi4j.create(PwmConfigBuilder.newInstance(pi4j)
                 .pwmType(PwmType.HARDWARE)
                 .chip(chip)
                 .channel(channel)
@@ -184,7 +184,7 @@ public class PWMTest {
         var pwmPeriod = new FileDescriptorNativeMock.FileDescriptorTestData(path + "/period", 4, ("1").getBytes());
 
         try (var construction = FileDescriptorNativeMock.setup(pwmEnable, pwmDutyCycle, pwmPolarity, pwmPeriod)) {
-            var pwm = pi4j.pwm().create(PwmConfigBuilder.newInstance(pi4j)
+            var pwm = pi4j.create(PwmConfigBuilder.newInstance(pi4j)
                 .pwmType(PwmType.HARDWARE)
                 .chip(chip)
                 .channel(channel)
@@ -216,7 +216,7 @@ public class PWMTest {
         var pwmPeriod = new FileDescriptorNativeMock.FileDescriptorTestData(path + "/period", 4, ("1").getBytes());
 
         try (var construction = FileDescriptorNativeMock.setup(pwmEnable, pwmDutyCycle, pwmPolarity, pwmPeriod)) {
-            var pwm = pi4j.pwm().create(PwmConfigBuilder.newInstance(pi4j)
+            var pwm = pi4j.create(PwmConfigBuilder.newInstance(pi4j)
                 .pwmType(PwmType.HARDWARE)
                 .chip(chip)
                 .channel(channel)

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/unit/SPITest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/unit/SPITest.java
@@ -51,7 +51,7 @@ public class SPITest {
         try (var _ = FileDescriptorNativeMock.setup();
              var _ = IoctlNativeMock.setup()) {
 
-            pi4j.spi().create(SpiConfigBuilder.newInstance()
+            pi4j.create(SpiConfigBuilder.newInstance()
                 .bus(SpiBus.BUS_0)
                 .channel(0)
                 .mode(0)
@@ -69,7 +69,7 @@ public class SPITest {
         try (var _ = FileDescriptorNativeMock.setup();
              var _ = IoctlNativeMock.setup(spiTestData)) {
 
-            var spi = pi4j.spi().create(SpiConfigBuilder.newInstance()
+            var spi = pi4j.create(SpiConfigBuilder.newInstance()
                 .bus(SpiBus.BUS_0)
                 .channel(1)
                 .mode(0)
@@ -97,7 +97,7 @@ public class SPITest {
         try (var _ = FileDescriptorNativeMock.setup();
              var _ = IoctlNativeMock.setup(spiTestData)) {
 
-            var spi = pi4j.spi().create(SpiConfigBuilder.newInstance()
+            var spi = pi4j.create(SpiConfigBuilder.newInstance()
                 .bus(SpiBus.BUS_0)
                 .channel(2)
                 .mode(0)
@@ -123,7 +123,7 @@ public class SPITest {
         try (var _ = FileDescriptorNativeMock.setup();
              var _ = IoctlNativeMock.setup(spiTestData)) {
 
-            var spi = pi4j.spi().create(SpiConfigBuilder.newInstance()
+            var spi = pi4j.create(SpiConfigBuilder.newInstance()
                 .bus(SpiBus.BUS_0)
                 .channel(3)
                 .mode(0)
@@ -147,7 +147,7 @@ public class SPITest {
         });
         try (var _ = FileDescriptorNativeMock.setup();
              var _ = IoctlNativeMock.setup(spiTestData)) {
-            var spi = pi4j.spi().create(SpiConfigBuilder.newInstance()
+            var spi = pi4j.create(SpiConfigBuilder.newInstance()
                 .bus(SpiBus.BUS_0)
                 .channel(4)
                 .mode(0)
@@ -175,7 +175,7 @@ public class SPITest {
         try (var _ = FileDescriptorNativeMock.setup(bufsiz);
              var _ = IoctlNativeMock.setup(spiTestData)) {
 
-            var spi = pi4j.spi().create(SpiConfigBuilder.newInstance()
+            var spi = pi4j.create(SpiConfigBuilder.newInstance()
                 .bus(SpiBus.BUS_0)
                 .channel(5)
                 .mode(0)
@@ -208,7 +208,7 @@ public class SPITest {
         try (var _ = FileDescriptorNativeMock.setup(bufsiz);
              var _ = IoctlNativeMock.setup(spiTestData)) {
 
-            var spi = pi4j.spi().create(SpiConfigBuilder.newInstance()
+            var spi = pi4j.create(SpiConfigBuilder.newInstance()
                 .bus(SpiBus.BUS_0)
                 .channel(6)
                 .mode(0)
@@ -258,7 +258,7 @@ public class SPITest {
         try (var _ = FileDescriptorNativeMock.setup(bufsiz);
              var _ = IoctlNativeMock.setup(spiTestData)) {
 
-            var spi = pi4j.spi().create(SpiConfigBuilder.newInstance()
+            var spi = pi4j.create(SpiConfigBuilder.newInstance()
                 .bus(SpiBus.BUS_0)
                 .channel(7)
                 .mode(0)

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/jmh/GPIOInputPerformanceTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/jmh/GPIOInputPerformanceTest.java
@@ -34,7 +34,7 @@ public class GPIOInputPerformanceTest extends BaseSetup {
             .debounce(99L, TimeUnit.MICROSECONDS)
             .pull(PullResistance.PULL_DOWN)
             .build();
-        this.pin = pi4j.digitalInput().create(config);
+        this.pin = pi4j.create(config);
     }
 
     @TearDown(Level.Trial)

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/jmh/GPIOOutputPerformanceTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/jmh/GPIOOutputPerformanceTest.java
@@ -33,7 +33,7 @@ public class GPIOOutputPerformanceTest extends BaseSetup {
             .bus(97)
             .bcm(5)
             .build();
-        this.pin = pi4j.digitalOutput().create(config);
+        this.pin = pi4j.create(config);
     }
 
     @TearDown

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/jmh/I2CDirectPerformanceTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/jmh/I2CDirectPerformanceTest.java
@@ -31,7 +31,7 @@ public class I2CDirectPerformanceTest extends BaseSetup {
         this.pi4j = Pi4J.newContextBuilder()
             .add(new FFMI2CProviderImpl())
             .build();
-        this.i2c = pi4j.i2c().create(I2CConfigBuilder.newInstance()
+        this.i2c = pi4j.create(I2CConfigBuilder.newInstance()
             .bus(99)
             .device(0x1C)
             .i2cImplementation(I2CImplementation.DIRECT));

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/jmh/I2CFilePerformanceTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/jmh/I2CFilePerformanceTest.java
@@ -31,7 +31,7 @@ public class I2CFilePerformanceTest extends BaseSetup {
         this.pi4j = Pi4J.newContextBuilder()
             .add(new FFMI2CProviderImpl())
             .build();
-        this.i2c = pi4j.i2c().create(I2CConfigBuilder.newInstance()
+        this.i2c = pi4j.create(I2CConfigBuilder.newInstance()
             .bus(99)
             .device(0x1C)
             .i2cImplementation(I2CImplementation.FILE));

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/jmh/I2CSMBusPerformanceTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/jmh/I2CSMBusPerformanceTest.java
@@ -31,7 +31,7 @@ public class I2CSMBusPerformanceTest extends BaseSetup {
         this.pi4j = Pi4J.newContextBuilder()
             .add(new FFMI2CProviderImpl())
             .build();
-        this.i2c = pi4j.i2c().create(I2CConfigBuilder.newInstance()
+        this.i2c = pi4j.create(I2CConfigBuilder.newInstance()
             .bus(99)
             .device(0x1C)
             .i2cImplementation(I2CImplementation.SMBUS));

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/jmh/PWMPerformanceTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/jmh/PWMPerformanceTest.java
@@ -33,7 +33,7 @@ public class PWMPerformanceTest extends BaseSetup {
             .chip(0)
             .channel(0)
             .build();
-        this.pwm = pi4j.pwm().create(config);
+        this.pwm = pi4j.create(config);
     }
 
     @TearDown

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/jmh/SPIPerformanceTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/jmh/SPIPerformanceTest.java
@@ -38,7 +38,7 @@ public class SPIPerformanceTest extends BaseSetup {
             .mode(0)
             .baud(50_000)
             .build();
-        this.spi = pi4j.spi().create(config);
+        this.spi = pi4j.create(config);
     }
 
     @TearDown

--- a/plugins/pi4j-plugin-mock/src/test/java/com/pi4j/plugin/mock/MockPluginTest.java
+++ b/plugins/pi4j-plugin-mock/src/test/java/com/pi4j/plugin/mock/MockPluginTest.java
@@ -42,7 +42,7 @@ class MockPluginTest {
             .channel(0)
             .build();
 
-        var device = pi4j.pwm().create(config);
+        var device = pi4j.create(config);
         assertNotNull(device);
 
         pi4j.shutdown(device.id());


### PR DESCRIPTION
This PR removes calls to factory methods deprecated in #728

`ProviderProvider` is deprecated. Factory methods it declares are deprecated too