### PR TITLE
register devices during `context.create(config)`

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/context/Context.java
+++ b/pi4j-core/src/main/java/com/pi4j/context/Context.java
@@ -222,14 +222,16 @@ public interface Context extends Describable, IOCreator, ProviderProvider, Initi
     // I/O INSTANCE ACCESSOR/CREATOR METHODS
     // ------------------------------------------------------------------------
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     default <I extends IO<?, ?, ?>> I create(IOConfig config, IOType ioType) {
+        I device = null;
         // create by explicitly configured IO <PROVIDER> from IO config
         String providerId = config.provider();
         if (StringUtil.isNotNullOrEmpty(providerId)) {
             // resolve the provider and use it to create the IO instance
             Provider provider = this.providers().get(providerId, ioType);
-            return (I) provider.create(config);
+            device = (I) provider.create(config);
         }
 
         // get implicitly defined provider (defined by IO type)
@@ -237,7 +239,12 @@ public interface Context extends Describable, IOCreator, ProviderProvider, Initi
         if (ioType != null) {
             // resolve the provider and use it to create the IO instance
             Provider provider = this.provider(ioType);
-            return (I) provider.create(config);
+            device = (I) provider.create(config);
+        }
+
+        if (device != null) {
+            register(device);
+            return device;
         }
 
         // unable to resolve the IO type and thus unable to create I/O instance

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMDigitalInputProviderImpl.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMDigitalInputProviderImpl.java
@@ -1,8 +1,5 @@
 package com.pi4j.plugin.ffm.providers.gpio;
 
-import com.pi4j.context.Context;
-import com.pi4j.exception.InitializeException;
-import com.pi4j.exception.ShutdownException;
 import com.pi4j.io.gpio.digital.DigitalInput;
 import com.pi4j.io.gpio.digital.DigitalInputConfig;
 import com.pi4j.io.gpio.digital.DigitalInputProvider;
@@ -35,23 +32,11 @@ public class FFMDigitalInputProviderImpl extends DigitalInputProviderBase implem
      */
     @Override
     public DigitalInput create(DigitalInputConfig config) {
-        var digitalInput = new FFMDigitalInput(this, config);
-        this.context.register(digitalInput);
-        return digitalInput;
+        return new FFMDigitalInput(this, config);
     }
 
     @Override
     public int getPriority() {
         return 200;
-    }
-
-    @Override
-    public DigitalInputProvider initialize(Context context) throws InitializeException {
-        return super.initialize(context);
-    }
-
-    @Override
-    public DigitalInputProvider shutdownInternal(Context context) throws ShutdownException {
-        return super.shutdownInternal(context);
     }
 }

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMDigitalInputProviderImpl.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMDigitalInputProviderImpl.java
@@ -27,8 +27,7 @@ public class FFMDigitalInputProviderImpl extends DigitalInputProviderBase implem
      * {@inheritDoc}
      * <p>
      * Resolves the GPIO chip name from the {@code gpio.chip.name} context property (defaulting to
-     * {@code "unknown"}), constructs an {@link FFMDigitalInput} for the requested line, and registers
-     * it with the context.
+     * {@code "unknown"}), constructs an {@link FFMDigitalInput} for the requested line.
      */
     @Override
     public DigitalInput create(DigitalInputConfig config) {

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMDigitalOutputProviderImpl.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMDigitalOutputProviderImpl.java
@@ -1,8 +1,5 @@
 package com.pi4j.plugin.ffm.providers.gpio;
 
-import com.pi4j.context.Context;
-import com.pi4j.exception.InitializeException;
-import com.pi4j.exception.ShutdownException;
 import com.pi4j.io.gpio.digital.DigitalOutput;
 import com.pi4j.io.gpio.digital.DigitalOutputConfig;
 import com.pi4j.io.gpio.digital.DigitalOutputProvider;
@@ -36,23 +33,11 @@ public class FFMDigitalOutputProviderImpl extends DigitalOutputProviderBase impl
      */
     @Override
     public DigitalOutput create(DigitalOutputConfig config) {
-        var digitalOutput = new FFMDigitalOutput( this, config);
-        this.context.register(digitalOutput);
-        return digitalOutput;
+        return new FFMDigitalOutput( this, config);
     }
 
     @Override
     public int getPriority() {
         return 200;
-    }
-
-    @Override
-    public DigitalOutputProvider initialize(Context context) throws InitializeException {
-        return super.initialize(context);
-    }
-
-    @Override
-    public DigitalOutputProvider shutdownInternal(Context context) throws ShutdownException {
-        return super.shutdownInternal(context);
     }
 }

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMDigitalOutputProviderImpl.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMDigitalOutputProviderImpl.java
@@ -28,8 +28,7 @@ public class FFMDigitalOutputProviderImpl extends DigitalOutputProviderBase impl
      * {@inheritDoc}
      * <p>
      * Resolves the GPIO chip name from the {@code gpio.chip.name} context property (defaulting to
-     * {@code "unknown"}), constructs an {@link FFMDigitalOutput} for the requested line, and registers
-     * it with the context.
+     * {@code "unknown"}), constructs an {@link FFMDigitalOutput} for the requested line.
      */
     @Override
     public DigitalOutput create(DigitalOutputConfig config) {

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/FFMI2CProviderImpl.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/FFMI2CProviderImpl.java
@@ -70,7 +70,6 @@ public class FFMI2CProviderImpl extends I2CProviderBase implements I2CProvider {
             i2c = new I2CFile(this, config, bus);
         }
 
-        this.context.register(i2c);
         return i2c;
     }
 }

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/FFMI2CProviderImpl.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/FFMI2CProviderImpl.java
@@ -38,8 +38,7 @@ public class FFMI2CProviderImpl extends I2CProviderBase implements I2CProvider {
      * <p>
      * Opens the {@link FFMI2CBus} for the configured bus, then chooses the access implementation: the
      * configured {@link I2CImplementation} is honoured when the adapter actually supports it
-     * (SMBus or direct), otherwise it falls back to the plain file-based implementation. The created
-     * device is registered with the context.
+     * (SMBus or direct), otherwise it falls back to the plain file-based implementation
      */
     @Override
     public I2C create(I2CConfig config) {

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/pwm/FFMPwmProviderImpl.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/pwm/FFMPwmProviderImpl.java
@@ -37,7 +37,7 @@ public class FFMPwmProviderImpl extends PwmProviderBase implements PwmProvider {
      * is ignored (with a warning) because hardware PWM is addressed by chip and channel.
      *
      * @param config the PWM configuration; must specify {@link PwmType#HARDWARE}, a chip and a channel
-     * @return the newly created and registered hardware PWM instance
+     * @return the newly created hardware PWM instance
      * @throws IOException              if the configuration requests a non-hardware PWM type
      * @throws IllegalArgumentException if the chip or channel is missing from the configuration
      */

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/pwm/FFMPwmProviderImpl.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/pwm/FFMPwmProviderImpl.java
@@ -59,8 +59,6 @@ public class FFMPwmProviderImpl extends PwmProviderBase implements PwmProvider {
         }
 
         // create new I/O instance based on I/O config
-        var pwm = new FFMPwmHardware(this, config);
-        this.context.register(pwm);
-        return pwm;
+        return new FFMPwmHardware(this, config);
     }
 }

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/spi/FFMSpiProviderImpl.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/spi/FFMSpiProviderImpl.java
@@ -43,8 +43,6 @@ public class FFMSpiProviderImpl extends SpiProviderBase implements SpiProvider {
     @Override
     public Spi create(SpiConfig config) {
         // create new I/O instance based on I/O config
-        var spi = new FFMSpi(this, config);
-        this.context.register(spi);
-        return spi;
+        return new FFMSpi(this, config);
     }
 }

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/spi/FFMSpiProviderImpl.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/spi/FFMSpiProviderImpl.java
@@ -38,7 +38,7 @@ public class FFMSpiProviderImpl extends SpiProviderBase implements SpiProvider {
      * configuration.
      *
      * @param config the SPI configuration carrying the bus, channel, mode and baud rate
-     * @return the newly created and registered SPI instance
+     * @return the newly created SPI instance
      */
     @Override
     public Spi create(SpiConfig config) {

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/digital/MockDigitalInputProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/digital/MockDigitalInputProviderImpl.java
@@ -33,13 +33,10 @@ public class MockDigitalInputProviderImpl extends DigitalInputProviderBase imple
     /**
      * {@inheritDoc}
      * <p>
-     * Creates a {@link MockDigitalInput} that simulates the pin in memory and registers it
-     * with the Pi4J context.
+     * Creates a {@link MockDigitalInput} that simulates the pin in memory.
      */
     @Override
     public DigitalInput create(DigitalInputConfig config) {
-        MockDigitalInput input = new MockDigitalInput(this, config);
-        this.context.register(input);
-        return input;
+        return new MockDigitalInput(this, config);
     }
 }

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/digital/MockDigitalOutputProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/digital/MockDigitalOutputProviderImpl.java
@@ -33,13 +33,10 @@ public class MockDigitalOutputProviderImpl extends DigitalOutputProviderBase imp
     /**
      * {@inheritDoc}
      * <p>
-     * Creates a {@link MockDigitalOutput} that simulates the pin in memory and registers it
-     * with the Pi4J context.
+     * Creates a {@link MockDigitalOutput} that simulates the pin in memory.
      */
     @Override
     public DigitalOutput create(DigitalOutputConfig config) {
-        MockDigitalOutput output = new MockDigitalOutput(this, config);
-        this.context.register(output);
-        return output;
+        return new MockDigitalOutput(this, config);
     }
 }

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/i2c/MockI2CProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/i2c/MockI2CProviderImpl.java
@@ -31,13 +31,10 @@ public class MockI2CProviderImpl extends I2CProviderBase implements MockI2CProvi
     /**
      * {@inheritDoc}
      * <p>
-     * Creates a new {@link MockI2C} instance that simulates the device in memory and registers
-     * it with the Pi4J context.
+     * Creates a new {@link MockI2C} instance that simulates the device in memory.
      */
     @Override
     public I2C create(I2CConfig config) {
-        MockI2C i2C = new MockI2C(this, config);
-        this.context.register(i2C);
-        return i2C;
+        return new MockI2C(this, config);
     }
 }

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/pwm/MockPwmProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/pwm/MockPwmProviderImpl.java
@@ -32,13 +32,10 @@ public class MockPwmProviderImpl extends PwmProviderBase implements MockPwmProvi
     /**
      * {@inheritDoc}
      * <p>
-     * Creates a new {@link MockPwm} instance that simulates the channel in memory and registers
-     * it with the Pi4J context.
+     * Creates a new {@link MockPwm} instance that simulates the channel in memory.
      */
     @Override
     public Pwm create(PwmConfig config) {
-        MockPwm pwm = new MockPwm(this, config);
-        this.context.register(pwm);
-        return pwm;
+        return new MockPwm(this, config);
     }
 }

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/spi/MockSpiProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/spi/MockSpiProviderImpl.java
@@ -31,13 +31,10 @@ public class MockSpiProviderImpl extends SpiProviderBase implements MockSpiProvi
     /**
      * {@inheritDoc}
      * <p>
-     * Creates a new {@link MockSpi} instance that simulates the SPI device in memory and registers
-     * it with the Pi4J context.
+     * Creates a new {@link MockSpi} instance that simulates the SPI device in memory.
      */
     @Override
     public Spi create(SpiConfig config) {
-        MockSpi spi = new MockSpi(this, config);
-        this.context.register(spi);
-        return spi;
+        return new MockSpi(this, config);
     }
 }


### PR DESCRIPTION
This PR relates to the discussion on canonical construction in #704 and is encouraged by the deprecation of `ProviderProvider` in #728 

It assumes a minimal number of construction paths and centralises functionality that might be expected of the context as a result of constructing via `context.create(config)`. 

* Devices are registered by the context during `create`. The context now owns all the mutation during device construction transaction and is responsible for maintaining its own state.
* Providers are no longer required to the implement boilerplate `context.register(device)`. `Provider.create(...)` is now "pure", with the single responsibility to construct the device.

Based on suggestions [in this comment](https://github.com/Pi4J/pi4j/issues/704#issuecomment-5242513000), it aims to give the two affected execution paths clearer intention.

--- 

I'm tempted to suggest taking this further by removing/deprecating `Context.register(IO)`:

* This PR would mean it's no longer called from anywhere in the main codebase. (we don't need it).
* It would remove some ambiguity around construction responsibilities. Users wouldn't have the option of registering devices outside a "canonical" execution path. 