### PR TITLE
fix: remove remaining calls to deprecated factory methods

### DIFF
--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/integration/I2CDirectTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/integration/I2CDirectTest.java
@@ -29,8 +29,7 @@ public class I2CDirectTest extends BaseSetup {
         pi4j = Pi4J.newContextBuilder()
             .add(new FFMI2CProviderImpl())
             .build();
-        i2c = pi4j.i2c()
-            .create(I2CConfigBuilder.newInstance()
+        i2c = pi4j.create(I2CConfigBuilder.newInstance()
                 .bus(99)
                 .device(0x1C)
                 .i2cImplementation(I2CImplementation.DIRECT));

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/integration/I2CFileTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/integration/I2CFileTest.java
@@ -29,8 +29,7 @@ public class I2CFileTest extends BaseSetup {
         pi4j = Pi4J.newContextBuilder()
             .add(new FFMI2CProviderImpl())
             .build();
-        i2c = pi4j.i2c()
-            .create(I2CConfigBuilder.newInstance()
+        i2c = pi4j.create(I2CConfigBuilder.newInstance()
                 .bus(99)
                 .device(0x1C)
                 .i2cImplementation(I2CImplementation.FILE));

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/integration/I2CSMBusTest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/integration/I2CSMBusTest.java
@@ -31,8 +31,7 @@ public class I2CSMBusTest extends BaseSetup {
         pi4j = Pi4J.newContextBuilder()
             .add(new FFMI2CProviderImpl())
             .build();
-        i2c = pi4j.i2c()
-            .create(I2CConfigBuilder.newInstance()
+        i2c = pi4j.create(I2CConfigBuilder.newInstance()
                 .bus(99)
                 .device(0x1C)
                 .i2cImplementation(I2CImplementation.SMBUS));


### PR DESCRIPTION
This PR removes the remaining calls to deprecated factory methods.

I missed these in #733 as the affected tests don't run on MacOS. These have now been validated on Pi5