### PR TITLE
Make IOBase.close() final

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/IO.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IO.java
@@ -31,6 +31,9 @@ public interface IO<IO_TYPE extends IO, CONFIG_TYPE extends IOConfig, PROVIDER_T
     @Override
     void close();
 
+    /** True if the device hasn't been closed. */
+    boolean isOpen();
+
     /**
      * Returns the configuration this I/O instance was created from.
      *

--- a/pi4j-core/src/main/java/com/pi4j/io/IOBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IOBase.java
@@ -64,7 +64,7 @@ public abstract class IOBase<IO_TYPE extends IO, CONFIG_TYPE extends IOConfig, P
 
     /**
      * Closes the driver by calling this.context().shutdown(this.getId()), which in turn calls
-     * the local shutdown() method here via DefaultRuntimeRegistry.remove().
+     * the local shutdownInternal(context) method here via DefaultRuntimeRegistry.remove().
      * <p>
      * Basically, for Pi4J, this constitutes an idempotent user convenience method for
      * this.context().shutdown(this.getId())
@@ -73,13 +73,17 @@ public abstract class IOBase<IO_TYPE extends IO, CONFIG_TYPE extends IOConfig, P
      * behaviour. Behaviour added here will not be triggered by context.shutdown()
      */
     @Override
-    public void close() {
+    public final void close() {
         // The null check accounts for contextless tests or somehow just closing without initializing
         // The closed check ensures idempotency, as required by the close method contract.
         if (this.context != null && !closed) {
-            this.closed = true;
             this.context.shutdown(getId());
         }
+    }
+
+    @Override
+    public final boolean isOpen() {
+        return !closed;
     }
 
     @Override

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalBase.java
@@ -95,7 +95,7 @@ public abstract class DigitalBase<DIGITAL_TYPE extends Digital<DIGITAL_TYPE, CON
         stateChangeEventManager.clear();
 
         // return this instance
-        return (DIGITAL_TYPE) this;
+        return super.shutdownInternal(context);
     }
 
     @Override

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBase.java
@@ -1,7 +1,5 @@
 package com.pi4j.io.i2c;
 
-import com.pi4j.context.Context;
-import com.pi4j.exception.ShutdownException;
 import com.pi4j.io.IOBase;
 import com.pi4j.io.i2c.impl.DefaultI2CRegister;
 

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBase.java
@@ -16,7 +16,6 @@ import java.util.concurrent.Callable;
  */
 public abstract class I2CBase<T extends I2CBus> extends IOBase<I2C, I2CConfig, I2CProvider> implements I2C {
 
-    protected boolean isOpen;
     protected final T i2CBus;
 
     /**
@@ -28,22 +27,9 @@ public abstract class I2CBase<T extends I2CBus> extends IOBase<I2C, I2CConfig, I
      */
     public I2CBase(I2CProvider provider, I2CConfig config, T i2CBus) {
         super(provider, config);
-        this.isOpen = true;
         this.i2CBus = i2CBus;
     }
 
-    @Override
-    public boolean isOpen() {
-        return this.isOpen;
-    }
-
-    @Override
-    public void close() {
-        if (isOpen) {
-            super.close();
-            this.isOpen = false;
-        }
-    }
 
     @Override
     public I2CRegister getRegister(int address) {
@@ -55,18 +41,5 @@ public abstract class I2CBase<T extends I2CBus> extends IOBase<I2C, I2CConfig, I
         if (action == null)
             throw new NullPointerException("Parameter 'action' is mandatory!");
         return this.i2CBus.execute(this, action);
-    }
-
-    @Override
-    public I2C shutdownInternal(Context context) throws ShutdownException {
-        // if this I2C device is still open, then we need to close it since we are shutting down
-        if (this.isOpen()) {
-            try {
-                close();
-            } catch (Exception e) {
-                throw new ShutdownException(e);
-            }
-        }
-        return this;
     }
 }

--- a/pi4j-core/src/main/java/com/pi4j/io/spi/SpiBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/SpiBase.java
@@ -13,9 +13,6 @@ public abstract class SpiBase extends IOBase<Spi, SpiConfig, SpiProvider> implem
 
     Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    /** Tracks whether this SPI device is currently open; managed by {@link #open()} and {@link #close()}. */
-    protected boolean isOpen = false;
-
     /**
      * Creates a new SPI device instance bound to the given provider and configuration.
      *
@@ -27,19 +24,7 @@ public abstract class SpiBase extends IOBase<Spi, SpiConfig, SpiProvider> implem
     }
 
     @Override
-    public boolean isOpen() {
-        return this.isOpen;
-    }
-
-    @Override
     public void open() {
         logger.trace("invoked 'open()'");
-    }
-
-    @Override
-    public void close() {
-        logger.trace("invoked 'closed()'");
-        super.close();
-        this.isOpen = false;
     }
 }

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/impl/I2CDirect.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/impl/I2CDirect.java
@@ -134,9 +134,10 @@ public class I2CDirect extends I2CBase<FFMI2CBus> {
      * I2C bus file descriptor.
      */
     @Override
-    public void close() {
-        super.close();
+    public I2C shutdownInternal(Context context) {
+        super.shutdownInternal(context);
         i2CBus.close();
+        return this;
     }
 
     @Override

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/impl/I2CFile.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/impl/I2CFile.java
@@ -2,6 +2,7 @@ package com.pi4j.plugin.ffm.providers.i2c.impl;
 
 import com.pi4j.context.Context;
 import com.pi4j.exception.InitializeException;
+import com.pi4j.exception.ShutdownException;
 import com.pi4j.io.i2c.I2C;
 import com.pi4j.io.i2c.I2CBase;
 import com.pi4j.io.i2c.I2CConfig;
@@ -119,8 +120,9 @@ public class I2CFile extends I2CBase<FFMI2CBus> {
     }
 
     @Override
-    public void close() {
-        super.close();
+    public I2C shutdownInternal(Context context) throws ShutdownException {
+        super.shutdownInternal(context);
         i2CBus.close();
+        return this;
     }
 }

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/impl/I2CSMBus.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/impl/I2CSMBus.java
@@ -3,6 +3,7 @@ package com.pi4j.plugin.ffm.providers.i2c.impl;
 import com.pi4j.context.Context;
 import com.pi4j.exception.InitializeException;
 import com.pi4j.exception.Pi4JException;
+import com.pi4j.exception.ShutdownException;
 import com.pi4j.io.i2c.I2C;
 import com.pi4j.io.i2c.I2CBase;
 import com.pi4j.io.i2c.I2CConfig;
@@ -180,8 +181,9 @@ public class I2CSMBus extends I2CBase<FFMI2CBus> {
     }
 
     @Override
-    public void close() {
-        super.close();
+    public I2C shutdownInternal(Context context) throws ShutdownException {
+        super.shutdownInternal(context);
         i2CBus.close();
+        return this;
     }
 }

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/spi/FFMSpi.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/spi/FFMSpi.java
@@ -115,7 +115,6 @@ public class FFMSpi extends SpiBase implements Spi {
         this.bufferSize = readBufferSize();
         logger.debug("{} - SPI transfer chunk size (bufsiz) is {} bytes.", path, bufferSize);
 
-        this.isOpen = true;
         logger.info("{} - SPI Bus configured.", path);
         return this;
     }
@@ -303,7 +302,7 @@ public class FFMSpi extends SpiBase implements Spi {
      * Checks if SPI Bus is closed.
      */
     private void checkClosed() {
-        if (!isOpen) {
+        if (!isOpen()) {
             throw new Pi4JException("SPI bus  '" + path + "' is closed");
         }
     }

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/i2c/MockI2C.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/i2c/MockI2C.java
@@ -1,5 +1,6 @@
 package com.pi4j.plugin.mock.provider.i2c;
 
+import com.pi4j.context.Context;
 import com.pi4j.io.i2c.*;
 import com.pi4j.plugin.mock.Mock;
 import com.pi4j.util.StringUtil;
@@ -57,10 +58,10 @@ public class MockI2C extends I2CBase<MockI2CBus> implements I2C, I2CRegisterData
     }
 
     @Override
-    public void close() {
-        super.close();
+    public I2C shutdownInternal(Context context) {
         logger.debug("[{}::{}] :: CLOSE(BUS={}; DEVICE={})",
             Mock.I2C_PROVIDER_NAME, this.id, config.bus(), config.device());
+        return super.shutdownInternal(context);
     }
 
     // -------------------------------------------------------------------

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/spi/MockSpi.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/spi/MockSpi.java
@@ -1,5 +1,6 @@
 package com.pi4j.plugin.mock.provider.spi;
 
+import com.pi4j.context.Context;
 import com.pi4j.io.spi.Spi;
 import com.pi4j.io.spi.SpiBase;
 import com.pi4j.io.spi.SpiConfig;
@@ -61,9 +62,9 @@ public class MockSpi extends SpiBase implements Spi {
     }
 
     @Override
-    public void close() {
+    public Spi shutdownInternal(Context context) {
         logger.info("{} CLOSE(CHANNEL={}; BAUD={})", logPreamble, config.channel(), config.baud());
-        super.close();
+        return super.shutdownInternal(context);
     }
 
     /**


### PR DESCRIPTION
This forces IOBase to not implement close. Looking up the documentation for close then will point to shutdownInternal 

Clean up the fallout

- Add isOpen to the interface so we don't have it only in I2C where it would need to access the private closed state (widening visibility would make it writeable from elsewhere
- Remove some overrides that were doing nothing or redundant checks
- Move actual code over to shutdownInternal where it was misplaced

Background: #736