### PR TITLE
Fix/support deprecated factory methods

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/context/impl/DefaultContext.java
+++ b/pi4j-core/src/main/java/com/pi4j/context/impl/DefaultContext.java
@@ -351,6 +351,7 @@ public class DefaultContext implements Context {
      * Provide backwards compatibility for deprecated {@link ProviderProvider#digitalInput()}
      */
     @SuppressWarnings("unchecked")
+    @Override
     public <T extends DigitalInputProvider> T digitalInput() {
         return (T) new DigitalInputProviderBase() {
             @Override
@@ -364,6 +365,7 @@ public class DefaultContext implements Context {
      * Provide backwards compatibility for deprecated {@link ProviderProvider#digitalOutput()}
      */
     @SuppressWarnings("unchecked")
+    @Override
     public <T extends DigitalOutputProvider> T digitalOutput() {
         return (T) new DigitalOutputProviderBase() {
             @Override
@@ -377,6 +379,7 @@ public class DefaultContext implements Context {
      * Provide backwards compatibility for deprecated {@link ProviderProvider#pwm()}
      */
     @SuppressWarnings("unchecked")
+    @Override
     public <T extends PwmProvider> T pwm() {
         return (T) new PwmProviderBase() {
             @Override
@@ -390,6 +393,7 @@ public class DefaultContext implements Context {
      * Provide backwards compatibility for deprecated {@link ProviderProvider#i2c()}
      */
     @SuppressWarnings("unchecked")
+    @Override
     public <T extends I2CProvider> T i2c() {
         return (T) new I2CProviderBase() {
             @Override
@@ -403,6 +407,7 @@ public class DefaultContext implements Context {
      * Provide backwards compatibility for deprecated {@link ProviderProvider#spi()}
      */
     @SuppressWarnings("unchecked")
+    @Override
     public <T extends SpiProvider> T spi() {
         return (T) new SpiProviderBase() {
             @Override

--- a/pi4j-core/src/main/java/com/pi4j/context/impl/DefaultContext.java
+++ b/pi4j-core/src/main/java/com/pi4j/context/impl/DefaultContext.java
@@ -11,8 +11,29 @@ import com.pi4j.exception.ShutdownException;
 import com.pi4j.extension.Plugin;
 import com.pi4j.extension.impl.DefaultPluginService;
 import com.pi4j.extension.impl.PluginStore;
+import com.pi4j.internal.ProviderProvider;
 import com.pi4j.io.IO;
 import com.pi4j.io.IOType;
+import com.pi4j.io.gpio.digital.DigitalInput;
+import com.pi4j.io.gpio.digital.DigitalInputConfig;
+import com.pi4j.io.gpio.digital.DigitalInputProvider;
+import com.pi4j.io.gpio.digital.DigitalInputProviderBase;
+import com.pi4j.io.gpio.digital.DigitalOutput;
+import com.pi4j.io.gpio.digital.DigitalOutputConfig;
+import com.pi4j.io.gpio.digital.DigitalOutputProvider;
+import com.pi4j.io.gpio.digital.DigitalOutputProviderBase;
+import com.pi4j.io.i2c.I2C;
+import com.pi4j.io.i2c.I2CConfig;
+import com.pi4j.io.i2c.I2CProvider;
+import com.pi4j.io.i2c.I2CProviderBase;
+import com.pi4j.io.pwm.Pwm;
+import com.pi4j.io.pwm.PwmConfig;
+import com.pi4j.io.pwm.PwmProvider;
+import com.pi4j.io.pwm.PwmProviderBase;
+import com.pi4j.io.spi.Spi;
+import com.pi4j.io.spi.SpiConfig;
+import com.pi4j.io.spi.SpiProvider;
+import com.pi4j.io.spi.SpiProviderBase;
 import com.pi4j.provider.Provider;
 import com.pi4j.provider.Providers;
 import com.pi4j.registry.Registry;
@@ -254,19 +275,19 @@ public class DefaultContext implements Context {
         this.shutdownEventManager.clear();
 
         return this;
-	}
+    }
 
-	@Override
-	public <T extends IO> void shutdown(T instance) {
-		mutableRegistry.shutdown(instance);
-	}
+    @Override
+    public <T extends IO> void shutdown(T instance) {
+        mutableRegistry.shutdown(instance);
+    }
 
-	@Override
-	public <T extends IO> T shutdown(String id) {
+    @Override
+    public <T extends IO> T shutdown(String id) {
         T io = mutableRegistry.get(id);
-		shutdown(io);
+        shutdown(io);
         return io;
-	}
+    }
 
     @Override
     public boolean isShutdown() {
@@ -324,5 +345,70 @@ public class DefaultContext implements Context {
     @Override
     public void register(IO instance) {
         mutableRegistry.register(instance);
+    }
+
+    /**
+     * Provide backwards compatibility for deprecated {@link ProviderProvider#digitalInput()}
+     */
+    @SuppressWarnings("unchecked")
+    public <T extends DigitalInputProvider> T digitalInput() {
+        return (T) new DigitalInputProviderBase() {
+            @Override
+            public DigitalInput create(DigitalInputConfig config) {
+                return DefaultContext.this.create(config);
+            }
+        };
+    }
+
+    /**
+     * Provide backwards compatibility for deprecated {@link ProviderProvider#digitalOutput()}
+     */
+    @SuppressWarnings("unchecked")
+    public <T extends DigitalOutputProvider> T digitalOutput() {
+        return (T) new DigitalOutputProviderBase() {
+            @Override
+            public DigitalOutput create(DigitalOutputConfig config) {
+                return DefaultContext.this.create(config);
+            }
+        };
+    }
+
+    /**
+     * Provide backwards compatibility for deprecated {@link ProviderProvider#pwm()}
+     */
+    @SuppressWarnings("unchecked")
+    public <T extends PwmProvider> T pwm() {
+        return (T) new PwmProviderBase() {
+            @Override
+            public Pwm create(PwmConfig config) {
+                return DefaultContext.this.create(config);
+            }
+        };
+    }
+
+    /**
+     * Provide backwards compatibility for deprecated {@link ProviderProvider#i2c()}
+     */
+    @SuppressWarnings("unchecked")
+    public <T extends I2CProvider> T i2c() {
+        return (T) new I2CProviderBase() {
+            @Override
+            public I2C create(I2CConfig config) {
+                return DefaultContext.this.create(config);
+            }
+        };
+    }
+
+    /**
+     * Provide backwards compatibility for deprecated {@link ProviderProvider#spi()}
+     */
+    @SuppressWarnings("unchecked")
+    public <T extends SpiProvider> T spi() {
+        return (T) new SpiProviderBase() {
+            @Override
+            public Spi create(SpiConfig config) {
+                return DefaultContext.this.create(config);
+            }
+        };
     }
 }

--- a/pi4j-test/src/test/java/com/pi4j/test/context/ContextTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/context/ContextTest.java
@@ -1,10 +1,14 @@
 package com.pi4j.test.context;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import com.pi4j.Pi4J;
 import com.pi4j.context.Context;
 import com.pi4j.exception.Pi4JException;
+import com.pi4j.io.gpio.digital.DigitalInput;
+import com.pi4j.io.gpio.digital.DigitalOutput;
+import com.pi4j.io.i2c.I2C;
+import com.pi4j.io.pwm.Pwm;
+import com.pi4j.io.spi.Spi;
+import com.pi4j.registry.Registry;
 import com.pi4j.test.Slf4jStreamBridge;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -13,6 +17,11 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ContextTest {
@@ -42,4 +51,46 @@ public class ContextTest {
         var ps = Slf4jStreamBridge.createPrintStream(logger);
         pi4j.describe().print(ps);
     }
+
+    @Test
+    void testDeprecatedFactoryMethodSupport() throws Pi4JException {
+        var inputConfig = DigitalInput.newConfigBuilder().id("DIN-3").name("DIN-3").bcm(3);
+        var outputConfig = DigitalOutput.newConfigBuilder().id("DOUT-3").name("DOUT-3").bcm(3);
+        var i2cConfig = I2C.newConfigBuilder().bus(0).device(0x70).build();
+        var pwmConfig = Pwm.newConfigBuilder().id("PWM-3").name("PWM-3").channel(3);
+        var spiConfig = Spi.newConfigBuilder().bus(0).build();
+
+        // create I/O instances via deprecated factory methods
+        var input = pi4j.din().create(inputConfig);
+        var output = pi4j.dout().create(outputConfig);
+        var i2c = pi4j.i2c().create(i2cConfig);
+        var pwm = pi4j.pwm().create(pwmConfig);
+        var spi = pi4j.spi().create(spiConfig);
+
+        Registry registry = pi4j.registry();
+        assertAll(
+            () -> assertTrue(registry.exists(input.id()), "Should exist: Digital Input by ID"),
+            () -> assertTrue(registry.exists(output.id()), "Should exist: Digital Output by ID"),
+            () -> assertTrue(registry.exists(pwm.id()), "Should exist: PWM by ID"),
+            () -> assertTrue(registry.exists(i2c.id()), "Should exist: I2C by ID"),
+            () -> assertTrue(registry.exists(spi.id()), "Should exist: Spi by ID")
+        );
+
+
+        // now shutdown all I/O instances by closing them.
+        input.close();
+        output.close();
+        i2c.close();
+        pwm.close();
+        spi.close();
+
+        assertAll(
+            () -> assertFalse(registry.exists(input.id()), "Should not exist: Digital Input by ID"),
+            () -> assertFalse(registry.exists(output.id()), "Should not exist: Digital Output by ID"),
+            () -> assertFalse(registry.exists(pwm.id()), "Should not exist: PWM by ID"),
+            () -> assertFalse(registry.exists(i2c.id()), "Should not exist: I2C by ID"),
+            () -> assertFalse(registry.exists(spi.id()), "Should not exist: SPI by ID")
+        );
+    }
+
 }


### PR DESCRIPTION
This PR allows deprecated `ProviderProvider` factories in the `DefaultContext` to remain functional after #734 likely caused them to stop working. (as pointed out [here](https://github.com/Pi4J/pi4j/pull/734#issuecomment-5258614740))

When these methods are called on the default context, the method now returns a shim implementation which calls the non-deprecated, favoured method of construction.
