### PR TITLE
chore: update checkstyle to 13.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,7 @@
         <junit.jupiter.version>5.12.1</junit.jupiter.version>
         <slf4j.version>2.0.17</slf4j.version>
         <jna.version>5.15.0</jna.version>
+        <checkstyle.version>13.10.0</checkstyle.version>
 
         <!-- PLUGIN VERSIONS -->
         <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
@@ -664,6 +665,19 @@
                     <version>3.5.0</version>
                 </plugin>
 
+                <!-- CHECKSTYLE PLUGIN -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>${maven-checkstyle-plugin.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <version>${checkstyle.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
Updates the Checkstyle version used by the plugin. 

The default version is 9.6 from 2022 and does not support newer Java syntax. 

Implemented as per https://maven.apache.org/plugins/maven-checkstyle-plugin/examples/upgrading-checkstyle.html

