### PR TITLE
Feat/add port interfaces

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/internal/IOCreator.java
+++ b/pi4j-core/src/main/java/com/pi4j/internal/IOCreator.java
@@ -5,6 +5,9 @@ import com.pi4j.io.IOConfig;
 import com.pi4j.io.IOConfigBuilder;
 import com.pi4j.io.IOType;
 import com.pi4j.io.gpio.digital.*;
+import com.pi4j.io.gpio.parallel.ParallelPort;
+import com.pi4j.io.gpio.parallel.ParallelPortConfig;
+import com.pi4j.io.gpio.parallel.ParallelPortConfigBuilder;
 import com.pi4j.io.i2c.I2C;
 import com.pi4j.io.i2c.I2CConfig;
 import com.pi4j.io.i2c.I2CConfigBuilder;
@@ -58,6 +61,10 @@ public interface IOCreator {
         return create(config, Spi.class);
     }
 
+    default ParallelPort create(ParallelPortConfig config) {
+        return create(config, ParallelPort.class);
+    }
+
     default DigitalOutput create(DigitalOutputConfigBuilder config) {
         return create(config.build());
     }
@@ -75,6 +82,10 @@ public interface IOCreator {
     }
 
     default Spi create(SpiConfigBuilder config) {
+        return create(config.build());
+    }
+
+    default ParallelPort create(ParallelPortConfigBuilder config) {
         return create(config.build());
     }
 }

--- a/pi4j-core/src/main/java/com/pi4j/io/IOType.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IOType.java
@@ -3,6 +3,10 @@ package com.pi4j.io;
 import com.pi4j.context.Context;
 import com.pi4j.exception.Pi4JException;
 import com.pi4j.io.gpio.digital.*;
+import com.pi4j.io.gpio.parallel.ParallelPort;
+import com.pi4j.io.gpio.parallel.ParallelPortConfig;
+import com.pi4j.io.gpio.parallel.ParallelPortConfigBuilder;
+import com.pi4j.io.gpio.parallel.ParallelPortProvider;
 import com.pi4j.io.i2c.I2C;
 import com.pi4j.io.i2c.I2CConfig;
 import com.pi4j.io.i2c.I2CConfigBuilder;
@@ -38,7 +42,9 @@ public enum IOType {
     /** I2C (Inter-Integrated Circuit) bus device. */
     I2C(I2CProvider.class, I2C.class, I2CConfig.class, I2CConfigBuilder.class),
     /** SPI (Serial Peripheral Interface) bus device. */
-    SPI(SpiProvider.class, Spi.class, SpiConfig.class, SpiConfigBuilder.class);
+    SPI(SpiProvider.class, Spi.class, SpiConfig.class, SpiConfigBuilder.class),
+    /** Parallel port device. */
+    PARALLEL(ParallelPortProvider.class, ParallelPort.class, ParallelPortConfig.class, ParallelPortConfigBuilder.class);
 
     private Class<? extends Provider> providerClass;
     private Class<? extends IO> ioClass;

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/MaskUtils.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/MaskUtils.java
@@ -1,14 +1,11 @@
-package com.pi4j.plugin.ffm.providers.gpio;
+package com.pi4j.io.gpio;
 
-import java.util.Iterator;
+import java.util.PrimitiveIterator;
 
 /**
  * Utility functions to convert between long value bit masks and offsets representing set bits
- * <p>
- * TODO: This is likely to become relevant at a more generic level, as devices with multiple channels are built out.
- *  This utility should be considered likely to be made public and relocated.
  */
-class MaskUtils {
+public class MaskUtils {
 
     private MaskUtils() {}
 
@@ -39,10 +36,18 @@ class MaskUtils {
         return mask;
     }
 
+    public static long packed(long mask) {
+        long packed = 0;
+        for (int i = 0; i < Long.bitCount(mask); i++) {
+            packed |= 1L << i;
+        }
+        return packed;
+    }
+
     /**
      * Iterator over the offsets of a mask
      */
-    private static class MaskIterator implements Iterator<Integer> {
+    private static class MaskIterator implements PrimitiveIterator.OfInt {
 
         private long remaining;
 
@@ -56,7 +61,7 @@ class MaskUtils {
         }
 
         @Override
-        public Integer next() {
+        public int nextInt() {
             int index = Long.numberOfTrailingZeros(remaining);
             remaining &= ~(1L << index);
             return index;

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/parallel/ParallelPort.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/parallel/ParallelPort.java
@@ -1,0 +1,105 @@
+package com.pi4j.io.gpio.parallel;
+
+import com.pi4j.io.IOType;
+import com.pi4j.io.gpio.Gpio;
+import com.pi4j.io.gpio.digital.DigitalInput;
+import com.pi4j.io.gpio.digital.DigitalInputProvider;
+import com.pi4j.io.gpio.digital.DigitalOutput;
+import com.pi4j.io.gpio.digital.DigitalOutputProvider;
+
+/**
+ * A {@link Gpio} which is capable of reading and writing multiple bits to a device.
+ */
+public interface ParallelPort extends com.pi4j.io.IO<ParallelPort, ParallelPortConfig, ParallelPortProvider> {
+
+    /**
+     * Enumeration representing the direction of the parallel port.
+     */
+    enum Direction {
+        INPUT, OUTPUT
+    }
+
+    /**
+     * Get the {@link IOType} of the parallel port {@link com.pi4j.io.IO}.
+     * @return the type of {@link com.pi4j.io.IO} being implemented
+     */
+    @Override
+    default IOType type() {
+        return IOType.PARALLEL;
+    }
+
+    /**
+     * Write the bits specified by `value` to the device.
+     * @param value the value to write
+     */
+    void write(int value);
+
+    /**
+     * Read the current value from the parallel port.
+     * @return a bitmask of the current value
+     */
+    int read();
+
+    /**
+     * Set the direction of the parallel port.
+     * @param direction the direction to set
+     */
+    void setDirection(Direction direction);
+
+    /**
+     * Get the direction of the parallel port.
+     * @return the current direction
+     */
+    Direction getDirection();
+
+    /**
+     * Add a listener for state changes on the parallel port.
+     * @param listener the listener to add
+     * @return the parallel port instance
+     */
+    ParallelPort addListener(Listener listener);
+
+    /**
+     * Remove a listener for state changes on the parallel port.
+     * @param listener the listener to remove
+     * @return the parallel port instance
+     */
+    ParallelPort removeListener(Listener listener);
+
+    /**
+     * Event representing a change in the value of the parallel port.
+     */
+    record ValueChangeEvent(ParallelPort source, int value) {}
+
+    /**
+     * Listener for value change events on the parallel port.
+     */
+    @FunctionalInterface
+    interface Listener extends com.pi4j.event.Listener {
+        void onValueChange(ValueChangeEvent event);
+    }
+
+    /**
+     * Create a digital input provider based on the parallel port.
+     * <p>
+     * Implementing classes ideally provide a singleton instance of this provider to avoid potential conflicts
+     * in BCM allocations.
+     *
+     * @return a provider for creating {@link DigitalInput}s backed by this port
+     */
+    default DigitalInputProvider digitalInputProvider() {
+        return new VirtualDigitalInputProvider(this);
+    }
+
+    /**
+     * Create a digital output provider based on the parallel port.
+     * <p>
+     * Implementing classes ideally provide a singleton instance of this provider to avoid potential conflicts
+     * in BCM allocations.
+     *
+     * @return a provider for creating {@link DigitalOutput}s backed by this port
+     */
+    default DigitalOutputProvider digitalOutputProvider() {
+        return new VirtualDigitalOutputProvider(this);
+    }
+}

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/parallel/ParallelPortBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/parallel/ParallelPortBase.java
@@ -56,6 +56,9 @@ public abstract class ParallelPortBase
 
     @Override
     public final void setDirection(Direction direction) {
+        if (direction == this.direction) {
+            return;
+        }
         this.direction = handleSetDirection(direction);
     }
 

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/parallel/ParallelPortBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/parallel/ParallelPortBase.java
@@ -1,0 +1,133 @@
+package com.pi4j.io.gpio.parallel;
+
+import com.pi4j.event.EventManager;
+import com.pi4j.io.IOBase;
+import com.pi4j.io.gpio.MaskUtils;
+
+/**
+ * Abstract base class for parallel port implementations.
+ * <p>
+ * This base class requires abstract methods to be implemented by its inheritors, while the equivalent
+ * public implementations are declared final. The intention of this pattern is for the execution order of each
+ * to be predictable and deterministic while reducing the possibility of implementing classes to alter core behaviour.
+ * <p>
+ * An alternative approach could be to declare this class as non-abstract, final, and for the abstract methods
+ * to be provided via composition with an `Operations`-like implementation which is able to focus on a simplified
+ * set of runtime responsibilities without having to also account for configuration aspects such as
+ * {@link com.pi4j.provider.Provider} references and {@link com.pi4j.common.Identity}, whose implementations don't vary
+ * significantly between {@link com.pi4j.io.IO} implementations.
+ */
+public abstract class ParallelPortBase
+    extends IOBase<ParallelPort, ParallelPortConfig, ParallelPortProvider>
+    implements ParallelPort {
+
+    private final int mask;
+
+    private Direction direction;
+
+    protected final EventManager<ParallelPort, Listener, ValueChangeEvent> events = new EventManager<>(
+        this, Listener::onValueChange
+    );
+
+    protected ParallelPortBase(ParallelPortProvider provider, ParallelPortConfig config) {
+        super(provider, config);
+        this.mask = (int) MaskUtils.packed(config.mask());
+        this.direction = config.initialDirection();
+    }
+
+    @Override
+    public final void write(int value) {
+        if (this.direction == Direction.INPUT) {
+            throw new IllegalStateException("Parallel port is not configured as an output");
+        }
+
+        if ((value &~ this.mask) != 0) {
+            throw new IllegalArgumentException("Value " + value + " is not valid for mask " + this.mask);
+        }
+
+        handleWrite(value);
+        fireEventWithValue(value);
+    }
+
+    @Override
+    public final int read() {
+        return handleRead() & this.mask;
+    }
+
+    @Override
+    public final void setDirection(Direction direction) {
+        this.direction = handleSetDirection(direction);
+    }
+
+    @Override
+    public final Direction getDirection() {
+        direction = handleGetDirection();
+        return direction;
+    }
+
+    @Override
+    public ParallelPort addListener(Listener listener) {
+        return events.add(listener);
+    }
+
+    @Override
+    public ParallelPort removeListener(Listener listener) {
+        return events.remove(listener);
+    }
+
+    public void fireEventWithValue(int value) {
+        events.dispatch(new ValueChangeEvent(this, value));
+    }
+
+    /**
+     * Implementation-specific write handler to perform the actual write operation.
+     * <p>
+     * Requiring this method to be implemented rather than the {@link #write(int)} allows the
+     * execution order to be deterministic, as {@link #write(int)} is responsible for orchestration and
+     * the implementing class is not required to make calls to `super`
+     *
+     * @param value the value to write
+     */
+    protected abstract void handleWrite(int value);
+
+    /**
+     * Implementation-specific read handler to perform the actual read operation.
+     * <p>
+     * Requiring this method to be implemented rather than the {@link #read()} allows the
+     * execution order to be deterministic, as {@link #read()} is responsible for orchestration and
+     * the implementing class is not required to make calls to `super`
+     *
+     * @return the value read
+     */
+    protected abstract int handleRead();
+
+    /**
+     * Implementation-specific set direction handler to perform the actual set direction operation.
+     * <p>
+     * This method can be overridden by subclasses to provide custom behavior when setting the direction.
+     * <p>
+     * Requiring this method to be implemented rather than the {@link #setDirection(Direction)} allows the
+     * execution order to be deterministic, as {@link #setDirection(Direction)} is responsible for orchestration and
+     * the implementing class is not required to make calls to `super`
+     *
+     * @param direction the direction to set
+     * @return the direction which will be set
+     */
+    protected Direction handleSetDirection(Direction direction) {
+        return direction;
+    }
+    /**
+     * Implementation-specific get direction handler to perform the actual get direction operation.
+     * <p>
+     * This method can be overridden by subclasses to provide custom behaviour when getting the direction.
+     * <p>
+     * Requiring this method to be implemented rather than the {@link #getDirection()} allows the
+     * execution order to be deterministic, as {@link #getDirection()} is responsible for orchestration and
+     * the implementing class is not required to make calls to `super`
+     *
+     * @return the current direction
+     */
+    protected ParallelPort.Direction handleGetDirection() {
+        return direction;
+    }
+}

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/parallel/ParallelPortConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/parallel/ParallelPortConfig.java
@@ -1,0 +1,60 @@
+package com.pi4j.io.gpio.parallel;
+
+import com.pi4j.io.IOConfig;
+import com.pi4j.io.gpio.digital.PullResistance;
+
+import java.util.Map;
+
+/**
+ * Configuration for a parallel port
+ * @param id the user-provided ID
+ * @param name the user-provided name
+ * @param description the user-provided description
+ * @param bus the bus number / GPIO chip
+ * @param mask bit mask representing the pins in the port
+ * @param pull the pull resistance setting
+ * @param debounce the debounce time in microseconds
+ * @param initialValue the initial value of the port
+ * @param shutdownValue the value applied to the port on shutdown
+ * @param initialDirection the initial direction of the port
+ */
+public record ParallelPortConfig(
+    @Override String id,
+    @Override String name,
+    @Override String description,
+    int bus,
+    int mask,
+    // input
+    PullResistance pull,
+    long debounce,
+    // output
+    int initialValue,
+    int shutdownValue,
+    // port
+    ParallelPort.Direction initialDirection
+) implements IOConfig {
+
+    @Override
+    public int getUniqueIdentifier() {
+        return mask;
+    }
+
+    @Override
+    public String provider() {
+        return null;
+    }
+
+    @Override
+    public Map<String, String> properties() {
+        throw new UnsupportedOperationException("Unsupported operation");
+    }
+
+    @Override
+    public void validate() {
+        // this current core codebase doesn't seem to do anything here except check that the ID is non-null
+        // `@NonNull` annotations could be used to indicate this requirement, so leaving faults up to the user(?)
+        if (id == null) {
+            throw new IllegalStateException("ID cannot be null");
+        }
+    }
+}

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/parallel/ParallelPortConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/parallel/ParallelPortConfigBuilder.java
@@ -1,0 +1,123 @@
+package com.pi4j.io.gpio.parallel;
+
+import com.pi4j.config.Config;
+import com.pi4j.io.gpio.digital.PullResistance;
+import com.pi4j.io.impl.IOConfigBuilderBase;
+
+/**
+ * Builder for {@link ParallelPortConfig}
+ */
+public class ParallelPortConfigBuilder extends IOConfigBuilderBase<ParallelPortConfigBuilder, ParallelPortConfig> {
+
+    private Integer bus = 0;
+    private int bcmMask = 0;
+    private ParallelPort.Direction initialDirection = ParallelPort.Direction.INPUT;
+    private Integer initialValue = 0;
+    private Integer shutdownValue = 0;
+    private PullResistance pull = PullResistance.OFF;
+    private Long debounce = 0L;
+
+    /**
+     * Specify the GPIO chip
+     * @param bus the GPIO chip number
+     * @return this builder instance
+     */
+    public ParallelPortConfigBuilder bus(int bus) {
+        this.bus = bus;
+        return this;
+    }
+
+    /**
+     * Add a BCM pin mapping. This can be called multiple times to add multiple BCM pin mappings.
+     * @param bcm the BCM pin mapping
+     * @return this builder instance
+     */
+    public ParallelPortConfigBuilder bcm(int bcm) {
+        this.bcmMask |= (1 << bcm);
+        return this;
+    }
+
+    /**
+     * Specify the initial direction
+     * @param initialDirection the initial direction
+     * @return this builder instance
+     */
+    public ParallelPortConfigBuilder initialDirection(ParallelPort.Direction initialDirection) {
+        this.initialDirection = initialDirection;
+        return this;
+    }
+
+    /**
+     * Specify the initial value when the port is intialised as OUTPUT
+     * @param initialValue the initial value
+     * @return this builder instance
+     */
+    public ParallelPortConfigBuilder initialValue(int initialValue) {
+        this.initialValue = initialValue;
+        return this;
+    }
+
+    /**
+     * Specify the value to be applied on shutdown when the port is intialised as OUTPUT
+     * @param shutdownValue the shutdown value
+     * @return this builder instance
+     */
+    public ParallelPortConfigBuilder shutdownValue(int shutdownValue) {
+        this.shutdownValue = shutdownValue;
+        return this;
+    }
+
+    /**
+     * Specify the pull resistance when the port is intialised as INPUT
+     * @param pull the pull resistance
+     * @return this builder instance
+     */
+    public ParallelPortConfigBuilder pull(PullResistance pull) {
+        this.pull = pull;
+        return this;
+    }
+
+    /**
+     * Specify the debounce time when the port is intialised as INPUT
+     * @param debounce the debounce time
+     * @return this builder instance
+     */
+    public ParallelPortConfigBuilder debounce(long debounce) {
+        this.debounce = debounce;
+        return this;
+    }
+
+    /**
+     * Construct the {@link ParallelPortConfig} instance
+     * @return the constructed {@link ParallelPortConfig} instance
+     */
+    @Override
+    public ParallelPortConfig build() {
+        if (bcmMask == 0) {
+            throw new IllegalArgumentException("BCM pins must be specified");
+        }
+        if (initialDirection == null) {
+            throw new IllegalArgumentException("Initial direction must be specified");
+        }
+        return new ParallelPortConfig(
+            this.id(),
+            this.properties.get(Config.NAME_KEY),
+            this.properties.get(Config.DESCRIPTION_KEY),
+            this.bus,
+            this.bcmMask,
+            this.pull,
+            this.debounce,
+            this.initialValue,
+            this.shutdownValue,
+            this.initialDirection
+        );
+    }
+
+    /**
+     * Provided mainly for compatibility. A constructor with the same signature as other config builders
+     * @return a new builder instance
+     */
+    public static ParallelPortConfigBuilder newInstance() {
+        return new ParallelPortConfigBuilder();
+    }
+}

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/parallel/ParallelPortProvider.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/parallel/ParallelPortProvider.java
@@ -1,0 +1,10 @@
+package com.pi4j.io.gpio.parallel;
+
+import com.pi4j.io.gpio.GpioProvider;
+import com.pi4j.provider.Provider;
+
+/**
+ * {@link GpioProvider} for {@link ParallelPort}
+ */
+public interface ParallelPortProvider extends Provider<ParallelPortProvider, ParallelPort, ParallelPortConfig> {
+}

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/parallel/ValidatingVirtualDigitalFactory.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/parallel/ValidatingVirtualDigitalFactory.java
@@ -1,0 +1,73 @@
+package com.pi4j.io.gpio.parallel;
+
+import com.pi4j.io.exception.IOAlreadyExistsException;
+import com.pi4j.io.exception.IOBoundsException;
+import com.pi4j.io.gpio.MaskUtils;
+import com.pi4j.io.gpio.digital.Digital;
+import com.pi4j.io.gpio.digital.DigitalConfig;
+
+/**
+ * Package private factory decorator with responsibility to validate configuration before delegating construction.
+ * <p>
+ * The functionality provided by this factory is common to both input and output providers.
+ *
+ * @param <D> type of digital output
+ * @param <C> type of digital output config
+ */
+final class ValidatingVirtualDigitalFactory<D extends Digital<D, C, ?>, C extends DigitalConfig> implements VirtualDigitalFactory<D, C> {
+
+    /**
+     * The delegate used to perform actual construction
+     */
+    private final VirtualDigitalFactory<D, C> delegate;
+
+    /**
+     * A mask representing the valid pins which can be allocated by the underlying port
+     */
+    private final long portMask;
+
+    /**
+     * The number of pins available on the underlying port
+     */
+    private final int portPinCount;
+
+    /**
+     * Tracks which pins have already been allocated
+     */
+    private long inUseOffsets = 0;
+
+    /**
+     * Creates a new validating virtual digital factory
+     * @param config the port configuration
+     * @param delegate the delegate used to perform actual construction
+     */
+    public ValidatingVirtualDigitalFactory(ParallelPortConfig config, VirtualDigitalFactory<D, C> delegate) {
+        this.delegate = delegate;
+        this.portMask = MaskUtils.packed(config.mask());
+        this.portPinCount = Long.bitCount(portMask);
+    }
+
+    /**
+     * Validate the device configuration before creating a new virtual digital device
+     * @param config the device configuration
+     * @return the new virtual digital device
+     */
+    @Override
+    public D createDigital(C config) {
+        final int bcmMask = 1 << config.bcm();
+
+        // check that the requested pin is in the range of physical pins available
+        if ((bcmMask & portMask) == 0) {
+            throw new IOBoundsException(config.bcm(), 0, portPinCount);
+        }
+
+        // check that the requested pin has not already been allocated
+        if ((inUseOffsets & bcmMask) != 0) {
+            throw new IOAlreadyExistsException(config.bcm());
+        }
+
+        // mark the pin as allocated
+        inUseOffsets = inUseOffsets | bcmMask;
+        return delegate.createDigital(config);
+    }
+}

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/parallel/VirtualDigitalFactory.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/parallel/VirtualDigitalFactory.java
@@ -1,0 +1,26 @@
+package com.pi4j.io.gpio.parallel;
+
+import com.pi4j.config.Config;
+import com.pi4j.io.gpio.digital.Digital;
+import com.pi4j.io.gpio.digital.DigitalConfig;
+
+/**
+ * Package-private function specification for constructing {@link Digital} devices.
+ * This is essentially shorthand for what would otherwise be a verbose type definition.
+ * <p>
+ * This represents a high-level abstraction for what is exposed by the framework as
+ * {@link com.pi4j.provider.Provider#create(Config)}, but does not require the implementation to be a
+ * complete {@link com.pi4j.provider.Provider}.
+ *
+ * @param <D> type of digital device
+ * @param <C> type of digital device config
+ */
+@FunctionalInterface
+interface VirtualDigitalFactory<D extends Digital<D, C, ?>, C extends DigitalConfig> {
+    /**
+     * Creates a new virtual digital device.
+     * @param config the device configuration
+     * @return the new virtual digital device
+     */
+    D createDigital(C config);
+}

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/parallel/VirtualDigitalInputProvider.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/parallel/VirtualDigitalInputProvider.java
@@ -1,0 +1,127 @@
+package com.pi4j.io.gpio.parallel;
+
+import com.pi4j.io.gpio.digital.DigitalBase;
+import com.pi4j.io.gpio.digital.DigitalInput;
+import com.pi4j.io.gpio.digital.DigitalInputConfig;
+import com.pi4j.io.gpio.digital.DigitalInputProvider;
+import com.pi4j.io.gpio.digital.DigitalState;
+import com.pi4j.io.gpio.digital.DigitalStateChangeEvent;
+import com.pi4j.io.gpio.digital.DigitalStateChangeListener;
+import com.pi4j.provider.ProviderBase;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A provider for creating digital input instances from this parallel port.
+ * <p>
+ * The bcm numbering of digital devices created by this provider corresponds to the bits in the parallel port's value.
+ * E.g. If the {@link ParallelPort} is mapped to pins 10 and 12, the logical bcm of for the {@link DigitalInput}s
+ * creatable via this instance would be `0` and `1` respectively.
+ * <p>
+ * All {@link DigitalInput}s created by this provider share the same {@link ParallelPort} instance and therefore
+ * also the same event source.
+ */
+public class VirtualDigitalInputProvider
+    extends ProviderBase<DigitalInputProvider, DigitalInput, DigitalInputConfig>
+    implements DigitalInputProvider {
+
+    /**
+     * The parallel port instance that is shared by all {@link DigitalInput}s created by this provider.
+     */
+    private final ParallelPort port;
+
+    /**
+     * Factory responsible for creating digital inputs. Actual construction is fulfilled by
+     * {@link VirtualDigitalInput}. The abstraction allows composition of additional or shared
+     * responsibilities, avoiding possible inheritance from a base class to benefit from shared code.
+     */
+    private final VirtualDigitalFactory<DigitalInput, DigitalInputConfig> factory;
+
+    /**
+     * Construct a new provider which uses the given parallel port to allocate devices.
+     * @param port the underlying parallel port
+     */
+    public VirtualDigitalInputProvider(ParallelPort port) {
+        this.port = port;
+        this.factory = new ValidatingVirtualDigitalFactory<>(port.config(), VirtualDigitalInput::new);
+    }
+
+    @Override
+    public DigitalInput create(DigitalInputConfig config) {
+        return factory.createDigital(config);
+    }
+
+    /**
+     * {@link DigitalInput} implementation backed by {@link VirtualDigitalInputProvider#port}
+     */
+    private class VirtualDigitalInput
+        extends DigitalBase<DigitalInput, DigitalInputConfig, DigitalInputProvider>
+        implements DigitalInput {
+
+        /**
+         * Mask for the BCM pin associated with this digital input.
+         */
+        private final int bcmMask;
+
+        private final Map<DigitalStateChangeListener, ListenerPair> listeners = new HashMap<>();
+
+        private VirtualDigitalInput(DigitalInputConfig config) {
+            super(VirtualDigitalInputProvider.this, config);
+            this.bcmMask = 1 << config.bcm();
+        }
+
+        @Override
+        public DigitalState state() {
+            var intValue = ((port.read() & bcmMask) != 0) ? 1 : 0;
+            return DigitalState.state(intValue);
+        }
+
+        /**
+         * Hypothetical implementation of adding listeners to the digital input.
+         * <p>
+         * This simply forwards any event on the port to every digital listener regardless of whether value-change
+         * on the port actually affects the digital input.
+         * <p>
+         * If we want to filter events for each digital device, we might need to track state and compare the before
+         * and after values of the port.
+         * <p>
+         * If a port is used to back only a single pin, this is not an issue as the events would have a 1:1 mapping.
+         */
+        @Override
+        public DigitalInput addListener(DigitalStateChangeListener... listener) {
+            ParallelPort.Listener parallelPortListener = _ -> {
+                for (var l : listener) {
+                    l.onDigitalStateChange(new DigitalStateChangeEvent<>(this, state()));
+                }
+            };
+
+            port.addListener(parallelPortListener);
+
+            for (var l : listener) {
+                listeners.put(l, new ListenerPair(l, parallelPortListener));
+            }
+
+            return super.addListener(listener);
+        }
+
+        /**
+         * Hypothetical implementation of removing listeners from the digital input.
+         */
+        @Override
+        public DigitalInput removeListener(DigitalStateChangeListener... listener) {
+            for (var l : listener) {
+                var listenerReference = listeners.remove(l);
+                if (listenerReference != null) {
+                    port.removeListener(listenerReference.parallelPortListener());
+                }
+            }
+            return super.removeListener(listener);
+        }
+
+        private record ListenerPair(
+            DigitalStateChangeListener listener,
+            ParallelPort.Listener parallelPortListener
+        ) {}
+    }
+}

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/parallel/VirtualDigitalOutputProvider.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/parallel/VirtualDigitalOutputProvider.java
@@ -1,0 +1,102 @@
+package com.pi4j.io.gpio.parallel;
+
+import com.pi4j.io.exception.IOException;
+import com.pi4j.io.gpio.digital.DigitalOutput;
+import com.pi4j.io.gpio.digital.DigitalOutputBase;
+import com.pi4j.io.gpio.digital.DigitalOutputConfig;
+import com.pi4j.io.gpio.digital.DigitalOutputProvider;
+import com.pi4j.io.gpio.digital.DigitalState;
+import com.pi4j.provider.ProviderBase;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A provider for creating digital output instances from this parallel port.
+ * <p>
+ * The bcm numbering of digital devices created by this provider corresponds to the bits in the parallel port's value.
+ * E.g. If the {@link ParallelPort} is mapped to pins 10 and 12, the logical bcm of for the {@link DigitalOutput}s
+ * creatable via this instance would be `0` and `1` respectively.
+ */
+public class VirtualDigitalOutputProvider
+    extends ProviderBase<DigitalOutputProvider, DigitalOutput, DigitalOutputConfig>
+    implements DigitalOutputProvider {
+
+    /**
+     * The parallel port instance that is shared by all {@link DigitalOutput}s created by this provider.
+     */
+    private final ParallelPort port;
+
+    /**
+     * An in-memory representation of the parallel port's value. This approach assumes that all write operations
+     * are performed via {@link DigitalOutput} devices created by this provider.
+     * <p>
+     * Alternative approaches could include:
+     * <ul>
+     *     <li>Perform a read of the port's value before setting writing via {@link DigitalOutput}.</li>
+     *     <li>Shared state with a {@link ParallelPort} implementation.</li>
+     * </ul>
+     * This could possibly be swapped for an explicit read of the port's value before setting the port's value.
+     */
+    private final AtomicReference<Integer> portValue;
+
+    /**
+     * Factory responsible for creating digital outputs. Actual construction is fulfilled by
+     * {@link VirtualDigitalOutput}. The abstraction allows composition of additional or shared
+     * responsibilities, avoiding possible inheritance from a base class to benefit from shared code.
+     */
+    private final VirtualDigitalFactory<DigitalOutput, DigitalOutputConfig> factory;
+
+    /**
+     * Construct a new provider which uses the given parallel port to allocate devices.
+     * @param port the underlying parallel port
+     */
+    public VirtualDigitalOutputProvider(ParallelPort port) {
+        this.port = port;
+        this.portValue = new AtomicReference<>(port.read());
+        this.factory = new ValidatingVirtualDigitalFactory<>(port.config(), VirtualDigitalOutput::new);
+    }
+
+    @Override
+    public DigitalOutput create(DigitalOutputConfig config) {
+        return factory.createDigital(config);
+    }
+
+
+    /**
+     * A {@link DigitalOutput} implementation backed by {@link VirtualDigitalOutputProvider#port}.
+     */
+    private class VirtualDigitalOutput extends DigitalOutputBase {
+
+        /**
+         * Mask for the BCM pin associated with this digital input.
+         */
+        private final int bcmMask;
+
+        private VirtualDigitalOutput(DigitalOutputConfig config) {
+            super(VirtualDigitalOutputProvider.this, config);
+            this.bcmMask = 1 << config.bcm();
+        }
+
+        @Override
+        public DigitalState state() {
+            var intValue = ((port.read() & bcmMask) != 0) ? 1 : 0;
+            return DigitalState.state(intValue);
+        }
+
+        @Override
+        public DigitalOutput state(DigitalState state) throws IOException {
+            if (port.getDirection() != ParallelPort.Direction.OUTPUT) {
+                throw new IOException("Port direction is not set to OUTPUT");
+            }
+            var intValue = state.isHigh() ? 1 : 0;
+            if (intValue != 0) {
+                portValue.getAndUpdate(current -> current | bcmMask);
+            } else {
+                portValue.getAndUpdate(current -> current & ~bcmMask);
+            }
+            port.write(portValue.get());
+            return super.state(state);
+        }
+
+    }
+}

--- a/pi4j-core/src/main/java/module-info.java
+++ b/pi4j-core/src/main/java/module-info.java
@@ -36,6 +36,7 @@ module com.pi4j {
     opens com.pi4j.boardinfo.datareader;
     exports com.pi4j.boardinfo.util.command;
     opens com.pi4j.boardinfo.util.command;
+    exports com.pi4j.io.gpio.parallel;
 
     // extensibility service interfaces
     uses com.pi4j.extension.Plugin;

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/MaskUtilsTest.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/MaskUtilsTest.java
@@ -1,4 +1,4 @@
-package com.pi4j.plugin.ffm.providers.gpio;
+package com.pi4j.io.gpio;
 
 import org.junit.jupiter.api.Test;
 

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/parallel/ValidatingVirtualDigitalFactoryTest.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/parallel/ValidatingVirtualDigitalFactoryTest.java
@@ -1,0 +1,80 @@
+package com.pi4j.io.gpio.parallel;
+
+import com.pi4j.io.exception.IOAlreadyExistsException;
+import com.pi4j.io.exception.IOBoundsException;
+import com.pi4j.io.gpio.digital.DigitalInput;
+import com.pi4j.io.gpio.digital.DigitalInputBase;
+import com.pi4j.io.gpio.digital.DigitalInputConfig;
+import com.pi4j.io.gpio.digital.DigitalInputConfigBuilder;
+import com.pi4j.io.gpio.digital.DigitalState;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Being able to test validation in isolation largely eliminates the need to mock out providers which use it in
+ * their entirety.
+ */
+class ValidatingVirtualDigitalFactoryTest {
+
+    private final ParallelPortConfig inputPortConfig = ParallelPortConfigBuilder.newInstance()
+        .bcm(0b101)
+        .initialDirection(ParallelPort.Direction.INPUT)
+        .build();
+
+
+    @Test
+    void canCreateValidInput() {
+        var factory = new ValidatingVirtualDigitalFactory<>(inputPortConfig, this::createInput);
+
+        var inputConfig = DigitalInputConfigBuilder.newInstance()
+            .bcm(0)
+            .build();
+
+        var input = factory.createDigital(inputConfig);
+        assertEquals("test-input", input.id());
+    }
+
+    @Test
+    void failsToCreateInvalidInput() {
+        var factory = new ValidatingVirtualDigitalFactory<>(inputPortConfig, this::createInput);
+
+        var inputConfig = DigitalInputConfigBuilder.newInstance()
+            .bcm(2)
+            .build();
+
+        assertThrows(IOBoundsException.class, () -> factory.createDigital(inputConfig));
+    }
+
+    @Test
+    void cannotCreateConflictingInputs() {
+        var factory = new ValidatingVirtualDigitalFactory<>(inputPortConfig, this::createInput);
+
+        var inputConfig = DigitalInputConfigBuilder.newInstance()
+            .bcm(0)
+            .build();
+
+        var input = factory.createDigital(inputConfig);
+        assertNotNull(input);
+        assertEquals("test-input", input.id());
+
+        assertThrows(IOAlreadyExistsException.class, () -> factory.createDigital(inputConfig));
+    }
+
+
+    private DigitalInput createInput(DigitalInputConfig config) {
+        return new DigitalInputBase(null, config) {
+            @Override
+            public String id() {
+                return "test-input";
+            }
+
+            @Override
+            public DigitalState state() {
+                return DigitalState.HIGH;
+            }
+        };
+    }
+}

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMDigitalInput.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMDigitalInput.java
@@ -4,6 +4,7 @@ import com.pi4j.context.Context;
 import com.pi4j.exception.InitializeException;
 import com.pi4j.exception.Pi4JException;
 import com.pi4j.exception.ShutdownException;
+import com.pi4j.io.gpio.MaskUtils;
 import com.pi4j.io.gpio.digital.*;
 import com.pi4j.plugin.ffm.common.FFMPermissionHelper;
 import com.pi4j.plugin.ffm.common.gpio.DetectedEvent;

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMDigitalOutput.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMDigitalOutput.java
@@ -4,6 +4,7 @@ import com.pi4j.context.Context;
 import com.pi4j.exception.InitializeException;
 import com.pi4j.exception.ShutdownException;
 import com.pi4j.io.exception.IOException;
+import com.pi4j.io.gpio.MaskUtils;
 import com.pi4j.io.gpio.digital.*;
 import com.pi4j.plugin.ffm.common.FFMPermissionHelper;
 import com.pi4j.plugin.ffm.common.gpio.PinFlag;

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMGpioLine.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMGpioLine.java
@@ -2,6 +2,7 @@ package com.pi4j.plugin.ffm.providers.gpio;
 
 import com.pi4j.exception.InitializeException;
 import com.pi4j.exception.Pi4JException;
+import com.pi4j.io.gpio.MaskUtils;
 import com.pi4j.io.gpio.digital.DigitalState;
 import com.pi4j.plugin.ffm.common.file.FileDescriptorNative;
 import com.pi4j.plugin.ffm.common.file.FileFlag;

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/parallel/MockParallelPort.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/parallel/MockParallelPort.java
@@ -1,0 +1,49 @@
+package com.pi4j.plugin.mock.provider.gpio.parallel;
+
+import com.pi4j.io.gpio.MaskUtils;
+import com.pi4j.io.gpio.parallel.ParallelPort;
+import com.pi4j.io.gpio.parallel.ParallelPortBase;
+import com.pi4j.io.gpio.parallel.ParallelPortConfig;
+import com.pi4j.io.gpio.parallel.ParallelPortProvider;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Placeholder mock implementation of a {@link ParallelPort}
+ */
+public class MockParallelPort
+    extends ParallelPortBase
+    implements ParallelPort {
+
+    private final AtomicInteger value;
+
+    /**
+     * Creates a new GPIO I/O instance bound to the given provider and configuration.
+     *
+     * @param provider the {@link ParallelPortProvider} that creates and backs this I/O instance
+     * @param config   the {@link ParallelPortConfig} describing this I/O, including its BCM pin numbers
+     */
+    public MockParallelPort(ParallelPortProvider provider, ParallelPortConfig config) {
+        super(provider, config);
+        this.value = new AtomicInteger((int) (config.initialValue() & MaskUtils.packed(config.mask())));
+    }
+
+    /**
+     * Allow the backing value to be set directly for testing purposes.
+     * @param value the value to set
+     */
+    public void mockValue(int value) {
+        handleWrite(value);
+        fireEventWithValue(value);
+    }
+
+    @Override
+    protected void handleWrite(int value) {
+        this.value.set(value);
+    }
+
+    @Override
+    protected int handleRead() {
+        return value.get();
+    }
+}

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/parallel/MockParallelPortProvider.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/parallel/MockParallelPortProvider.java
@@ -1,0 +1,23 @@
+package com.pi4j.plugin.mock.provider.gpio.parallel;
+
+import com.pi4j.io.gpio.parallel.ParallelPort;
+import com.pi4j.io.gpio.parallel.ParallelPortConfig;
+import com.pi4j.io.gpio.parallel.ParallelPortProvider;
+import com.pi4j.provider.ProviderBase;
+
+/**
+ * Placeholder mock implementation of a {@link ParallelPortProvider}
+ */
+public class MockParallelPortProvider
+    extends ProviderBase<ParallelPortProvider, ParallelPort, ParallelPortConfig>
+    implements ParallelPortProvider {
+
+    public MockParallelPortProvider() {
+        super("mock-gpio-port", "Mock GPIO Port");
+    }
+
+    @Override
+    public MockParallelPort create(ParallelPortConfig config) {
+        return new MockParallelPort(this, config);
+    }
+}

--- a/plugins/pi4j-plugin-mock/src/test/java/com/pi4j/plugin/mock/provider/gpio/parallel/MockParallelPortTest.java
+++ b/plugins/pi4j-plugin-mock/src/test/java/com/pi4j/plugin/mock/provider/gpio/parallel/MockParallelPortTest.java
@@ -1,0 +1,210 @@
+package com.pi4j.plugin.mock.provider.gpio.parallel;
+
+import com.pi4j.Pi4J;
+import com.pi4j.io.gpio.digital.DigitalState;
+import com.pi4j.io.gpio.digital.DigitalStateChangeListener;
+import com.pi4j.io.gpio.parallel.ParallelPort;
+import com.pi4j.io.gpio.parallel.ParallelPortConfigBuilder;
+import com.pi4j.io.gpio.parallel.ParallelPortProvider;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static com.pi4j.io.gpio.digital.DigitalState.HIGH;
+import static com.pi4j.io.gpio.digital.DigitalState.LOW;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MockParallelPortTest {
+
+    private final ParallelPortProvider provider = new MockParallelPortProvider();
+
+    private final ParallelPortConfigBuilder configBuilder = ParallelPortConfigBuilder.newInstance()
+        .id("parallel-port")
+        .bcm(1)
+        .bcm(3);
+
+    private final List<DigitalExpectation> digitalExpectations = List.of(
+        new DigitalExpectation(0, LOW, LOW),
+        new DigitalExpectation(1, HIGH, LOW),
+        new DigitalExpectation(2, LOW, HIGH),
+        new DigitalExpectation(3, HIGH, HIGH)
+    );
+
+    /**
+     * Write a value to the port and assert that the value is reflected
+     */
+    @Test
+    void canWriteToPort() {
+        var context = Pi4J.newContextBuilder().add(provider).build();
+        var port = context.create(configBuilder.initialDirection(ParallelPort.Direction.OUTPUT).build());
+
+        port.write(0b10);
+        assertEquals(0b10, port.read());
+    }
+
+    /**
+     * We may want to fail writes to ports which are currently configured as inputs
+     */
+    @Test
+    void cannotWriteToInputPort() {
+        var context = Pi4J.newContextBuilder().add(provider).build();
+        var port = context.create(configBuilder.initialDirection(ParallelPort.Direction.INPUT).build());
+
+        assertThrows(IllegalStateException.class, () -> port.write(0b10));
+    }
+
+    /**
+     * We may want to fail writes to ports which are outside the port mask and cannot be represented by the port
+     */
+    @Test
+    void cannotWriteOutsideThePortMask() {
+        var context = Pi4J.newContextBuilder().add(provider).build();
+        var port = context.create(configBuilder.initialDirection(ParallelPort.Direction.OUTPUT).build());
+
+        assertThrows(IllegalArgumentException.class, () -> port.write(0b1000));
+    }
+
+    /**
+     * Port direction can be changed to allow writes to a port, which might be initially configured as an input
+     */
+    @Test
+    void canChangePortDirection() {
+        var context = Pi4J.newContextBuilder().add(provider).build();
+        var port = context.create(configBuilder.initialDirection(ParallelPort.Direction.INPUT).build());
+
+        assertThrows(IllegalStateException.class, () -> port.write(0b10));
+
+        port.setDirection(ParallelPort.Direction.OUTPUT);
+        port.write(0b10);
+        assertEquals(0b10, port.read());
+    }
+
+    /**
+     * Write a value to the port and assert that it is represented by the individual digital states
+     */
+    @TestFactory
+    Stream<DynamicTest> canReadDigitalValues() {
+        var context = Pi4J.newContextBuilder().add(provider).build();
+        var port = context.create(configBuilder.build());
+        var inputProvider = port.digitalInputProvider();
+        var input0 = inputProvider.create(0);
+        var input1 = inputProvider.create(1);
+
+        return digitalExpectations.stream()
+            .map(expectation -> DynamicTest.dynamicTest(expectation.toString(), () -> {
+                ((MockParallelPort)port).mockValue(expectation.portValue);
+                assertEquals(expectation.portValue, port.read());
+                assertEquals(expectation.state0, input0.state());
+                assertEquals(expectation.state1, input1.state());
+            }));
+    }
+
+    /**
+     * Write digital states and validate the value on the port
+     */
+    @TestFactory
+    Stream<DynamicTest> writeOperationsAffectPort() {
+        var context = Pi4J.newContextBuilder().add(provider).build();
+        var port = (MockParallelPort)context.create(configBuilder.initialDirection(ParallelPort.Direction.OUTPUT).build());
+        var outputProvider = port.digitalOutputProvider();
+        var output0 = outputProvider.create(0);
+        var output1 = outputProvider.create(1);
+
+        return digitalExpectations.stream()
+            .map(expectation -> DynamicTest.dynamicTest(expectation.toString(), () -> {
+                output0.state(expectation.state0);
+                assertEquals(expectation.state0, output0.state());
+                output1.state(expectation.state1);
+                assertEquals(expectation.state1, output1.state());
+                assertEquals(expectation.portValue, port.read());
+            }));
+    }
+
+    /**
+     * Verify that digital inputs receive events when the port value changes
+     */
+    @Test
+    void portTriggersDigitalEvents() {
+        var context = Pi4J.newContextBuilder().add(provider).build();
+        var port = (MockParallelPort)context.create(configBuilder.build());
+        var inputProvider = port.digitalInputProvider();
+        var eventCount = new AtomicInteger(0);
+        var input = inputProvider.create(0).addListener(_ -> eventCount.incrementAndGet());
+
+        port.mockValue(1);
+        assertEquals(1, eventCount.get());
+        assertEquals(HIGH, input.state());
+
+        port.mockValue(0);
+        assertEquals(2, eventCount.get());
+        assertEquals(LOW, input.state());
+    }
+
+    /**
+     * Verify that listeners can be removed from digital inputs
+     */
+    @Test
+    void canRemoveListeners() {
+        var context = Pi4J.newContextBuilder().add(provider).build();
+        var port = (MockParallelPort)context.create(configBuilder.build());
+        var inputProvider = port.digitalInputProvider();
+        var eventCount = new AtomicInteger(0);
+
+        DigitalStateChangeListener listener = _ -> eventCount.incrementAndGet();
+        var input = inputProvider.create(0).addListener(listener);
+
+        port.mockValue(1);
+        assertEquals(1, eventCount.get());
+        assertEquals(HIGH, input.state());
+
+        port.mockValue(0);
+        assertEquals(2, eventCount.get());
+        assertEquals(LOW, input.state());
+
+        input.removeListener(listener);
+        port.mockValue(1);
+        assertEquals(2, eventCount.get());
+        assertEquals(HIGH, input.state());
+    }
+
+    /**
+     * Verify that a listener can be removed from a digital device and that listeners on other devices are unaffected.
+     */
+    @Test
+    void canRemoveIndividualListers() {
+        var context = Pi4J.newContextBuilder().add(provider).build();
+        var port = (MockParallelPort)context.create(configBuilder.build());
+        var inputProvider = port.digitalInputProvider();
+
+        var input0 = inputProvider.create(0);
+        var eventCount0 = new AtomicInteger(0);
+        DigitalStateChangeListener listener0 = _ -> eventCount0.incrementAndGet();
+        input0.addListener(listener0);
+
+        var input1 = inputProvider.create(1);
+        var eventCount1 = new AtomicInteger(0);
+        DigitalStateChangeListener listener1 = _ -> eventCount1.incrementAndGet();
+        input1.addListener(listener1);
+
+        port.mockValue(1);
+        assertEquals(1, eventCount0.get());
+        assertEquals(1, eventCount1.get());
+
+        input0.removeListener(listener0);
+        port.mockValue(0);
+        assertEquals(1, eventCount0.get());
+        assertEquals(2, eventCount1.get());
+    }
+
+    /**
+     * Container for test expectations
+     * @param portValue the value on the port
+     * @param state0 the state of the first output
+     * @param state1 the state of the second output
+     */
+    record DigitalExpectation(int portValue, DigitalState state0, DigitalState state1) {}
+}


### PR DESCRIPTION
This PR proposes a `ParallelPort` device to provide a superset of existing `Digital` devices, with two key differences:

* Multiple GPIOs can be read or written simultaneously (dependent on the configured direction)
* Direction can be explicitly reconfigured at runtime. 

## Multiple GPIOs

Simultaneous control of multiple GPIOs allows:

### Bus participation

Multiple GPIOs are represented as a bit mask and interpreted as `int`. This simplifies participating on a data bus. The complete value of a bus can be read or written in a single, atomic operation. This is preferable to to individually invoking multiple `Digital` devices to achieve the same effect.

### Virtual `Digital` devices

Once a `ParallelPort` is created, the user is still able to manipulate individual pins by writing the appropriate mask value to the port. It might be preferable however, to use the existing `Digital` abstractions to do this. 

A `ParallelPort` can be used as the backing device for `VirtualDigitalInputProvider` or `VirtualDigitalOutputProvider`. These are called out as being "virtual" because a) they don't directly control the hardware and b) their pin numbering is relative the the bit of the port they control and, as such are numbered sequentially  from `0`. 

For example, a 3-bit port to control a 3-to-8 decoder might be mapped to BCM pins 16, 20 and 21. This could be efficiently controlled by writing numeric values from 0 to 7. But, if the user wished to, they could create virtual digital devices on top of the port, where the pins would be numbered 0, 1 and 2. (This example might be unrealistic, but it illustrates the numbering scheme).

A more realistic use could be to for this mechanism to provide all digital devices. A port with a single BCM is essentially a digital device. A abstraction around the port can provide required `Digital.state` operations.

## Direction control

E.g. A `ParallelPort` could be used to participate in a data bus. Such a port could be configured with an initial direction of `INPUT`, allowing other participants control of the bus. When data is requested, the port might be required to write data and can be temporarily reconfigured as OUTPUT to do so.

