### PR TITLE
Push the writeThenRead method down to I2C implementations 

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2C.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2C.java
@@ -86,27 +86,6 @@ public interface I2C
         return device();
     }
 
-    /**
-     * Method to write the writeBuffer, and then a read into the readBuffer
-     * in a single atomic operation.
-     *
-     * @param writeBuffer    the buffer to write respecting the given length and offset
-     * @param writeOffset    the offset of the array to write
-     * @param writeSize      the number of bytes to write
-     * @param readDelayNanos delay after writing before reading; currently ignored for i2c.
-     * @param readBuffer     the buffer into which to read the bytes
-     * @param readOffset     the offset in the read buffer at which to insert the read bytes
-     * @param readSize       the number of bytes to read
-     */
-    default void writeThenRead(byte[] writeBuffer, int writeOffset, int writeSize, int readDelayNanos, byte[] readBuffer, int readOffset, int readSize) {
-        // Ideally, new implementations support this call directly.
-        // however, we can emulate it using the multi-byte register call
-        if (writeSize != writeBuffer.length) {
-            writeBuffer = Arrays.copyOfRange(writeBuffer, writeOffset, writeOffset + writeSize);
-        }
-        readRegister(writeBuffer, readBuffer, readOffset, readSize);
-    }
-
     // --------------------
     // Disambiguation
     // ---------------------

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2C.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2C.java
@@ -6,7 +6,6 @@ import com.pi4j.io.IODataReader;
 import com.pi4j.io.IODataWriter;
 import com.pi4j.io.SerialCircuitIO;
 
-import java.util.Arrays;
 import java.util.concurrent.Callable;
 
 /**

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/impl/I2CDirect.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/impl/I2CDirect.java
@@ -12,6 +12,7 @@ import com.pi4j.plugin.ffm.common.i2c.rdwr.RDWRData;
 import com.pi4j.plugin.ffm.common.ioctl.IoctlNative;
 import com.pi4j.plugin.ffm.providers.i2c.FFMI2CBus;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -191,5 +192,13 @@ public class I2CDirect extends I2CBase<FFMI2CBus> {
     @Override
     public int writeRegister(byte[] register, byte[] data, int offset, int length) {
         return internalWrite(register, data, offset, length);
+    }
+
+    @Override
+    public void writeThenRead(byte[] writeBuffer, int writeOffset, int writeSize, int readDelayNanos, byte[] readBuffer, int readOffset, int readSize) {
+        if (writeSize != writeBuffer.length) {
+            writeBuffer = Arrays.copyOfRange(writeBuffer, writeOffset, writeOffset + writeSize);
+        }
+        readRegister(writeBuffer, readBuffer, readOffset, readSize);
     }
 }

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/impl/I2CFile.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/impl/I2CFile.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 /**
  * {@link I2C} implementation that communicates with an I2C device through plain {@code read(2)}/{@code write(2)}
@@ -120,9 +121,18 @@ public class I2CFile extends I2CBase<FFMI2CBus> {
     }
 
     @Override
+    public void writeThenRead(byte[] writeBuffer, int writeOffset, int writeSize, int readDelayNanos, byte[] readBuffer, int readOffset, int readSize) {
+        if (writeSize != writeBuffer.length) {
+            writeBuffer = Arrays.copyOfRange(writeBuffer, writeOffset, writeOffset + writeSize);
+        }
+        readRegister(writeBuffer, readBuffer, readOffset, readSize);
+    }
+
+    @Override
     public I2C shutdownInternal(Context context) throws ShutdownException {
         super.shutdownInternal(context);
         i2CBus.close();
         return this;
     }
+
 }

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/impl/I2CSMBus.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/i2c/impl/I2CSMBus.java
@@ -186,4 +186,12 @@ public class I2CSMBus extends I2CBase<FFMI2CBus> {
         i2CBus.close();
         return this;
     }
+
+    @Override
+    public void writeThenRead(byte[] writeBuffer, int writeOffset, int writeSize, int readDelayNanos, byte[] readBuffer, int readOffset, int readSize) {
+        if (writeSize != writeBuffer.length) {
+            writeBuffer = Arrays.copyOfRange(writeBuffer, writeOffset, writeOffset + writeSize);
+        }
+        readRegister(writeBuffer, readBuffer, readOffset, readSize);
+    }
 }

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/i2c/MockI2C.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/i2c/MockI2C.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.charset.Charset;
 import java.util.ArrayDeque;
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -354,5 +355,13 @@ public class MockI2C extends I2CBase<MockI2CBus> implements I2C, I2CRegisterData
         logger.debug("[{}::{}] :: WRITE(REG={}, 0x{})", Mock.I2C_PROVIDER_NAME, this.id, register, result);
 
         return result;
+    }
+
+    @Override
+    public void writeThenRead(byte[] writeBuffer, int writeOffset, int writeSize, int readDelayNanos, byte[] readBuffer, int readOffset, int readSize) {
+        if (writeSize != writeBuffer.length) {
+            writeBuffer = Arrays.copyOfRange(writeBuffer, writeOffset, writeOffset + writeSize);
+        }
+        readRegister(writeBuffer, readBuffer, readOffset, readSize);
     }
 }


### PR DESCRIPTION
Remove it from I2C, so implementations are forced to provide an implementation

For now, I am just pushing the existing code to all I2C implementations

This allows cleaning up implementations individually in clean isolated changes.